### PR TITLE
Set button type on controls to 'button'

### DIFF
--- a/lib/decorators.js
+++ b/lib/decorators.js
@@ -19,7 +19,8 @@ var DefaultDecorators = [{
         'button',
         {
           style: this.getButtonStyles(this.props.currentSlide === 0 && !this.props.wrapAround),
-          onClick: this.handleClick },
+          onClick: this.handleClick,
+          type: 'button' },
         'PREV'
       );
     },
@@ -49,7 +50,8 @@ var DefaultDecorators = [{
         'button',
         {
           style: this.getButtonStyles(this.props.currentSlide + this.props.slidesToScroll >= this.props.slideCount && !this.props.wrapAround),
-          onClick: this.handleClick },
+          onClick: this.handleClick,
+          type: 'button' },
         'NEXT'
       );
     },
@@ -88,7 +90,8 @@ var DefaultDecorators = [{
               'button',
               {
                 style: self.getButtonStyles(self.props.currentSlide === index),
-                onClick: self.props.goToSlide.bind(null, index) },
+                onClick: self.props.goToSlide.bind(null, index),
+                type: 'button' },
               '•'
             )
           );

--- a/src/decorators.js
+++ b/src/decorators.js
@@ -9,7 +9,8 @@ const DefaultDecorators = [
         return (
           <button
             style={this.getButtonStyles(this.props.currentSlide === 0 && !this.props.wrapAround)}
-            onClick={this.handleClick}>PREV</button>
+            onClick={this.handleClick}
+            type='button'>PREV</button>
         )
       },
       handleClick(e) {
@@ -36,7 +37,8 @@ const DefaultDecorators = [
         return (
           <button
             style={this.getButtonStyles(this.props.currentSlide + this.props.slidesToScroll >= this.props.slideCount && !this.props.wrapAround)}
-            onClick={this.handleClick}>NEXT</button>
+            onClick={this.handleClick}
+            type='button'>NEXT</button>
         )
       },
       handleClick(e) {
@@ -70,7 +72,8 @@ const DefaultDecorators = [
                   <li style={self.getListItemStyles()} key={index}>
                     <button
                       style={self.getButtonStyles(self.props.currentSlide === index)}
-                      onClick={self.props.goToSlide.bind(null, index)}>
+                      onClick={self.props.goToSlide.bind(null, index)}
+                      type='button'>
                       &bull;
                     </button>
                   </li>


### PR DESCRIPTION
This prevents 2 types of unwanted behaviour when the prev/next/bullet buttons are clicked -
1 - the page won't jump to the top
2 - any surrounding form elements won't submit
