### PR TITLE
Fix drag to change slide

### DIFF
--- a/src/carousel.js
+++ b/src/carousel.js
@@ -173,7 +173,7 @@ const Carousel = React.createClass({
           style={this.getFrameStyles()}
           {...this.getTouchEvents()}
           {...this.getMouseEvents()}
-          onClick={this.handleClick}>
+          onClickCapture={this.handleClick}>
           <ul className="slider-list" ref="list" style={this.getListStyles()}>
             {children}
           </ul>


### PR DESCRIPTION
When the carousel slide is clickable, dragging to change slide invoked the click handler as well.