### PR TITLE
Don't call goToSlide if touch direction is 0

### DIFF
--- a/src/carousel.js
+++ b/src/carousel.js
@@ -338,7 +338,9 @@ const Carousel = React.createClass({
         }
       }
     } else {
-      this.goToSlide(this.state.currentSlide);
+      if (this.touchObject.direction !== 0) {
+        this.goToSlide(this.state.currentSlide);
+      }
     }
 
     this.touchObject = {};


### PR DESCRIPTION
I found a bug when run this component in iOS webview. reproduce steps:
1. the whole page is wrapped by Carousel which means i can slide page horizontally to switch view.
2. props of Carousel: slidesToShow={1} slidesToScroll={1}
3. slide page vertically firstly after page load.
4. slide page horizontally and will see view isn't animated to correct position.

I digged into codes and found slide page vertically at the beginning and then slide horizontally would cause more than one object in variable  **newTweenQueue** of **kw-react-tween-state** package which cause animation failed.
Since it's not necessary to reset slide back to current index when slide vertically, so just prevent call **goToSlide** which will call **animateSlide** and then call tweenState of **kw-react-tween-state** package when touch direction is 0(means vertical for this case).
