### PR TITLE
Fix clickSafe preventing all clicks when dragging / swiping are both disabled.

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -9,7 +9,7 @@ window.React = React;
 const App = React.createClass({
   mixins: [Carousel.ControllerMixin],
 
-  getInitialState() { return { slideIndex: 0 }; },
+  getInitialState() { return { slideIndex: 0, dragging: true, swiping: true }; },
 
   render() {
     return (
@@ -18,7 +18,9 @@ const App = React.createClass({
           ref="carousel"
           data={this.setCarouselData.bind(this, 'carousel')}
           slideIndex={this.state.slideIndex}
-          afterSlide={newSlideIndex => this.setState({ slideIndex: newSlideIndex })}>
+          afterSlide={newSlideIndex => this.setState({ slideIndex: newSlideIndex })}
+          dragging={this.state.dragging}
+          swiping={this.state.swiping}>
           <img src="http://placehold.it/1000x400&text=slide1"/>
           <img src="http://placehold.it/1000x400&text=slide2"/>
           <img src="http://placehold.it/1000x400&text=slide3"/>
@@ -32,6 +34,12 @@ const App = React.createClass({
         <button onClick={() => this.setState({ slideIndex: 3 })}>4</button>
         <button onClick={() => this.setState({ slideIndex: 4 })}>5</button>
         <button onClick={() => this.setState({ slideIndex: 5 })}>6</button>
+        <button onClick={() => this.setState({dragging: !this.state.dragging})}>
+          {this.state.dragging ? 'Disable dragging' : 'Enable dragging'}
+        </button>
+        <button onClick={() => this.setState({swiping: !this.state.swiping})}>
+          {this.state.swiping ? 'Disable swiping' : 'Enable swiping'}
+        </button>
       </div>
     )
   }

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -214,6 +214,8 @@ const Carousel = React.createClass({
 
     if (self.props.swiping === false) {
       return null;
+    } else {
+      self.clickSafe = true;
     }
 
     return {
@@ -263,13 +265,15 @@ const Carousel = React.createClass({
     }
   },
 
-  clickSafe: true,
+  clickSafe: false,
 
   getMouseEvents() {
     var self = this;
 
     if (this.props.dragging === false) {
       return null;
+    } else {
+      self.clickSafe = true;
     }
 
     return {


### PR DESCRIPTION
This fixes issue #168.

When both swiping and dragging are disabled, clickSafe isn't needed yet it is set to true by default because the handleSwipe function is never called to unset it after a click. This means the click event is always blocked.

This change replaces that behaviour by defaulting clickSafe to false and enabling it if either dragging or swiping.

I've also added swipe and drag enable and disable buttons to the demo to aid testing (and showing the features of the project).