### PR TITLE
fix unnecessary afterSlide Calls

### DIFF
--- a/lib/carousel.js
+++ b/lib/carousel.js
@@ -508,14 +508,18 @@ var Carousel = _react2['default'].createClass({
     }
 
     this.props.beforeSlide(this.state.currentSlide, index);
+    var previousIndex = this.state.currentSlide;
 
     this.setState({
       currentSlide: index
     }, function () {
       self.animateSlide();
-      this.props.afterSlide(index);
       self.resetAutoplay();
       self.setExternalData();
+
+      if (previousIndex !== index) {
+        this.props.afterSlide(index);
+      }
     });
   },
 

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -516,14 +516,18 @@ const Carousel = React.createClass({
     }
 
     this.props.beforeSlide(this.state.currentSlide, index);
+    const previousIndex = this.state.currentSlide;
 
     this.setState({
       currentSlide: index
     }, function() {
       self.animateSlide();
-      this.props.afterSlide(index);
       self.resetAutoplay();
       self.setExternalData();
+
+      if (previousIndex !== index) {
+        this.props.afterSlide(index);
+      }
     });
   },
 


### PR DESCRIPTION
add check that if `previous index === current index` in set state callback not to trigger the `afterSlide` event. Fixes #129 