### PR TITLE
Adding beforeSlide hook conditional sliding.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,12 @@ Interval for autoplay iteration. Defaults to 3000.
 ####beforeSlide
 `React.PropTypes.func`
 
-Hook to be called before a slide is changed.
+Hook to be called before a slide is changed. Return `false` if you want to prevent the carousel from transitioning.
+
+####alwaysAllowBackSlide
+`React.PropTypes.bool`
+
+Overrides a false `beforeSlide` hook if the carousel is moving backwards.  Defaults to `true`.
 
 ####cellAlign
 `React.PropTypes.oneOf(['left', 'center', 'right'])`

--- a/lib/carousel.js
+++ b/lib/carousel.js
@@ -4,6 +4,8 @@ Object.defineProperty(exports, '__esModule', {
   value: true
 });
 
+var _slicedToArray = (function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i['return']) _i['return'](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError('Invalid attempt to destructure non-iterable instance'); } }; })();
+
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
@@ -98,7 +100,10 @@ var Carousel = _react2['default'].createClass({
       afterSlide: function afterSlide() {},
       autoplay: false,
       autoplayInterval: 3000,
-      beforeSlide: function beforeSlide() {},
+      beforeSlide: function beforeSlide() {
+        return true;
+      },
+      alwaysAllowBackSlide: true,
       cellAlign: 'left',
       cellSpacing: 0,
       data: function data() {},
@@ -150,7 +155,7 @@ var Carousel = _react2['default'].createClass({
       slideCount: nextProps.children.length
     });
     this.setDimensions(nextProps);
-    if (typeof nextProps.slideIndex === 'number' && nextProps.slideIndex !== this.state.currentSlide) {
+    if (this.props.slideIndex !== nextProps.slideIndex && nextProps.slideIndex !== this.state.currentSlide) {
       this.goToSlide(nextProps.slideIndex);
     }
     if (this.props.autoplay !== nextProps.autoplay) {
@@ -447,53 +452,107 @@ var Carousel = _react2['default'].createClass({
   stopAutoplay: function stopAutoplay() {
     this.autoplayID && clearInterval(this.autoplayID);
   },
-
   // Action Methods
+  /**
+   * wrappedAnimation returns a function used to animate a carousel animation
+   * that wraps start <-> end;
+   * @param  {int} index     The index the user is trying to slide to. (< 0 || > children.length)
+   * @param  {int} nextSlide The actual slide the user is moving to. (Should be within the children[])
+   * @return {func} animationFunc The function to be passed to the setState call that sets the new slide index
+   */
+  wrappedAnimation: function wrappedAnimation(index, nextSlide) {
+    var _this = this;
+
+    return function () {
+      _this.animateSlide(null, null, _this.getTargetLeft(null, index), function () {
+        _this.animateSlide(null, 0.01);
+        _this.props.afterSlide(nextSlide);
+        _this.resetAutoplay();
+        _this.setExternalData();
+      });
+    };
+  },
+  /**
+   * A simpler animationFunc for normal transitions that don't wrap.
+   * @param  {int} nextSlide The slide the user is moving to.
+   * @return {func} animationFunc The function to be passed to the setState call that sets the new slide index
+   */
+  basicAnimation: function basicAnimation(nextSlide) {
+    var _this2 = this;
+
+    return function () {
+      _this2.animateSlide();
+      _this2.props.afterSlide(nextSlide);
+      _this2.resetAutoplay();
+      _this2.setExternalData();
+    };
+  },
+  /**
+   * Returns the index of the nextSlide, as well as the animationFunc that should
+   * be used to move there. Uses the attempted index and the current
+   * state/props.
+   * @param  {int} index The index the user is trying to move to.
+   * @return {[int, func]} The actual slide index to move to, and the animation func to get there.
+   */
+  getNextSlideAndAndimationFunc: function getNextSlideAndAndimationFunc(index) {
+    // Get the data we need out of props, and state.
+    var _props = this.props;
+    var wrapAround = _props.wrapAround;
+    var children = _props.children;
+    var beforeSlide = _props.beforeSlide;
+    var alwaysAllowBackSlide = _props.alwaysAllowBackSlide;
+    var _state = this.state;
+    var currentSlide = _state.currentSlide;
+    var slidesToScroll = _state.slidesToScroll;
+    var basicAnimation = this.basicAnimation;
+    var wrappedAnimation = this.wrappedAnimation;
+
+    // And setup some variables to ease the conditionals...
+
+    // We're attempting to move out of bounds if index is < 0 or > than children count.
+    var overflow = index >= _react2['default'].Children.count(children);
+    var underflow = index < 0;
+    var outOfBounds = overflow || underflow;
+
+    // The last slide is children.length - the amount we scroll.
+    var endSlide = _react2['default'].Children.count(children) - slidesToScroll;
+
+    // Wrapped slide is the index of the first or end slide, depending
+    // on how (if?) we're out of bounds.
+    var wrappedSlide = overflow ? 0 : endSlide;
+
+    // If we're not out of bounds, our next slide should just be where ever the user was trying to go (index);
+    var nextSlide = outOfBounds ? wrappedSlide : index;
+    var movingBack = nextSlide < currentSlide;
+    var beforeHookCheck = beforeSlide(currentSlide, nextSlide) !== false;
+
+    // If we're trying to move out of bounds, but don't have wrap enabled, just return the currentSlide.
+    if (outOfBounds && !wrapAround) {
+      return [currentSlide, basicAnimation(nextSlide)];
+    }
+
+    // If we always allowBackSliding, and we're moving back, we should be good to continue.
+    // Otherwise we need to make sure the beforeSlide check is ok.
+    if (alwaysAllowBackSlide && movingBack || beforeHookCheck) {
+      // Different animation funcs depending on where we're going.
+      return [nextSlide, outOfBounds ? wrappedAnimation(index, nextSlide) : basicAnimation(nextSlide)];
+    }
+
+    // Not currently allowed to slide... Stay put!
+    return [currentSlide, basicAnimation(currentSlide)];
+  },
 
   goToSlide: function goToSlide(index) {
     var self = this;
-    if (index >= _react2['default'].Children.count(this.props.children) || index < 0) {
-      if (!this.props.wrapAround) {
-        return;
-      };
-      if (index >= _react2['default'].Children.count(this.props.children)) {
-        this.props.beforeSlide(this.state.currentSlide, 0);
-        return this.setState({
-          currentSlide: 0
-        }, function () {
-          self.animateSlide(null, null, self.getTargetLeft(null, index), function () {
-            self.animateSlide(null, 0.01);
-            self.props.afterSlide(0);
-            self.resetAutoplay();
-            self.setExternalData();
-          });
-        });
-      } else {
-        var endSlide = _react2['default'].Children.count(this.props.children) - this.state.slidesToScroll;
-        this.props.beforeSlide(this.state.currentSlide, endSlide);
-        return this.setState({
-          currentSlide: endSlide
-        }, function () {
-          self.animateSlide(null, null, self.getTargetLeft(null, index), function () {
-            self.animateSlide(null, 0.01);
-            self.props.afterSlide(endSlide);
-            self.resetAutoplay();
-            self.setExternalData();
-          });
-        });
-      }
-    }
 
-    this.props.beforeSlide(this.state.currentSlide, index);
+    var _getNextSlideAndAndimationFunc = this.getNextSlideAndAndimationFunc(index);
 
-    this.setState({
-      currentSlide: index
-    }, function () {
-      self.animateSlide();
-      this.props.afterSlide(index);
-      self.resetAutoplay();
-      self.setExternalData();
-    });
+    var _getNextSlideAndAndimationFunc2 = _slicedToArray(_getNextSlideAndAndimationFunc, 2);
+
+    var currentSlide = _getNextSlideAndAndimationFunc2[0];
+    var animationFunc = _getNextSlideAndAndimationFunc2[1];
+
+    return this.setState({ currentSlide: currentSlide }, animationFunc);
   },
 
   nextSlide: function nextSlide() {

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -91,7 +91,8 @@ const Carousel = React.createClass({
       afterSlide: function() { },
       autoplay: false,
       autoplayInterval: 3000,
-      beforeSlide: function() { },
+      beforeSlide: function() { return true; },
+      alwaysAllowBackSlide: true,
       cellAlign: 'left',
       cellSpacing: 0,
       data: function() {},
@@ -455,51 +456,89 @@ const Carousel = React.createClass({
   stopAutoplay() {
     this.autoplayID && clearInterval(this.autoplayID);
   },
-
   // Action Methods
+  /**
+   * wrappedAnimation returns a function used to animate a carousel animation
+   * that wraps start <-> end;
+   * @param  {int} index     The index the user is trying to slide to. (< 0 || > children.length)
+   * @param  {int} nextSlide The actual slide the user is moving to. (Should be within the children[])
+   * @return {func} animationFunc The function to be passed to the setState call that sets the new slide index
+   */
+  wrappedAnimation(index, nextSlide) {
+    return () => {
+      this.animateSlide(null, null, this.getTargetLeft(null, index), () => {
+        this.animateSlide(null, 0.01);
+        this.props.afterSlide(nextSlide);
+        this.resetAutoplay();
+        this.setExternalData();
+      });
+    }
+  },
+  /**
+   * A simpler animationFunc for normal transitions that don't wrap.
+   * @param  {int} nextSlide The slide the user is moving to.
+   * @return {func} animationFunc The function to be passed to the setState call that sets the new slide index
+   */
+  basicAnimation(nextSlide) {
+    return () => {
+      this.animateSlide();
+      this.props.afterSlide(nextSlide);
+      this.resetAutoplay();
+      this.setExternalData();
+    }
+  },
+  /**
+   * Returns the index of the nextSlide, as well as the animationFunc that should
+   * be used to move there. Uses the attempted index and the current
+   * state/props.
+   * @param  {int} index The index the user is trying to move to.
+   * @return {[int, func]} The actual slide index to move to, and the animation func to get there.
+   */
+  getNextSlideAndAndimationFunc(index) {
+    // Get the data we need out of props, and state.
+    const { wrapAround, children, beforeSlide, alwaysAllowBackSlide } = this.props;
+    const { currentSlide, slidesToScroll } = this.state;
+    const { basicAnimation, wrappedAnimation } = this;
+
+    // And setup some variables to ease the conditionals...
+
+    // We're attempting to move out of bounds if index is < 0 or > than children count.
+    const overflow = index >= React.Children.count(children);
+    const underflow = index < 0;
+    const outOfBounds = overflow || underflow;
+
+    // The last slide is children.length - the amount we scroll.
+    const endSlide = React.Children.count(children) - slidesToScroll;
+
+    // Wrapped slide is the index of the first or end slide, depending
+    // on how (if?) we're out of bounds.
+    const wrappedSlide = overflow ? 0 : endSlide;
+
+    // If we're not out of bounds, our next slide should just be where ever the user was trying to go (index);
+    const nextSlide = outOfBounds ? wrappedSlide : index;
+    const movingBack = nextSlide < currentSlide;
+    const beforeHookCheck = beforeSlide(currentSlide, nextSlide) !== false;
+
+    // If we're trying to move out of bounds, but don't have wrap enabled, just return the currentSlide.
+    if (outOfBounds && !wrapAround) {
+      return [currentSlide, basicAnimation(nextSlide)];
+    }
+
+    // If we always allowBackSliding, and we're moving back, we should be good to continue.
+    // Otherwise we need to make sure the beforeSlide check is ok.
+    if ((alwaysAllowBackSlide && movingBack) || beforeHookCheck) {
+      // Different animation funcs depending on where we're going.
+      return [nextSlide, outOfBounds ? wrappedAnimation(index, nextSlide) : basicAnimation(nextSlide)];
+    }
+
+    // Not currently allowed to slide... Stay put!
+    return [currentSlide, basicAnimation(currentSlide)];
+  },
 
   goToSlide(index) {
     var self = this;
-    if ((index >= React.Children.count(this.props.children) || index < 0)) {
-      if (!this.props.wrapAround) { return };
-      if (index >= React.Children.count(this.props.children)) {
-        this.props.beforeSlide(this.state.currentSlide, 0);
-        return this.setState({
-          currentSlide: 0
-        }, function() {
-          self.animateSlide(null, null, self.getTargetLeft(null, index), function() {
-            self.animateSlide(null, 0.01);
-            self.props.afterSlide(0);
-            self.resetAutoplay();
-            self.setExternalData();
-          });
-        });
-      } else {
-        var endSlide = React.Children.count(this.props.children) - this.state.slidesToScroll;
-        this.props.beforeSlide(this.state.currentSlide, endSlide);
-        return this.setState({
-          currentSlide: endSlide
-        }, function() {
-          self.animateSlide(null, null, self.getTargetLeft(null, index), function() {
-            self.animateSlide(null, 0.01);
-            self.props.afterSlide(endSlide);
-            self.resetAutoplay();
-            self.setExternalData();
-          });
-        });
-      }
-    }
-
-    this.props.beforeSlide(this.state.currentSlide, index);
-
-    this.setState({
-      currentSlide: index
-    }, function() {
-      self.animateSlide();
-      this.props.afterSlide(index);
-      self.resetAutoplay();
-      self.setExternalData();
-    });
+    const [currentSlide, animationFunc] = this.getNextSlideAndAndimationFunc(index);
+    return this.setState({ currentSlide }, animationFunc);
   },
 
   nextSlide() {


### PR DESCRIPTION
I needed a carousel that only transitions forward on certain conditions.  I made some changes to Nuka Carousel to check the return of the `beforeSlide` hook and only move forward when it's _not_ `false`. (`undefined` should be ok, hopefully ensuring backwards compatibility.) 

Not sure if this is something useful enough to be merged, but if so let me know and I can add some tests, and make sure it works for multi slides + different orientations.  I can't get the tests running, even on a clean master... so it'll take a little digging. 

```
PhantomJS 1.9.8 (Mac OS X 0.0.0) ERROR
  RangeError: Maximum call stack size exceeded.
  at ~/nuka-carousel/node_modules/chai/chai.js:3863
```
