### PR TITLE
Fix slideCount being undefined

### DIFF
--- a/src/carousel.js
+++ b/src/carousel.js
@@ -139,9 +139,11 @@ const Carousel = React.createClass({
   },
 
   componentWillReceiveProps(nextProps) {
-    this.setState({
-      slideCount: nextProps.children.length,
-    });
+    if (React.Children.count(this.props.children) !== React.Children.count(nextProps.children)) {
+      this.setState({
+        slideCount: React.Children.count(nextProps.children),
+      });
+    }
     this.setDimensions(nextProps);
     if (
       this.props.slideIndex !== nextProps.slideIndex &&


### PR DESCRIPTION
This uses `React.Children.count` for counting the children instead of `this.props.children.length` that was returning undefined when used in Decorators.