### PR TITLE
Fix last slides not visible

### DIFF
--- a/lib/carousel.js
+++ b/lib/carousel.js
@@ -852,7 +852,7 @@ var Carousel = _react2['default'].createClass({
       }
 
       if (index <= slidesAfter - 1) {
-        return slidesBefore < 0 ? (this.state.slideWidth + this.props.cellSpacing) * (this.state.slideCount + index) : 0;
+        return (this.state.slideWidth + this.props.cellSpacing) * (this.state.slideCount + index);
       }
     }
 

--- a/lib/carousel.js
+++ b/lib/carousel.js
@@ -199,6 +199,7 @@ var Carousel = _react2['default'].createClass({
             className: 'slider-decorator-' + index,
             key: index },
           _react2['default'].createElement(Decorator.component, {
+            scrollMode: self.props.scrollMode,
             currentSlide: self.state.currentSlide,
             slideCount: self.state.slideCount,
             frameWidth: self.state.frameWidth,
@@ -373,7 +374,6 @@ var Carousel = _react2['default'].createClass({
 
     if (this.touchObject.length > this.state.slideWidth / slidesToShow / 5) {
       if (this.touchObject.direction === 1) {
-        console.log(this.state.currentSlide, _react2['default'].Children.count(this.props.children));
         if (this.state.currentSlide >= _react2['default'].Children.count(this.props.children) - 1 && !this.props.wrapAround) {
           this.animateSlide(_kwReactTweenState2['default'].easingTypes[this.props.edgeEasing]);
         } else {

--- a/lib/carousel.js
+++ b/lib/carousel.js
@@ -199,18 +199,20 @@ var Carousel = _react2['default'].createClass({
             className: 'slider-decorator-' + index,
             key: index },
           _react2['default'].createElement(Decorator.component, {
-            scrollMode: self.props.scrollMode,
-            currentSlide: self.state.currentSlide,
-            slideCount: self.state.slideCount,
-            frameWidth: self.state.frameWidth,
-            slideWidth: self.state.slideWidth,
-            slidesToScroll: self.state.slidesToScroll,
             cellSpacing: self.props.cellSpacing,
-            slidesToShow: self.props.slidesToShow,
-            wrapAround: self.props.wrapAround,
+            cellAlign: self.props.cellAlign,
+            currentSlide: self.state.currentSlide,
+            frameWidth: self.state.frameWidth,
+            goToSlide: self.goToSlide,
             nextSlide: self.nextSlide,
             previousSlide: self.previousSlide,
-            goToSlide: self.goToSlide })
+            scrollMode: self.props.scrollMode,
+            slideCount: self.state.slideCount,
+            slidesToScroll: self.state.slidesToScroll,
+            slidesToShow: self.props.slidesToShow,
+            slideWidth: self.state.slideWidth,
+            wrapAround: self.props.wrapAround
+          })
         );
       }) : null,
       _react2['default'].createElement('style', { type: 'text/css', dangerouslySetInnerHTML: { __html: self.getStyleTagStyles() } })
@@ -374,7 +376,22 @@ var Carousel = _react2['default'].createClass({
 
     if (this.touchObject.length > this.state.slideWidth / slidesToShow / 5) {
       if (this.touchObject.direction === 1) {
-        if (this.state.currentSlide >= _react2['default'].Children.count(this.props.children) - (this.props.scrollMode === 'remainder' ? this.state.slidesToScroll : 1) && !this.props.wrapAround) {
+        var lastPossibleIndex = undefined;
+        var count = _react2['default'].Children.count(this.props.children);
+
+        switch (this.props.cellAlign) {
+          case 'left':
+            lastPossibleIndex = count - this.props.slidesToShow;
+            break;
+          case 'center':
+            lastPossibleIndex = count - Math.ceil(this.props.slidesToShow / 2) - (this.props.slidesToShow % 2 === 0 ? 1 : 0);
+            break;
+          case 'right':
+            lastPossibleIndex = count - 1;
+            break;
+        }
+
+        if (this.state.currentSlide >= (this.props.scrollMode === 'remainder' ? lastPossibleIndex : count - 1) && !this.props.wrapAround) {
           this.animateSlide(_kwReactTweenState2['default'].easingTypes[this.props.edgeEasing]);
         } else {
           this.nextSlide();
@@ -522,12 +539,21 @@ var Carousel = _react2['default'].createClass({
       }
 
       // If scrollMode = remainder, only scroll the amount of slides necessary without showing blank slides.
-      if (this.props.scrollMode === 'remainder') {
-        this.goToSlide(this.state.currentSlide + this.state.slidesToScroll);
-      } else if (this.props.scrollMode === 'page') {
-        // Otherwise, slidesToScroll always equals slides to show
-        this.goToSlide(Math.min(this.state.currentSlide + this.state.slidesToScroll, childrenCount - 1));
+      if (this.props.scrollMode === 'remainder' && this.props.cellAlign !== 'right') {
+        var _state = this.state;
+        var currentSlide = _state.currentSlide;
+        var slidesToScroll = _state.slidesToScroll;
+        var cellAlign = this.props.cellAlign;
+
+        var lastIndex = childrenCount - slidesToShow;
+
+        if (cellAlign === 'center') {
+          lastIndex = childrenCount - 1 - Math.floor(slidesToShow / 2);
+        }
+        return this.goToSlide(currentSlide + slidesToScroll >= lastIndex ? lastIndex : currentSlide + slidesToScroll);
       }
+
+      this.goToSlide(Math.min(this.state.currentSlide + this.state.slidesToScroll, childrenCount - 1));
     }
   },
 
@@ -539,25 +565,21 @@ var Carousel = _react2['default'].createClass({
     if (this.props.wrapAround) {
       this.goToSlide(this.state.currentSlide - this.state.slidesToScroll);
     } else {
-      if (this.props.scrollMode === 'remainder') {
-        this.goToSlide(this.state.currentSlide - this.state.slidesToScroll);
-      } else if (this.props.scrollMode === 'page') {
-        var _state = this.state;
-        var currentSlide = _state.currentSlide;
-        var slidesToScroll = _state.slidesToScroll;
+      var _state2 = this.state;
+      var currentSlide = _state2.currentSlide;
+      var slidesToScroll = _state2.slidesToScroll;
 
-        var index = 0;
+      var index = 0;
 
-        while (index < currentSlide) {
-          if (index + slidesToScroll >= currentSlide) {
-            break;
-          }
-
-          index += slidesToScroll;
+      while (index < currentSlide) {
+        if (index + slidesToScroll >= currentSlide) {
+          break;
         }
 
-        this.goToSlide(index);
+        index += slidesToScroll;
       }
+
+      this.goToSlide(index);
     }
   },
 

--- a/lib/carousel.js
+++ b/lib/carousel.js
@@ -813,7 +813,7 @@ var Carousel = _react2['default'].createClass({
       }
 
       if (index <= slidesAfter - 1) {
-        return (this.state.slideWidth + this.props.cellSpacing) * (this.state.slideCount + index);
+        return slidesBefore < 0 ? (this.state.slideWidth + this.props.cellSpacing) * (this.state.slideCount + index) : 0;
       }
     }
 

--- a/lib/carousel.js
+++ b/lib/carousel.js
@@ -374,7 +374,7 @@ var Carousel = _react2['default'].createClass({
 
     if (this.touchObject.length > this.state.slideWidth / slidesToShow / 5) {
       if (this.touchObject.direction === 1) {
-        if (this.state.currentSlide >= _react2['default'].Children.count(this.props.children) - 1 && !this.props.wrapAround) {
+        if (this.state.currentSlide >= _react2['default'].Children.count(this.props.children) - (this.props.scrollMode === 'remainder' ? this.state.slidesToScroll : 1) && !this.props.wrapAround) {
           this.animateSlide(_kwReactTweenState2['default'].easingTypes[this.props.edgeEasing]);
         } else {
           this.nextSlide();
@@ -523,10 +523,10 @@ var Carousel = _react2['default'].createClass({
 
       // If scrollMode = remainder, only scroll the amount of slides necessary without showing blank slides.
       if (this.props.scrollMode === 'remainder') {
-        this.goToSlide(Math.min(this.state.currentSlide + this.state.slidesToScroll, childrenCount - 1));
+        this.goToSlide(this.state.currentSlide + this.state.slidesToScroll);
       } else if (this.props.scrollMode === 'page') {
         // Otherwise, slidesToScroll always equals slides to show
-        this.goToSlide(this.state.currentSlide + this.state.slidesToScroll);
+        this.goToSlide(Math.min(this.state.currentSlide + this.state.slidesToScroll, childrenCount - 1));
       }
     }
   },
@@ -540,6 +540,8 @@ var Carousel = _react2['default'].createClass({
       this.goToSlide(this.state.currentSlide - this.state.slidesToScroll);
     } else {
       if (this.props.scrollMode === 'remainder') {
+        this.goToSlide(this.state.currentSlide - this.state.slidesToScroll);
+      } else if (this.props.scrollMode === 'page') {
         var _state = this.state;
         var currentSlide = _state.currentSlide;
         var slidesToScroll = _state.slidesToScroll;
@@ -555,8 +557,6 @@ var Carousel = _react2['default'].createClass({
         }
 
         this.goToSlide(index);
-      } else if (this.props.scrollMode === 'page') {
-        this.goToSlide(this.state.currentSlide - this.state.slidesToScroll);
       }
     }
   },

--- a/lib/carousel.js
+++ b/lib/carousel.js
@@ -373,7 +373,8 @@ var Carousel = _react2['default'].createClass({
 
     if (this.touchObject.length > this.state.slideWidth / slidesToShow / 5) {
       if (this.touchObject.direction === 1) {
-        if (this.state.currentSlide >= _react2['default'].Children.count(this.props.children) - slidesToShow && !this.props.wrapAround) {
+        console.log(this.state.currentSlide, _react2['default'].Children.count(this.props.children));
+        if (this.state.currentSlide >= _react2['default'].Children.count(this.props.children) - 1 && !this.props.wrapAround) {
           this.animateSlide(_kwReactTweenState2['default'].easingTypes[this.props.edgeEasing]);
         } else {
           this.nextSlide();
@@ -504,10 +505,12 @@ var Carousel = _react2['default'].createClass({
   nextSlide: function nextSlide() {
     var childrenCount = _react2['default'].Children.count(this.props.children);
     var slidesToShow = this.props.slidesToShow;
+
     if (this.props.slidesToScroll === 'auto') {
       slidesToShow = this.state.slidesToScroll;
     }
-    if (this.state.currentSlide >= childrenCount - slidesToShow && !this.props.wrapAround) {
+
+    if (this.state.currentSlide > childrenCount && !this.props.wrapAround) {
       return;
     }
 
@@ -520,7 +523,7 @@ var Carousel = _react2['default'].createClass({
 
       // If scrollMode = remainder, only scroll the amount of slides necessary without showing blank slides.
       if (this.props.scrollMode === 'remainder') {
-        this.goToSlide(Math.min(this.state.currentSlide + this.state.slidesToScroll, childrenCount - slidesToShow));
+        this.goToSlide(Math.min(this.state.currentSlide + this.state.slidesToScroll, childrenCount - 1));
       } else if (this.props.scrollMode === 'page') {
         // Otherwise, slidesToScroll always equals slides to show
         this.goToSlide(this.state.currentSlide + this.state.slidesToScroll);
@@ -537,7 +540,21 @@ var Carousel = _react2['default'].createClass({
       this.goToSlide(this.state.currentSlide - this.state.slidesToScroll);
     } else {
       if (this.props.scrollMode === 'remainder') {
-        this.goToSlide(Math.max(0, this.state.currentSlide - this.state.slidesToScroll));
+        var _state = this.state;
+        var currentSlide = _state.currentSlide;
+        var slidesToScroll = _state.slidesToScroll;
+
+        var index = 0;
+
+        while (index < currentSlide) {
+          if (index + slidesToScroll >= currentSlide) {
+            break;
+          }
+
+          index += slidesToScroll;
+        }
+
+        this.goToSlide(index);
       } else if (this.props.scrollMode === 'page') {
         this.goToSlide(this.state.currentSlide - this.state.slidesToScroll);
       }

--- a/lib/decorators.js
+++ b/lib/decorators.js
@@ -45,11 +45,22 @@ var DefaultDecorators = [{
     displayName: 'component',
 
     render: function render() {
+      var cellOffsetPosition = this.props.slideCount - 1;
+
+      if (this.props.scrollMode === 'remainder') {
+        switch (this.props.cellAlign) {
+          case 'center':
+            cellOffsetPosition = this.props.slideCount - Math.ceil(this.props.slidesToShow / 2) - (this.props.slidesToShow % 2 === 0 ? 1 : 0);
+            break;
+          case 'left':
+            cellOffsetPosition = this.props.slideCount - this.props.slidesToShow;
+        }
+      }
 
       return _react2['default'].createElement(
         'button',
         {
-          style: this.getButtonStyles(this.props.currentSlide === this.props.slideCount - 1 && !this.props.wrapAround),
+          style: this.getButtonStyles(this.props.currentSlide === cellOffsetPosition && !this.props.wrapAround),
           onClick: this.handleClick },
         'NEXT'
       );
@@ -77,7 +88,7 @@ var DefaultDecorators = [{
 
     render: function render() {
       var self = this;
-      var indexes = this.getIndexes(self.props.slideCount, self.props.slidesToScroll);
+      var indexes = this.getIndexes(self.props.slideCount, self.props.slidesToScroll, this.props.scrollMode === 'page');
       return _react2['default'].createElement(
         'ul',
         { style: self.getListStyles() },
@@ -96,18 +107,45 @@ var DefaultDecorators = [{
         })
       );
     },
-    getIndexes: function getIndexes(count, inc) {
+    getIndexes: function getIndexes(count, inc, remainderScroll) {
       var arr = [];
 
-      for (var i = 0; i < count; i += inc) {
-        arr.push(i);
+      if (remainderScroll) {
+        for (var i = 0; i < count; i += inc) {
+          arr.push(i);
+        }
+
+        if (arr[arr.length - 1] < count - 1) {
+          arr.push(count - 1);
+        }
+      } else {
+        var lastPossibleIndex = undefined;
+
+        switch (this.props.cellAlign) {
+          case 'left':
+            lastPossibleIndex = count - this.props.slidesToShow;
+            break;
+          case 'center':
+            lastPossibleIndex = count - Math.ceil(this.props.slidesToShow / 2) - (this.props.slidesToShow % 2 === 0 ? 1 : 0);
+            break;
+          case 'right':
+            lastPossibleIndex = count - 1;
+            break;
+        }
+
+        for (var i = 0; i <= count; i += inc) {
+          arr.push(i < lastPossibleIndex ? i : lastPossibleIndex);
+        }
       }
 
-      if (arr.slice(-1)[0] !== count - 1 && this.props.scrollMode === 'page') {
-        arr.push(count - 1);
-      }
+      var log = {};
+      return arr.filter(function (val) {
+        if (log[val] === undefined) {
+          log[val] = val;
 
-      return arr;
+          return true;
+        }
+      }).sort();
     },
     getListStyles: function getListStyles() {
       return {

--- a/lib/decorators.js
+++ b/lib/decorators.js
@@ -103,9 +103,10 @@ var DefaultDecorators = [{
         arr.push(i);
       }
 
-      if (arr.slice(-1)[0] !== count - 1) {
+      if (arr.slice(-1)[0] !== count - 1 && this.props.scrollMode === 'remainder') {
         arr.push(count - 1);
       }
+
       return arr;
     },
     getListStyles: function getListStyles() {

--- a/lib/decorators.js
+++ b/lib/decorators.js
@@ -45,10 +45,11 @@ var DefaultDecorators = [{
     displayName: 'component',
 
     render: function render() {
+
       return _react2['default'].createElement(
         'button',
         {
-          style: this.getButtonStyles(this.props.currentSlide + this.props.slidesToScroll >= this.props.slideCount && !this.props.wrapAround),
+          style: this.getButtonStyles(this.props.currentSlide === this.props.slideCount - 1 && !this.props.wrapAround),
           onClick: this.handleClick },
         'NEXT'
       );
@@ -97,8 +98,13 @@ var DefaultDecorators = [{
     },
     getIndexes: function getIndexes(count, inc) {
       var arr = [];
+
       for (var i = 0; i < count; i += inc) {
         arr.push(i);
+      }
+
+      if (arr.slice(-1)[0] !== count - 1) {
+        arr.push(count - 1);
       }
       return arr;
     },

--- a/lib/decorators.js
+++ b/lib/decorators.js
@@ -103,7 +103,7 @@ var DefaultDecorators = [{
         arr.push(i);
       }
 
-      if (arr.slice(-1)[0] !== count - 1 && this.props.scrollMode === 'remainder') {
+      if (arr.slice(-1)[0] !== count - 1 && this.props.scrollMode === 'page') {
         arr.push(count - 1);
       }
 

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -188,6 +188,7 @@ const Carousel = React.createClass({
                 className={'slider-decorator-' + index}
                 key={index}>
                 <Decorator.component
+                  scrollMode={self.props.scrollMode}
                   currentSlide={self.state.currentSlide}
                   slideCount={self.state.slideCount}
                   frameWidth={self.state.frameWidth}
@@ -377,7 +378,6 @@ const Carousel = React.createClass({
 
     if (this.touchObject.length > (this.state.slideWidth / slidesToShow) / 5) {
       if (this.touchObject.direction === 1) {
-        console.log(this.state.currentSlide, React.Children.count(this.props.children));
         if (
           this.state.currentSlide >= (React.Children.count(this.props.children) - 1) &&
           !this.props.wrapAround

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -188,18 +188,20 @@ const Carousel = React.createClass({
                 className={'slider-decorator-' + index}
                 key={index}>
                 <Decorator.component
-                  scrollMode={self.props.scrollMode}
-                  currentSlide={self.state.currentSlide}
-                  slideCount={self.state.slideCount}
-                  frameWidth={self.state.frameWidth}
-                  slideWidth={self.state.slideWidth}
-                  slidesToScroll={self.state.slidesToScroll}
                   cellSpacing={self.props.cellSpacing}
-                  slidesToShow={self.props.slidesToShow}
-                  wrapAround={self.props.wrapAround}
+                  cellAlign={self.props.cellAlign}
+                  currentSlide={self.state.currentSlide}
+                  frameWidth={self.state.frameWidth}
+                  goToSlide={self.goToSlide}
                   nextSlide={self.nextSlide}
                   previousSlide={self.previousSlide}
-                  goToSlide={self.goToSlide} />
+                  scrollMode={self.props.scrollMode}
+                  slideCount={self.state.slideCount}
+                  slidesToScroll={self.state.slidesToScroll}
+                  slidesToShow={self.props.slidesToShow}
+                  slideWidth={self.state.slideWidth}
+                  wrapAround={self.props.wrapAround}
+                />
               </div>
             )
           })
@@ -528,13 +530,25 @@ const Carousel = React.createClass({
       }
 
       // If scrollMode = remainder, only scroll the amount of slides necessary without showing blank slides.
-      if (this.props.scrollMode === 'remainder') {
-        this.goToSlide(this.state.currentSlide + this.state.slidesToScroll);
-      } else if (this.props.scrollMode === 'page') { // Otherwise, slidesToScroll always equals slides to show
-        this.goToSlide(
-          Math.min(this.state.currentSlide + this.state.slidesToScroll, childrenCount - 1)
+      if (this.props.scrollMode === 'remainder' && this.props.cellAlign !== 'right') {
+        const { currentSlide, slidesToScroll } = this.state;
+        const { cellAlign } = this.props;
+        let lastIndex = childrenCount - slidesToShow;
+
+        if (cellAlign === 'center') {
+          lastIndex =  (childrenCount - 1) - Math.floor(slidesToShow / 2);
+        }
+        return this.goToSlide(
+          currentSlide + slidesToScroll >= lastIndex ?
+            lastIndex
+            :
+            currentSlide + slidesToScroll
         );
       }
+
+      this.goToSlide(
+        Math.min(this.state.currentSlide + this.state.slidesToScroll, childrenCount - 1)
+      );
     }
   },
 
@@ -546,22 +560,18 @@ const Carousel = React.createClass({
     if (this.props.wrapAround) {
       this.goToSlide(this.state.currentSlide - this.state.slidesToScroll);
     } else {
-      if (this.props.scrollMode === 'remainder') {
-        this.goToSlide(this.state.currentSlide - this.state.slidesToScroll);
-      } else if (this.props.scrollMode === 'page') {
-        var { currentSlide, slidesToScroll } = this.state;
-        var index = 0;
+      const { currentSlide, slidesToScroll } = this.state;
+      let index = 0;
 
-        while (index < currentSlide) {
-          if (index + slidesToScroll >= currentSlide) {
-            break;
-          }
-
-          index += slidesToScroll;
+      while (index < currentSlide) {
+        if (index + slidesToScroll >= currentSlide) {
+          break;
         }
 
-        this.goToSlide(index);
+        index += slidesToScroll
       }
+
+      this.goToSlide(index);
     }
   },
 

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -379,7 +379,7 @@ const Carousel = React.createClass({
     if (this.touchObject.length > (this.state.slideWidth / slidesToShow) / 5) {
       if (this.touchObject.direction === 1) {
         if (
-          this.state.currentSlide >= (React.Children.count(this.props.children) - 1) &&
+          this.state.currentSlide >= (React.Children.count(this.props.children) - (this.props.scrollMode === 'remainder' ? this.state.slidesToScroll : 1)) &&
           !this.props.wrapAround
         ) {
           this.animateSlide(tweenState.easingTypes[this.props.edgeEasing]);
@@ -529,11 +529,11 @@ const Carousel = React.createClass({
 
       // If scrollMode = remainder, only scroll the amount of slides necessary without showing blank slides.
       if (this.props.scrollMode === 'remainder') {
+        this.goToSlide(this.state.currentSlide + this.state.slidesToScroll);
+      } else if (this.props.scrollMode === 'page') { // Otherwise, slidesToScroll always equals slides to show
         this.goToSlide(
           Math.min(this.state.currentSlide + this.state.slidesToScroll, childrenCount - 1)
         );
-      } else if (this.props.scrollMode === 'page') { // Otherwise, slidesToScroll always equals slides to show
-        this.goToSlide(this.state.currentSlide + this.state.slidesToScroll);
       }
     }
   },
@@ -547,6 +547,8 @@ const Carousel = React.createClass({
       this.goToSlide(this.state.currentSlide - this.state.slidesToScroll);
     } else {
       if (this.props.scrollMode === 'remainder') {
+        this.goToSlide(this.state.currentSlide - this.state.slidesToScroll);
+      } else if (this.props.scrollMode === 'page') {
         var { currentSlide, slidesToScroll } = this.state;
         var index = 0;
 
@@ -559,8 +561,6 @@ const Carousel = React.createClass({
         }
 
         this.goToSlide(index);
-      } else if (this.props.scrollMode === 'page') {
-        this.goToSlide(this.state.currentSlide - this.state.slidesToScroll);
       }
     }
   },

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -377,8 +377,9 @@ const Carousel = React.createClass({
 
     if (this.touchObject.length > (this.state.slideWidth / slidesToShow) / 5) {
       if (this.touchObject.direction === 1) {
+        console.log(this.state.currentSlide, React.Children.count(this.props.children));
         if (
-          this.state.currentSlide >= React.Children.count(this.props.children) - slidesToShow &&
+          this.state.currentSlide >= (React.Children.count(this.props.children) - 1) &&
           !this.props.wrapAround
         ) {
           this.animateSlide(tweenState.easingTypes[this.props.edgeEasing]);
@@ -510,10 +511,12 @@ const Carousel = React.createClass({
   nextSlide() {
     var childrenCount = React.Children.count(this.props.children);
     var slidesToShow = this.props.slidesToShow;
+
     if (this.props.slidesToScroll === 'auto') {
       slidesToShow = this.state.slidesToScroll;
     }
-    if (this.state.currentSlide >= childrenCount - slidesToShow && !this.props.wrapAround) {
+
+    if (this.state.currentSlide > childrenCount && !this.props.wrapAround) {
       return;
     }
 
@@ -526,7 +529,9 @@ const Carousel = React.createClass({
 
       // If scrollMode = remainder, only scroll the amount of slides necessary without showing blank slides.
       if (this.props.scrollMode === 'remainder') {
-        this.goToSlide(Math.min(this.state.currentSlide + this.state.slidesToScroll, childrenCount - slidesToShow))
+        this.goToSlide(
+          Math.min(this.state.currentSlide + this.state.slidesToScroll, childrenCount - 1)
+        );
       } else if (this.props.scrollMode === 'page') { // Otherwise, slidesToScroll always equals slides to show
         this.goToSlide(this.state.currentSlide + this.state.slidesToScroll);
       }
@@ -542,7 +547,18 @@ const Carousel = React.createClass({
       this.goToSlide(this.state.currentSlide - this.state.slidesToScroll);
     } else {
       if (this.props.scrollMode === 'remainder') {
-        this.goToSlide(Math.max(0, this.state.currentSlide - this.state.slidesToScroll));
+        var { currentSlide, slidesToScroll } = this.state;
+        var index = 0;
+
+        while (index < currentSlide) {
+          if (index + slidesToScroll >= currentSlide) {
+            break;
+          }
+
+          index += slidesToScroll;
+        }
+
+        this.goToSlide(index);
       } else if (this.props.scrollMode === 'page') {
         this.goToSlide(this.state.currentSlide - this.state.slidesToScroll);
       }

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -380,8 +380,25 @@ const Carousel = React.createClass({
 
     if (this.touchObject.length > (this.state.slideWidth / slidesToShow) / 5) {
       if (this.touchObject.direction === 1) {
+        let lastPossibleIndex;
+        const count = React.Children.count(this.props.children);
+
+        switch (this.props.cellAlign) {
+        case 'left':
+          lastPossibleIndex = count - this.props.slidesToShow;
+          break;
+        case 'center':
+          lastPossibleIndex =
+            count - Math.ceil(this.props.slidesToShow / 2)
+            - (this.props.slidesToShow % 2 === 0 ? 1 : 0);
+          break;
+        case 'right':
+          lastPossibleIndex = count - 1;
+          break;
+        }
+
         if (
-          this.state.currentSlide >= (React.Children.count(this.props.children) - (this.props.scrollMode === 'remainder' ? this.state.slidesToScroll : 1)) &&
+          this.state.currentSlide >= (this.props.scrollMode === 'remainder' ? lastPossibleIndex : count - 1) &&
           !this.props.wrapAround
         ) {
           this.animateSlide(tweenState.easingTypes[this.props.edgeEasing]);

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -859,7 +859,7 @@ const Carousel = React.createClass({
       }
 
       if (index <= slidesAfter - 1) {
-        return slidesBefore < 0 ? (this.state.slideWidth + this.props.cellSpacing) * (this.state.slideCount + index) : 0;
+        return (this.state.slideWidth + this.props.cellSpacing) * (this.state.slideCount + index);
       }
     }
 

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -816,7 +816,7 @@ const Carousel = React.createClass({
       }
 
       if (index <= slidesAfter - 1) {
-        return (this.state.slideWidth + this.props.cellSpacing) * (this.state.slideCount + index);
+        return slidesBefore < 0 ? (this.state.slideWidth + this.props.cellSpacing) * (this.state.slideCount + index) : 0;
       }
     }
 

--- a/src/decorators.js
+++ b/src/decorators.js
@@ -88,7 +88,7 @@ const DefaultDecorators = [
           arr.push(i);
         }
 
-        if (arr.slice(-1)[0] !== count - 1 && this.props.scrollMode === 'remainder') {
+        if (arr.slice(-1)[0] !== count - 1 && this.props.scrollMode === 'page') {
           arr.push(count - 1);
         }
 

--- a/src/decorators.js
+++ b/src/decorators.js
@@ -88,9 +88,10 @@ const DefaultDecorators = [
           arr.push(i);
         }
 
-        if (arr.slice(-1)[0] !== count - 1) {
+        if (arr.slice(-1)[0] !== count - 1 && this.props.scrollMode === 'remainder') {
           arr.push(count - 1);
         }
+
         return arr;
       },
       getListStyles() {

--- a/src/decorators.js
+++ b/src/decorators.js
@@ -33,9 +33,10 @@ const DefaultDecorators = [
   {
     component: React.createClass({
       render() {
+
         return (
           <button
-            style={this.getButtonStyles(this.props.currentSlide + this.props.slidesToScroll >= this.props.slideCount && !this.props.wrapAround)}
+            style={this.getButtonStyles(this.props.currentSlide === this.props.slideCount - 1 && !this.props.wrapAround)}
             onClick={this.handleClick}>NEXT</button>
         )
       },
@@ -82,8 +83,13 @@ const DefaultDecorators = [
       },
       getIndexes(count, inc) {
         var arr = [];
+
         for (var i = 0; i < count; i += inc) {
           arr.push(i);
+        }
+
+        if (arr.slice(-1)[0] !== count - 1) {
+          arr.push(count - 1);
         }
         return arr;
       },

--- a/src/decorators.js
+++ b/src/decorators.js
@@ -38,7 +38,9 @@ const DefaultDecorators = [
         if (this.props.scrollMode === 'remainder') {
           switch (this.props.cellAlign) {
           case 'center':
-            cellOffsetPosition = this.props.slideCount - Math.ceil(this.props.slidesToShow / 2)
+            cellOffsetPosition =
+              this.props.slideCount - Math.ceil(this.props.slidesToShow / 2)
+              - (this.props.slidesToShow % 2 === 0 ? 1 : 0);
             break;
           case 'left':
             cellOffsetPosition = this.props.slideCount - this.props.slidesToShow;
@@ -73,7 +75,7 @@ const DefaultDecorators = [
     component: React.createClass({
       render() {
         var self = this;
-        var indexes = this.getIndexes(self.props.slideCount, self.props.slidesToScroll);
+        var indexes = this.getIndexes(self.props.slideCount, self.props.slidesToScroll, this.props.scrollMode === 'page');
         return (
           <ul style={self.getListStyles()}>
             {
@@ -92,39 +94,47 @@ const DefaultDecorators = [
           </ul>
         )
       },
-      getIndexes(count, inc) {
+      getIndexes(count, inc, remainderScroll) {
         const arr = [];
 
-        for (var i = 0; i < count; i += inc) {
-          arr.push(i);
-        }
+        if (remainderScroll) {
+          for (var i = 0; i < count; i += inc) {
+            arr.push(i);
+          }
 
+          if (arr[arr.length - 1] < count - 1) {
+            arr.push(count - 1);
+          }
+        } else {
+          let lastPossibleIndex;
 
+          switch (this.props.cellAlign) {
+          case 'left':
+            lastPossibleIndex = count - this.props.slidesToShow;
+            break;
+          case 'center':
+            lastPossibleIndex =
+              count - Math.ceil(this.props.slidesToShow / 2)
+              - (this.props.slidesToShow % 2 === 0 ? 1 : 0);
+            break;
+          case 'right':
+            lastPossibleIndex = count - 1;
+            break;
+          }
 
-        if (arr[arr.length - 1] < count - 1) {
-          arr.push(count - 1);
-        }
-
-        if (this.props.scrollMode === 'remainder') {
-          if (this.props.cellAlign === 'left') {
-            const offset = this.props.slidesToShow;
-
-            if (arr.indexOf(count - offset) > -1) {
-              console.log('fdfd')
-              arr.pop();
-            } else {
-              arr[arr.length - 1] = count - offset;
-            }
-          } else if (this.props.cellAlign === 'center') {
-            const offset = Math.floor(this.props.slidesToShow / 2);
-            
-            if (arr[arr.length - 1] >= count - offset) {
-              arr[arr.length - 1] = arr[arr.length - 1] - offset;
-            }
+          for (var i = 0; i <= count; i += inc) {
+            arr.push(i < lastPossibleIndex ? i : lastPossibleIndex);
           }
         }
 
-        return arr;
+        const log = {};
+        return arr.filter((val) => {
+          if (log[val] === undefined) {
+            log[val] = val;
+
+            return true;
+          }
+        }).sort();
       },
       getListStyles() {
         return {

--- a/src/decorators.js
+++ b/src/decorators.js
@@ -33,10 +33,21 @@ const DefaultDecorators = [
   {
     component: React.createClass({
       render() {
+        let cellOffsetPosition = this.props.slideCount - 1;
+
+        if (this.props.scrollMode === 'remainder') {
+          switch (this.props.cellAlign) {
+          case 'center':
+            cellOffsetPosition = this.props.slideCount - Math.ceil(this.props.slidesToShow / 2)
+            break;
+          case 'left':
+            cellOffsetPosition = this.props.slideCount - this.props.slidesToShow;
+          }
+        }
 
         return (
           <button
-            style={this.getButtonStyles(this.props.currentSlide === this.props.slideCount - 1 && !this.props.wrapAround)}
+            style={this.getButtonStyles(this.props.currentSlide === cellOffsetPosition && !this.props.wrapAround)}
             onClick={this.handleClick}>NEXT</button>
         )
       },
@@ -82,14 +93,35 @@ const DefaultDecorators = [
         )
       },
       getIndexes(count, inc) {
-        var arr = [];
+        const arr = [];
 
         for (var i = 0; i < count; i += inc) {
           arr.push(i);
         }
 
-        if (arr.slice(-1)[0] !== count - 1 && this.props.scrollMode === 'page') {
+
+
+        if (arr[arr.length - 1] < count - 1) {
           arr.push(count - 1);
+        }
+
+        if (this.props.scrollMode === 'remainder') {
+          if (this.props.cellAlign === 'left') {
+            const offset = this.props.slidesToShow;
+
+            if (arr.indexOf(count - offset) > -1) {
+              console.log('fdfd')
+              arr.pop();
+            } else {
+              arr[arr.length - 1] = count - offset;
+            }
+          } else if (this.props.cellAlign === 'center') {
+            const offset = Math.floor(this.props.slidesToShow / 2);
+            
+            if (arr[arr.length - 1] >= count - offset) {
+              arr[arr.length - 1] = arr[arr.length - 1] - offset;
+            }
+          }
         }
 
         return arr;


### PR DESCRIPTION
@kenwheeler 

addresses #96, and is a more comprehensive fix than #110 will close both once this is merged.

![nuka](https://cloud.githubusercontent.com/assets/8061227/20550585/1f88a9e2-b0ec-11e6-8c55-4e1ab97eadea.gif)

- This PR takes into account what new prop `scrollMode` is, and doesn't show empty cells when finished scrolling if that prop is left blank or set to `remainder`.

- If `slidesToShow` and `slidesToScroll` are not mathematically divisible into each other, this PR ensures that the decorators function correctly to navigate to the last slide in the deck, even if the last slide index < `currentSlide` + n of `slidesToScroll`.

- `cellAlign` is taken into account so that whitespace is not shown if `scrollMode === "remainder"`

- Navigation through decorators as well as swiping are taken into account with this fix.