### PR TITLE
Fix backwards scroll flicker when wrapAround prop is set

### DIFF
--- a/lib/carousel.js
+++ b/lib/carousel.js
@@ -648,7 +648,8 @@ var Carousel = _react2['default'].createClass({
         frame,
         frameWidth,
         frameHeight,
-        slideHeight;
+        slideHeight,
+        toScroll;
 
     slidesToScroll = props.slidesToScroll;
     frame = this.refs.frame;
@@ -678,7 +679,8 @@ var Carousel = _react2['default'].createClass({
     frameWidth = props.vertical ? frameHeight : frame.offsetWidth;
 
     if (props.slidesToScroll === 'auto') {
-      slidesToScroll = Math.floor(frameWidth / (slideWidth + props.cellSpacing));
+      toScroll = frameWidth / (slideWidth + props.cellSpacing);
+      slidesToScroll = props.slideWidth === 1 ? Math.ceil(toScroll) : Math.floor(toScroll);
     }
 
     this.setState({
@@ -784,7 +786,7 @@ var Carousel = _react2['default'].createClass({
       }
 
       if (index <= slidesAfter - 1) {
-        return (this.state.slideWidth + this.props.cellSpacing) * (this.state.slideCount + index);
+        return slidesBefore < 0 ? (this.state.slideWidth + this.props.cellSpacing) * (this.state.slideCount + index) : 0;
       }
     }
 

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -794,7 +794,7 @@ const Carousel = React.createClass({
       }
 
       if (index <= slidesAfter - 1) {
-        return (this.state.slideWidth + this.props.cellSpacing) * (this.state.slideCount + index);
+        return slidesBefore < 0 ? (this.state.slideWidth + this.props.cellSpacing) * (this.state.slideCount + index) : 0;
       }
     }
 


### PR DESCRIPTION
Fixes #140 

When wrapAround property is passed there is a flicker when scrolling backwards from first to last slide. This fixes that.
