### PR TITLE
Fix slideToScroll='auto' bug

### DIFF
--- a/src/carousel.js
+++ b/src/carousel.js
@@ -678,7 +678,7 @@ const Carousel = React.createClass({
     frameWidth = props.vertical ? frameHeight : frame.offsetWidth;
 
     if (props.slidesToScroll === 'auto') {
-      slidesToScroll = Math.floor(frameWidth / (slideWidth + props.cellSpacing));
+      slidesToScroll = Math.ceil(frameWidth / (slideWidth + props.cellSpacing));
     }
 
     this.setState({


### PR DESCRIPTION
Fixes bug where when `slideToScroll` prop was set to auto, the last
page of slides would have a gap after the last slide.

Addresses #139 