### PR TITLE
'visibility' should use 'inherit', not 'visible'

### DIFF
--- a/src/carousel.js
+++ b/src/carousel.js
@@ -640,7 +640,7 @@ const Carousel = React.createClass({
       height: 'auto',
       boxSizing: 'border-box',
       MozBoxSizing: 'border-box',
-      visibility: this.state.slideWidth ? 'visible' : 'hidden'
+      visibility: this.state.slideWidth ? 'inherit' : 'hidden'
     }
   },
 


### PR DESCRIPTION
Fixes #80.

The `visibility: visible;` style makes an element visible regardless of the parent containers' `visibility: hidden;`.
The `visibility: inherit;` should be used in this component as the opposite to `hidden` to allow parent containers to hide this element via `visibility: hidden;`.

Reference: https://jakearchibald.com/2014/visible-undoes-hidden/
