### PR TITLE
Fix currentSlide when number of children and slideIndex changes.

### DIFF
--- a/lib/carousel.js
+++ b/lib/carousel.js
@@ -156,7 +156,7 @@ var Carousel = _react2['default'].createClass({
     });
     this.setDimensions(nextProps);
     if (this.props.slideIndex !== nextProps.slideIndex && nextProps.slideIndex !== this.state.currentSlide) {
-      this.goToSlide(nextProps.slideIndex);
+      this._goToSlide(this.props, nextProps.slideIndex);
     }
     if (this.props.autoplay !== nextProps.autoplay) {
       if (nextProps.autoplay) {
@@ -473,14 +473,14 @@ var Carousel = _react2['default'].createClass({
 
   // Action Methods
 
-  goToSlide: function goToSlide(index) {
+  _goToSlide: function _goToSlide(props, index) {
     var self = this;
-    if (index >= _react2['default'].Children.count(this.props.children) || index < 0) {
-      if (!this.props.wrapAround) {
+    if (index >= _react2['default'].Children.count(props.children) || index < 0) {
+      if (!props.wrapAround) {
         return;
       };
-      if (index >= _react2['default'].Children.count(this.props.children)) {
-        this.props.beforeSlide(this.state.currentSlide, 0);
+      if (index >= _react2['default'].Children.count(props.children)) {
+        props.beforeSlide(this.state.currentSlide, 0);
         return this.setState({
           currentSlide: 0
         }, function () {
@@ -492,8 +492,8 @@ var Carousel = _react2['default'].createClass({
           });
         });
       } else {
-        var endSlide = _react2['default'].Children.count(this.props.children) - this.state.slidesToScroll;
-        this.props.beforeSlide(this.state.currentSlide, endSlide);
+        var endSlide = _react2['default'].Children.count(props.children) - this.state.slidesToScroll;
+        props.beforeSlide(this.state.currentSlide, endSlide);
         return this.setState({
           currentSlide: endSlide
         }, function () {
@@ -521,6 +521,10 @@ var Carousel = _react2['default'].createClass({
         this.props.afterSlide(index);
       }
     });
+  },
+
+  goToSlide: function goToSlide(index) {
+    this._goToSlide(this.props, index);
   },
 
   nextSlide: function nextSlide() {
@@ -670,9 +674,10 @@ var Carousel = _react2['default'].createClass({
     var end = Math.min(this.state.currentSlide + 2 * this.props.slidesToShow, this.state.slideCount);
     return _react2['default'].Children.map(children, function (child, index) {
       if (!self.props.lazyLoad || start <= index && index < end) {
+        var slideKey = typeof child.props === 'object' && child.props.id ? child.props.id : index;
         return _react2['default'].createElement(
           'li',
-          { className: 'slider-slide', style: self.getSlideStyles(index, positionValue), key: index },
+          { className: 'slider-slide', style: self.getSlideStyles(index, positionValue), key: slideKey },
           child
         );
       }

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -149,7 +149,7 @@ const Carousel = React.createClass({
     });
     this.setDimensions(nextProps);
     if (this.props.slideIndex !== nextProps.slideIndex && nextProps.slideIndex !== this.state.currentSlide) {
-      this.goToSlide(nextProps.slideIndex);
+      this._goToSlide(nextProps, nextProps.slideIndex);
     }
     if (this.props.autoplay !== nextProps.autoplay) {
       if (nextProps.autoplay) {
@@ -483,12 +483,12 @@ const Carousel = React.createClass({
 
   // Action Methods
 
-  goToSlide(index) {
+  _goToSlide(props, index) {
     var self = this;
-    if ((index >= React.Children.count(this.props.children) || index < 0)) {
-      if (!this.props.wrapAround) { return };
-      if (index >= React.Children.count(this.props.children)) {
-        this.props.beforeSlide(this.state.currentSlide, 0);
+    if ((index >= React.Children.count(props.children) || index < 0)) {
+      if (!props.wrapAround) { return };
+      if (index >= React.Children.count(props.children)) {
+        props.beforeSlide(this.state.currentSlide, 0);
         return this.setState({
           currentSlide: 0
         }, function() {
@@ -500,8 +500,8 @@ const Carousel = React.createClass({
           });
         });
       } else {
-        var endSlide = React.Children.count(this.props.children) - this.state.slidesToScroll;
-        this.props.beforeSlide(this.state.currentSlide, endSlide);
+        var endSlide = React.Children.count(props.children) - this.state.slidesToScroll;
+        props.beforeSlide(this.state.currentSlide, endSlide);
         return this.setState({
           currentSlide: endSlide
         }, function() {
@@ -529,6 +529,10 @@ const Carousel = React.createClass({
         this.props.afterSlide(index);
       }
     });
+  },
+
+  goToSlide(index) {
+    this._goToSlide(this.props, index);
   },
 
   nextSlide() {

--- a/test/specs/carousel.spec.js
+++ b/test/specs/carousel.spec.js
@@ -713,6 +713,27 @@ describe('Carousel', function () {
         expect(component.state.currentSlide).to.equal(2);
     });
 
+    it('should go to 3 if slideIndex and the number of slides changes', function() {
+      component = ReactDOM.render(
+        React.createElement(carousel, {slideIndex: 1 },
+          React.createElement('p', null, 'Slide 1'),
+          React.createElement('p', null, 'Slide 2')
+        ),
+        container
+      );
+      ReactDOM.render(
+        React.createElement(carousel, {slideIndex: 3 },
+          React.createElement('p', null, 'Slide 1'),
+          React.createElement('p', null, 'Slide 2'),
+          React.createElement('p', null, 'Slide 3'),
+          React.createElement('p', null, 'Slide 4')
+        ),
+        container
+      );
+
+      expect(component.state.currentSlide).to.equal(3);
+    });
+
   });
 
 });


### PR DESCRIPTION
The number of children in our carousel changes based on our app state. We also dynamically alter the initial slideIndex based on state.

This fixes an issue when the carousel updates from 3 children to a higher number, with a slideIndex greater than the previous number of children.

This uses nextProps for goToSlide in componentWillReceiveProps, whilst maintaining the previous behaviour of `goToSlide` using `this.props`.

Thanks for your consideration! 