### PR TITLE
Revert "Fix slideToScroll='auto' bug"

### DIFF
--- a/src/carousel.js
+++ b/src/carousel.js
@@ -678,7 +678,7 @@ const Carousel = React.createClass({
     frameWidth = props.vertical ? frameHeight : frame.offsetWidth;
 
     if (props.slidesToScroll === 'auto') {
-      slidesToScroll = Math.ceil(frameWidth / (slideWidth + props.cellSpacing));
+      slidesToScroll = Math.floor(frameWidth / (slideWidth + props.cellSpacing));
     }
 
     this.setState({


### PR DESCRIPTION
Reverts FormidableLabs/nuka-carousel#141

Introduces an issue where next button disables when the last slide is only partially visible:
![image](https://cloud.githubusercontent.com/assets/13814048/18141322/f044511e-6f6d-11e6-98b8-8b03026e55a4.png)
