### PR TITLE
Take cell spacing into account during touchMove

### DIFF
--- a/src/carousel.js
+++ b/src/carousel.js
@@ -191,8 +191,8 @@ const Carousel = React.createClass({
         }
 
         self.setState({
-          left: self.props.vertical ? 0 : (self.state.slideWidth * self.state.currentSlide + (self.touchObject.length * self.touchObject.direction)) * -1,
-          top: self.props.vertical ? (self.state.slideWidth * self.state.currentSlide + (self.touchObject.length * self.touchObject.direction)) * -1 : 0
+          left: self.props.vertical ? 0 : ((self.state.slideWidth + self.props.cellSpacing) * self.state.currentSlide + (self.touchObject.length * self.touchObject.direction)) * -1,
+          top: self.props.vertical ? ((self.state.slideWidth + self.props.cellSpacing) * self.state.currentSlide + (self.touchObject.length * self.touchObject.direction)) * -1 : 0
         });
       },
       onTouchEnd(e) {


### PR DESCRIPTION
Fix #34.

Add cellSpacing to the top/left calculations in the onTouchMove handler.
