### PR TITLE
Add scrollMode prop in order to control how slidesToScroll behaves

### DIFF
--- a/lib/carousel.js
+++ b/lib/carousel.js
@@ -81,8 +81,11 @@ var Carousel = _react2['default'].createClass({
     edgeEasing: _react2['default'].PropTypes.string,
     framePadding: _react2['default'].PropTypes.string,
     frameOverflow: _react2['default'].PropTypes.string,
+    heightMode: _react2['default'].PropTypes.oneOf(['max', 'adaptive']).isRequired,
     initialSlideHeight: _react2['default'].PropTypes.number,
     initialSlideWidth: _react2['default'].PropTypes.number,
+    lazyLoad: _react2['default'].PropTypes.bool,
+    scrollMode: _react2['default'].PropTypes.oneOf(['page', 'remainder']),
     slideIndex: _react2['default'].PropTypes.number,
     slidesToShow: _react2['default'].PropTypes.number,
     slidesToScroll: _react2['default'].PropTypes.oneOfType([_react2['default'].PropTypes.number, _react2['default'].PropTypes.oneOf(['auto'])]),
@@ -108,6 +111,8 @@ var Carousel = _react2['default'].createClass({
       edgeEasing: 'easeOutElastic',
       framePadding: '0px',
       frameOverflow: 'hidden',
+      heightMode: 'max',
+      scrollMode: 'remainder',
       slideIndex: 0,
       slidesToScroll: 1,
       slidesToShow: 1,
@@ -512,7 +517,14 @@ var Carousel = _react2['default'].createClass({
       if (this.props.slideWidth !== 1) {
         return this.goToSlide(this.state.currentSlide + this.state.slidesToScroll);
       }
-      this.goToSlide(Math.min(this.state.currentSlide + this.state.slidesToScroll, childrenCount - slidesToShow));
+
+      // If scrollMode = remainder, only scroll the amount of slides necessary without showing blank slides.
+      if (this.props.scrollMode === 'remainder') {
+        this.goToSlide(Math.min(this.state.currentSlide + this.state.slidesToScroll, childrenCount - slidesToShow));
+      } else if (this.props.scrollMode === 'page') {
+        // Otherwise, slidesToScroll always equals slides to show
+        this.goToSlide(this.state.currentSlide + this.state.slidesToScroll);
+      }
     }
   },
 
@@ -524,7 +536,11 @@ var Carousel = _react2['default'].createClass({
     if (this.props.wrapAround) {
       this.goToSlide(this.state.currentSlide - this.state.slidesToScroll);
     } else {
-      this.goToSlide(Math.max(0, this.state.currentSlide - this.state.slidesToScroll));
+      if (this.props.scrollMode === 'remainder') {
+        this.goToSlide(Math.max(0, this.state.currentSlide - this.state.slidesToScroll));
+      } else if (this.props.scrollMode === 'page') {
+        this.goToSlide(this.state.currentSlide - this.state.slidesToScroll);
+      }
     }
   },
 
@@ -607,12 +623,16 @@ var Carousel = _react2['default'].createClass({
   formatChildren: function formatChildren(children) {
     var self = this;
     var positionValue = this.props.vertical ? this.getTweeningValue('top') : this.getTweeningValue('left');
+    var start = Math.max(this.state.currentSlide - this.props.slidesToShow, 0);
+    var end = Math.min(this.state.currentSlide + 2 * this.props.slidesToShow, this.state.slideCount);
     return _react2['default'].Children.map(children, function (child, index) {
-      return _react2['default'].createElement(
-        'li',
-        { className: 'slider-slide', style: self.getSlideStyles(index, positionValue), key: index },
-        child
-      );
+      if (!self.props.lazyLoad || start <= index && index < end) {
+        return _react2['default'].createElement(
+          'li',
+          { className: 'slider-slide', style: self.getSlideStyles(index, positionValue), key: index },
+          child
+        );
+      }
     });
   },
 
@@ -644,20 +664,28 @@ var Carousel = _react2['default'].createClass({
     var self = this,
         slideWidth,
         slidesToScroll,
-        firstSlide,
         frame,
         frameWidth,
         frameHeight,
-        slideHeight;
+        slideHeight,
+        toScroll;
 
     slidesToScroll = props.slidesToScroll;
     frame = this.refs.frame;
-    firstSlide = frame.childNodes[0].childNodes[0];
-    if (firstSlide) {
-      firstSlide.style.height = 'auto';
-      slideHeight = this.props.vertical ? firstSlide.offsetHeight * props.slidesToShow : firstSlide.offsetHeight;
+    var slides = frame.childNodes[0].childNodes;
+
+    if (this.props.vertical) {
+      if (slides.length) {
+        slides[0].style.height = 'auto';
+        slideHeight = slides[0].offsetHeight * props.slidesToShow;
+      } else {
+        slideHeight = 100;
+      }
     } else {
-      slideHeight = 100;
+      slideHeight = props.heightMode === 'max' && this.state.slideHeight || props.initialSlideHeight || 0;
+      for (var i = 0; i < slides.length; i++) {
+        slideHeight = Math.max(slideHeight, slides[i].offsetHeight);
+      }
     }
 
     if (typeof props.slideWidth !== 'number') {
@@ -678,7 +706,8 @@ var Carousel = _react2['default'].createClass({
     frameWidth = props.vertical ? frameHeight : frame.offsetWidth;
 
     if (props.slidesToScroll === 'auto') {
-      slidesToScroll = Math.floor(frameWidth / (slideWidth + props.cellSpacing));
+      toScroll = frameWidth / (slideWidth + props.cellSpacing);
+      slidesToScroll = props.slideWidth === 1 ? Math.ceil(toScroll) : Math.floor(toScroll);
     }
 
     this.setState({

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -72,6 +72,7 @@ const Carousel = React.createClass({
     initialSlideHeight: React.PropTypes.number,
     initialSlideWidth: React.PropTypes.number,
     lazyLoad: React.PropTypes.bool,
+    scrollMode: React.PropTypes.oneOf(['page', 'remainder']),
     slideIndex: React.PropTypes.number,
     slidesToShow: React.PropTypes.number,
     slidesToScroll: React.PropTypes.oneOfType([
@@ -104,6 +105,7 @@ const Carousel = React.createClass({
       framePadding: '0px',
       frameOverflow: 'hidden',
       heightMode: 'max',
+      scrollMode: 'remainder',
       slideIndex: 0,
       slidesToScroll: 1,
       slidesToShow: 1,
@@ -521,9 +523,13 @@ const Carousel = React.createClass({
       if (this.props.slideWidth !== 1) {
         return this.goToSlide(this.state.currentSlide + this.state.slidesToScroll);
       }
-      this.goToSlide(
-        Math.min(this.state.currentSlide + this.state.slidesToScroll, childrenCount - slidesToShow)
-      );
+
+      // If scrollMode = remainder, only scroll the amount of slides necessary without showing blank slides.
+      if (this.props.scrollMode === 'remainder') {
+        this.goToSlide(Math.min(this.state.currentSlide + this.state.slidesToScroll, childrenCount - slidesToShow))
+      } else if (this.props.scrollMode === 'page') { // Otherwise, slidesToScroll always equals slides to show
+        this.goToSlide(this.state.currentSlide + this.state.slidesToScroll);
+      }
     }
   },
 
@@ -535,7 +541,11 @@ const Carousel = React.createClass({
     if (this.props.wrapAround) {
       this.goToSlide(this.state.currentSlide - this.state.slidesToScroll);
     } else {
-      this.goToSlide(Math.max(0, this.state.currentSlide - this.state.slidesToScroll));
+      if (this.props.scrollMode === 'remainder') {
+        this.goToSlide(Math.max(0, this.state.currentSlide - this.state.slidesToScroll));
+      } else if (this.props.scrollMode === 'page') {
+        this.goToSlide(this.state.currentSlide - this.state.slidesToScroll);
+      }
     }
   },
 


### PR DESCRIPTION
Make feature based off of https://github.com/FormidableLabs/nuka-carousel/issues/13 optional.

Usage: When there are 10 slides and slidesToScroll = slidesToShow = 4, then clicking "next" will result in items 5-8 showing, clicking "next" again will have two different modes to handle this.

If scrollMode = 'remainder', then slides 7-10 will show to avoid blank spaces in the slider view.

If scrollMode = 'page', then slides 9-10 will show with 2 remaining empty slide slots.

scrollMode defaults to 'remainder' to avoid breaking existing usage.
