### PR TITLE
Fix slideToScroll='auto' bug including when the last slide is partially visible

### DIFF
--- a/src/carousel.js
+++ b/src/carousel.js
@@ -646,7 +646,8 @@ const Carousel = React.createClass({
       frame,
       frameWidth,
       frameHeight,
-      slideHeight;
+      slideHeight,
+      toScroll;
 
     slidesToScroll = props.slidesToScroll;
     frame = this.refs.frame;
@@ -678,7 +679,10 @@ const Carousel = React.createClass({
     frameWidth = props.vertical ? frameHeight : frame.offsetWidth;
 
     if (props.slidesToScroll === 'auto') {
-      slidesToScroll = Math.floor(frameWidth / (slideWidth + props.cellSpacing));
+      toScroll = frameWidth / (slideWidth + props.cellSpacing);
+      slidesToScroll = props.slideWidth === 1
+        ? Math.ceil(toScroll)
+        : Math.floor(toScroll);
     }
 
     this.setState({


### PR DESCRIPTION
> Fixes bug where when slideToScroll prop was set to auto, the last page of slides would have a gap after the last slide.

Addresses #139 and includes fix which caused the reversion of original pull request #141 with #142.
