### PR TITLE
Make slidesToShow an updatable property

### DIFF
--- a/lib/carousel.js
+++ b/lib/carousel.js
@@ -32,6 +32,8 @@ var _exenv = require('exenv');
 
 var _exenv2 = _interopRequireDefault(_exenv);
 
+var _lodash = require('lodash');
+
 var addEvent = function addEvent(elem, type, eventHandle) {
   if (elem === null || typeof elem === 'undefined') {
     return;
@@ -133,7 +135,7 @@ var Carousel = _react2['default'].createClass({
   },
 
   componentWillMount: function componentWillMount() {
-    this.setInitialDimensions();
+    this.setInitialDimensions(this.props);
   },
 
   componentDidMount: function componentDidMount() {
@@ -146,18 +148,23 @@ var Carousel = _react2['default'].createClass({
   },
 
   componentWillReceiveProps: function componentWillReceiveProps(nextProps) {
-    this.setState({
-      slideCount: nextProps.children.length
-    });
-    this.setDimensions(nextProps);
-    if (typeof nextProps.slideIndex === 'number' && nextProps.slideIndex !== this.state.currentSlide) {
-      this.goToSlide(nextProps.slideIndex);
-    }
-    if (this.props.autoplay !== nextProps.autoplay) {
-      if (nextProps.autoplay) {
-        this.startAutoplay();
-      } else {
-        this.stopAutoplay();
+    if (!(0, _lodash.isEqual)(this.props, nextProps)) {
+      this.setState({
+        slideCount: nextProps.children.length
+      });
+      if (this.props.slidesToShow !== nextProps.slidesToShow) {
+        this.setInitialDimensions(nextProps);
+      }
+      this.setDimensions(nextProps);
+      if (nextProps.slideIndex && nextProps.slideIndex !== this.state.currentSlide) {
+        this.goToSlide(nextProps.slideIndex);
+      }
+      if (this.props.autoplay !== nextProps.autoplay) {
+        if (nextProps.autoplay) {
+          this.startAutoplay();
+        } else {
+          this.stopAutoplay();
+        }
       }
     }
   },
@@ -617,20 +624,26 @@ var Carousel = _react2['default'].createClass({
   },
 
   setInitialDimensions: function setInitialDimensions() {
+    var props = arguments.length <= 0 || arguments[0] === undefined ? this.props : arguments[0];
+
     var self = this,
+        slideCount,
+        currentSlide,
         slideWidth,
         frameHeight,
         slideHeight;
 
-    slideWidth = this.props.vertical ? this.props.initialSlideHeight || 0 : this.props.initialSlideWidth || 0;
-    slideHeight = this.props.initialSlideHeight ? this.props.initialSlideHeight * this.props.slidesToShow : 0;
+    currentSlide = this.state.currentSlide - this.state.currentSlide % props.slidesToShow;
+    slideWidth = props.vertical ? props.initialSlideHeight || 0 : props.initialSlideWidth || 0;
+    slideHeight = props.initialSlideHeight ? props.initialSlideHeight * props.slidesToShow : 0;
 
-    frameHeight = slideHeight + this.props.cellSpacing * (this.props.slidesToShow - 1);
+    frameHeight = slideHeight + props.cellSpacing * (props.slidesToShow - 1);
 
     this.setState({
+      currentSlide: currentSlide,
       slideHeight: slideHeight,
-      frameWidth: this.props.vertical ? frameHeight : '100%',
-      slideCount: _react2['default'].Children.count(this.props.children),
+      frameWidth: props.vertical ? frameHeight : '100%',
+      slideCount: _react2['default'].Children.count(props.children),
       slideWidth: slideWidth
     }, function () {
       self.setLeft();

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "karma-script-launcher": "~0.1.0",
     "karma-sinon-chai": "^1.1.0",
     "karma-webpack": "^1.7.0",
+    "lodash": "^4.13.1",
     "mocha": "^2.3.3",
     "phantomjs": "^1.9.18",
     "react": "^15.0.1",

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -6,6 +6,7 @@ import tweenState from 'kw-react-tween-state';
 import decorators from './decorators';
 import assign from 'object-assign';
 import ExecutionEnvironment from 'exenv';
+import {isEqual} from 'lodash';
 
 const addEvent = function(elem, type, eventHandle) {
   if (elem === null || typeof (elem) === 'undefined') {
@@ -126,7 +127,7 @@ const Carousel = React.createClass({
   },
 
   componentWillMount() {
-    this.setInitialDimensions();
+    this.setInitialDimensions(this.props);
   },
 
   componentDidMount() {
@@ -139,18 +140,23 @@ const Carousel = React.createClass({
   },
 
   componentWillReceiveProps(nextProps) {
-    this.setState({
-      slideCount: nextProps.children.length
-    });
-    this.setDimensions(nextProps);
-    if (this.props.slideIndex !== nextProps.slideIndex && nextProps.slideIndex !== this.state.currentSlide) {
-      this.goToSlide(nextProps.slideIndex);
-    }
-    if (this.props.autoplay !== nextProps.autoplay) {
-      if (nextProps.autoplay) {
-        this.startAutoplay();
-      } else {
-        this.stopAutoplay();
+    if (!isEqual(this.props, nextProps)) {
+      this.setState({
+        slideCount: nextProps.children.length
+      });
+      if (this.props.slidesToShow !== nextProps.slidesToShow) {
+        this.setInitialDimensions(nextProps);
+      }
+      this.setDimensions(nextProps);
+      if (nextProps.slideIndex && nextProps.slideIndex !== this.state.currentSlide) {
+        this.goToSlide(nextProps.slideIndex);
+      }
+      if (this.props.autoplay !== nextProps.autoplay) {
+        if (nextProps.autoplay) {
+          this.startAutoplay();
+        } else {
+          this.stopAutoplay();
+        }
       }
     }
   },
@@ -617,18 +623,20 @@ const Carousel = React.createClass({
     });
   },
 
-  setInitialDimensions() {
-    var self = this, slideWidth, frameHeight, slideHeight;
+  setInitialDimensions(props = this.props) {
+    var self = this, slideCount, currentSlide, slideWidth, frameHeight, slideHeight;
 
-    slideWidth = this.props.vertical ? (this.props.initialSlideHeight || 0) : (this.props.initialSlideWidth || 0);
-    slideHeight = this.props.initialSlideHeight ? this.props.initialSlideHeight * this.props.slidesToShow : 0;
+    currentSlide = this.state.currentSlide - (this.state.currentSlide % props.slidesToShow);
+    slideWidth = props.vertical ? (props.initialSlideHeight || 0) : (props.initialSlideWidth || 0);
+    slideHeight = props.initialSlideHeight ? props.initialSlideHeight * props.slidesToShow : 0;
 
-    frameHeight = slideHeight + (this.props.cellSpacing * (this.props.slidesToShow - 1));
+    frameHeight = slideHeight + (props.cellSpacing * (props.slidesToShow - 1));
 
     this.setState({
+      currentSlide: currentSlide,
       slideHeight: slideHeight,
-      frameWidth: this.props.vertical ? frameHeight : '100%',
-      slideCount: React.Children.count(this.props.children),
+      frameWidth: props.vertical ? frameHeight : '100%',
+      slideCount: React.Children.count(props.children),
       slideWidth: slideWidth
     }, function() {
       self.setLeft();

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -6,7 +6,6 @@ import tweenState from 'kw-react-tween-state';
 import decorators from './decorators';
 import assign from 'object-assign';
 import ExecutionEnvironment from 'exenv';
-import {isEqual} from 'lodash';
 
 const addEvent = function(elem, type, eventHandle) {
   if (elem === null || typeof (elem) === 'undefined') {
@@ -140,9 +139,9 @@ const Carousel = React.createClass({
   },
 
   componentWillReceiveProps(nextProps) {
-    if (!isEqual(this.props, nextProps)) {
+    //if (!isEqual(this.props, nextProps)) {
       this.setState({
-        slideCount: nextProps.children.length
+        slideCount: React.Children.count(nextProps.children)
       });
       if (this.props.slidesToShow !== nextProps.slidesToShow) {
         this.setInitialDimensions(nextProps);
@@ -158,7 +157,7 @@ const Carousel = React.createClass({
           this.stopAutoplay();
         }
       }
-    }
+    //}
   },
 
   componentWillUnmount() {


### PR DESCRIPTION
Solves two problems: (1) the component tries (and fails) to update itself when rerendered given the same props again, and (2) the component doesn't do a full update when given a new value for `slidesToShow`.

I get the feeling that there’s a better implementation.. but this should serve as a proof of concept.

In my use case, I'm changing the number of slidesToShow based on the screen width. This allows me to do this without things breaking.

Resolves Issue #79 
