### PR TITLE
Disable swipping when 'swiping' prop is set (#106)

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,12 @@ Manually set slideWidth. If you want hard pixel widths, use a string like `slide
 
 Animation duration.
 
+####swiping
+`React.PropTypes.bool`
+
+Enable touch swipe/dragging
+
+
 ####vertical
 `React.PropTypes.bool`
 

--- a/demo/app.js
+++ b/demo/app.js
@@ -92,6 +92,9 @@ const App = () => (
     <h1>Disable dragging</h1>
     <LazyCarousel count={6} dragging={false}/>
 
+    <h1>Disable dragging / swipping</h1>
+    <LazyCarousel count={6} dragging={false} swiping={false}/>
+
     <h1>Varying heights</h1>
     <VariableHeightCarousel slidesToShow={4}/>
 

--- a/lib/carousel.js
+++ b/lib/carousel.js
@@ -91,6 +91,7 @@ var Carousel = _react2['default'].createClass({
     slidesToScroll: _react2['default'].PropTypes.oneOfType([_react2['default'].PropTypes.number, _react2['default'].PropTypes.oneOf(['auto'])]),
     slideWidth: _react2['default'].PropTypes.oneOfType([_react2['default'].PropTypes.string, _react2['default'].PropTypes.number]),
     speed: _react2['default'].PropTypes.number,
+    swiping: _react2['default'].PropTypes.bool,
     vertical: _react2['default'].PropTypes.bool,
     width: _react2['default'].PropTypes.string,
     wrapAround: _react2['default'].PropTypes.bool
@@ -118,6 +119,7 @@ var Carousel = _react2['default'].createClass({
       slidesToShow: 1,
       slideWidth: 1,
       speed: 500,
+      swiping: true,
       vertical: false,
       width: '100%',
       wrapAround: false
@@ -222,6 +224,10 @@ var Carousel = _react2['default'].createClass({
 
   getTouchEvents: function getTouchEvents() {
     var self = this;
+
+    if (this.props.swiping === false) {
+      return null;
+    }
 
     return {
       onTouchStart: function onTouchStart(e) {

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -84,6 +84,7 @@ const Carousel = React.createClass({
       React.PropTypes.number
     ]),
     speed: React.PropTypes.number,
+    swiping: React.PropTypes.bool,
     vertical: React.PropTypes.bool,
     width: React.PropTypes.string,
     wrapAround: React.PropTypes.bool,
@@ -111,6 +112,7 @@ const Carousel = React.createClass({
       slidesToShow: 1,
       slideWidth: 1,
       speed: 500,
+      swiping: true,
       vertical: false,
       width: '100%',
       wrapAround: false
@@ -214,6 +216,10 @@ const Carousel = React.createClass({
 
   getTouchEvents() {
     var self = this;
+
+    if (this.props.swiping === false) {
+      return null;
+    }
 
     return {
       onTouchStart(e) {

--- a/test/specs/carousel.spec.js
+++ b/test/specs/carousel.spec.js
@@ -289,7 +289,7 @@ describe('Carousel', function () {
 
     it('should add mouse handlers if dragging is true', function() {
         component = ReactDOM.render(
-          React.createElement(carousel, {dragging: false},
+          React.createElement(carousel, {dragging: true},
             React.createElement('p', null, 'Slide 1'),
             React.createElement('p', null, 'Slide 2'),
             React.createElement('p', null, 'Slide 3')
@@ -299,6 +299,34 @@ describe('Carousel', function () {
 
         var frame = getSingleComponentWithClassName(component, 'slider-frame');
         expect(frame.onMouseDown).to.be.defined;
+    });
+
+    it('should not add touch handlers if swiping is false', function() {
+      component = ReactDOM.render(
+        React.createElement(carousel, {swiping: false},
+          React.createElement('p', null, 'Slide 1'),
+          React.createElement('p', null, 'Slide 2'),
+          React.createElement('p', null, 'Slide 3')
+        ),
+        container
+      );
+
+      var frame = getSingleComponentWithClassName(component, 'slider-frame');
+      expect(frame.onTouchStart).to.be.undefined;
+    });
+
+    it('should add touch handlers if swiping is true', function() {
+      component = ReactDOM.render(
+        React.createElement(carousel, {swiping: true},
+          React.createElement('p', null, 'Slide 1'),
+          React.createElement('p', null, 'Slide 2'),
+          React.createElement('p', null, 'Slide 3')
+        ),
+        container
+      );
+
+      var frame = getSingleComponentWithClassName(component, 'slider-frame');
+      expect(frame.onTouchStart).to.be.defined;
     });
 
     it('should add frame margin if framePadding is supplied a value', function() {


### PR DESCRIPTION
`<Carousel dragging={false} swiping={false}/>`

Fixes #106