### PR TITLE
Add additional class to all visible slides

### DIFF
--- a/src/carousel.js
+++ b/src/carousel.js
@@ -483,8 +483,13 @@ const Carousel = React.createClass({
 
   formatChildren(children) {
     var self = this;
+
+    const { currentSlide } = this.state;
+    const { slidesToShow } = this.props;
+
     return React.Children.map(children, function(child, index) {
-      return <li className="slider-slide" style={self.getSlideStyles()} key={index}>{child}</li>
+      let visible = index >= currentSlide && index < currentSlide + slidesToShow;
+      return <li className={'slider-slide' + (visible ? ' slide-visible' : '')} style={self.getSlideStyles()} key={index}>{child}</li>
     });
   },
 


### PR DESCRIPTION
This pull request adds a class to all visible slides. 

I needed a way to change the appearance of the currently visible slides. In my case I am setting the `max-height` to something other than `0px` for visible slides to so the slide height is automatic.
