### PR TITLE
Use child id as slide key when the id is available

### DIFF
--- a/src/carousel.js
+++ b/src/carousel.js
@@ -619,7 +619,8 @@ const Carousel = React.createClass({
     const end = Math.min(this.state.currentSlide + (2 * this.props.slidesToShow), this.state.slideCount);
     return React.Children.map(children, function(child, index) {
       if (!self.props.lazyLoad || (start <= index && index < end)) {
-        return <li className="slider-slide" style={self.getSlideStyles(index, positionValue)} key={index}>{child}</li>;
+        const slideKey = (typeof child.props === 'object' && child.props.id) ? child.props.id : index;
+        return <li className="slider-slide" style={self.getSlideStyles(index, positionValue)} key={slideKey}>{child}</li>;
       }
     });
   },


### PR DESCRIPTION
Issue https://github.com/FormidableLabs/nuka-carousel/issues/154

React key is very important for dynamic children because how React calculates the diff of DOM.

Proposal: key for each children slide can be set if child.props.id is available.

Currently we have `index` as the slide key https://github.com/FormidableLabs/nuka-carousel/blob/master/src/carousel.js#L622,

```
<li key="0"><div key="slide1" id="slide1">slide1</div></li>
<li key="1"><div key="slide2" id="slide2">slide2</div></li>
<li key="2"><div key="slide3" id="slide3">slide3</div></li>

<li key="0"><div key="slide1" id="slide1">slide1</div></li>
<li key="1"><div key="slide3" id="slide3">slide3</div></li>
```

The old slide3 will be destroyed and remount a new one.

If we set child key using `child.props.id`

```
<li key="slide1"><div key="slide1" id="slide1">slide1</div></li>
<li key="slide2"><div key="slide2" id="slide2">slide2</div></li>
<li key="slide3"><div key="slide3" id="slide3">slide3</div></li>

<li key="slide1"><div key="slide1" id="slide1">slide1</div></li>
<li key="slide3"><div key="slide3" id="slide3">slide3</div></li>
```

The old slide3 will be kept.

Reference:
https://facebook.github.io/react/docs/reconciliation.html#recursing-on-children
http://blog.arkency.com/2014/10/react-dot-js-and-dynamic-children-why-the-keys-are-important/

Note: lib/carousel.js is not updated in this PR because the build includes other changes...

```
diff --git a/lib/carousel.js b/lib/carousel.js
index d36502c..84c94c6 100644
--- a/lib/carousel.js
+++ b/lib/carousel.js
@@ -81,8 +81,10 @@ var Carousel = _react2['default'].createClass({
     edgeEasing: _react2['default'].PropTypes.string,
     framePadding: _react2['default'].PropTypes.string,
     frameOverflow: _react2['default'].PropTypes.string,
+    heightMode: _react2['default'].PropTypes.oneOf(['max', 'adaptive']).isRequired,
     initialSlideHeight: _react2['default'].PropTypes.number,
     initialSlideWidth: _react2['default'].PropTypes.number,
+    lazyLoad: _react2['default'].PropTypes.bool,
     slideIndex: _react2['default'].PropTypes.number,
     slidesToShow: _react2['default'].PropTypes.number,
     slidesToScroll: _react2['default'].PropTypes.oneOfType([_react2['default'].PropTypes.number, _react2['default'].PropTypes.oneOf(['auto'])]),
@@ -108,6 +110,7 @@ var Carousel = _react2['default'].createClass({
       edgeEasing: 'easeOutElastic',
       framePadding: '0px',
       frameOverflow: 'hidden',
+      heightMode: 'max',
       slideIndex: 0,
       slidesToScroll: 1,
       slidesToShow: 1,
@@ -607,12 +610,17 @@ var Carousel = _react2['default'].createClass({
   formatChildren: function formatChildren(children) {
     var self = this;
     var positionValue = this.props.vertical ? this.getTweeningValue('top') : this.getTweeningValue('left');
+    var start = Math.max(this.state.currentSlide - this.props.slidesToShow, 0);
+    var end = Math.min(this.state.currentSlide + 2 * this.props.slidesToShow, this.state.slideCount);
     return _react2['default'].Children.map(children, function (child, index) {
-      return _react2['default'].createElement(
-        'li',
-        { className: 'slider-slide', style: self.getSlideStyles(index, positionValue), key: index },
-        child
-      );
+      if (!self.props.lazyLoad || start <= index && index < end) {
+        var slideKey = typeof child.props === 'object' && child.props.id ? child.props.id : index;
+        return _react2['default'].createElement(
+          'li',
+          { className: 'slider-slide', style: self.getSlideStyles(index, positionValue), key: slideKey },
+          child
+        );
+      }
     });
   },

@@ -644,20 +652,28 @@ var Carousel = _react2['default'].createClass({
     var self = this,
         slideWidth,
         slidesToScroll,
-        firstSlide,
         frame,
         frameWidth,
         frameHeight,
-        slideHeight;
+        slideHeight,
+        toScroll;

     slidesToScroll = props.slidesToScroll;
     frame = this.refs.frame;
-    firstSlide = frame.childNodes[0].childNodes[0];
-    if (firstSlide) {
-      firstSlide.style.height = 'auto';
-      slideHeight = this.props.vertical ? firstSlide.offsetHeight * props.slidesToShow : firstSlide.offsetHeight;
+    var slides = frame.childNodes[0].childNodes;
+
+    if (this.props.vertical) {
+      if (slides.length) {
+        slides[0].style.height = 'auto';
+        slideHeight = slides[0].offsetHeight * props.slidesToShow;
+      } else {
+        slideHeight = 100;
+      }
     } else {
-      slideHeight = 100;
+      slideHeight = props.heightMode === 'max' && this.state.slideHeight || props.initialSlideHeight || 0;
+      for (var i = 0; i < slides.length; i++) {
+        slideHeight = Math.max(slideHeight, slides[i].offsetHeight);
+      }
     }

     if (typeof props.slideWidth !== 'number') {
@@ -678,7 +694,8 @@ var Carousel = _react2['default'].createClass({
     frameWidth = props.vertical ? frameHeight : frame.offsetWidth;

     if (props.slidesToScroll === 'auto') {
-      slidesToScroll = Math.floor(frameWidth / (slideWidth + props.cellSpacing));
+      toScroll = frameWidth / (slideWidth + props.cellSpacing);
+      slidesToScroll = props.slideWidth === 1 ? Math.ceil(toScroll) : Math.floor(toScroll);
     }

     this.setState({

```
