### PR TITLE
add new prop for fixedHeight, update documentation for it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,16 @@ Enable mouse swipe/dragging
 
 Animation easing function. See valid easings here: [https://github.com/chenglou/tween-functions](https://github.com/chenglou/tween-functions)
 
+####fixedHeight
+`React.PropTypes.bool`
+
+If set to `true` will set the height of the frame to the tallest slide in the carousel.
+If set to `false, will set the height of the frame to the height of the current slide.
+Default value is `true`.
+
+Note: If `slidesToShow > 1` the height of the frame may clip other shown slides if their
+height are greater than the current slide.
+
 ####framePadding
 `React.PropTypes.string`
 

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -66,6 +66,7 @@ const Carousel = React.createClass({
     dragging: React.PropTypes.bool,
     easing: React.PropTypes.string,
     edgeEasing: React.PropTypes.string,
+    fixedHeight: React.PropTypes.bool,
     framePadding: React.PropTypes.string,
     frameOverflow: React.PropTypes.string,
     heightMode: React.PropTypes.oneOf(['max', 'adaptive']).isRequired,
@@ -102,6 +103,7 @@ const Carousel = React.createClass({
       dragging: true,
       easing: 'easeOutCirc',
       edgeEasing: 'easeOutElastic',
+      fixedHeight: true,
       framePadding: '0px',
       frameOverflow: 'hidden',
       heightMode: 'max',
@@ -810,11 +812,17 @@ const Carousel = React.createClass({
   },
 
   getFrameStyles() {
+    let horizontalHeight = 'auto';
+
+    if (!this.props.vertical && !this.props.fixedHeight && this.refs.list) {
+      horizontalHeight = this.refs.list.childNodes[this.state.currentSlide].offsetHeight;
+    }
+
     return {
       position: 'relative',
       display: 'block',
       overflow: this.props.frameOverflow,
-      height: this.props.vertical ? this.state.frameWidth || 'initial' : 'auto',
+      height: this.props.vertical ? this.state.frameWidth || 'initial' : horizontalHeight,
       margin: this.props.framePadding,
       padding: 0,
       transform: 'translate3d(0, 0, 0)',


### PR DESCRIPTION
@kenwheeler addresses #18 

Establishes new prop, `fixedHeight` that if set to false will adapt the height of the carousel to whatever the height of the current slide is.

![carousel](https://cloud.githubusercontent.com/assets/8061227/20810912/87f55ab8-b7c0-11e6-8a3f-bcc52bcef4fb.gif)
