### PR TITLE
moving create-react-class to dependencies and fixpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,13 @@
 {
   "name": "nuka-carousel",
-  "version": "2.2.0",
   "description": "Pure React Carousel",
-  "main": "index.js",
+  "version": "2.2.0",
+  "author": "Ken Wheeler",
+  "bugs": {
+    "url": "https://github.com/kenwheeler/nuka-carousel/issues"
+  },
   "dependencies": {
+    "create-react-class": "^15.6.0",
     "exenv": "^1.2.0",
     "kw-react-tween-state": "^0.1.5",
     "object-assign": "^4.1.0"
@@ -13,7 +17,6 @@
     "babel-eslint": "^4.1.3",
     "babel-loader": "^5.3.2",
     "chai": "^3.3.0",
-    "create-react-class": "^15.6.0",
     "css-loader": "^0.19.0",
     "del": "^2.0.2",
     "eslint": "^1.6.0",
@@ -52,27 +55,24 @@
     "webpack": "^1.12.2",
     "webpack-dev-server": "^1.12.0"
   },
+  "homepage": "https://github.com/kenwheeler/nuka-carousel",
+  "keywords": [
+    "carousel",
+    "nuka",
+    "react"
+  ],
+  "license": "MIT",
+  "main": "index.js",
   "peerDependencies": {
     "prop-types": "^15.5.8",
     "react": "^0.14.9 || ^15.3.0",
     "react-dom": "^0.14.9 || ^15.3.0"
   },
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/kenwheeler/nuka-carousel.git"
   },
-  "keywords": [
-    "react",
-    "carousel",
-    "nuka"
-  ],
-  "author": "Ken Wheeler",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/kenwheeler/nuka-carousel/issues"
-  },
-  "homepage": "https://github.com/kenwheeler/nuka-carousel"
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
 }


### PR DESCRIPTION
- [ ] `create-react-class` is now in dependencies, not devDependencies

I also ran [fixpack](https://www.npmjs.com/package/fixpack) on the package to make sure it was ordered cleanly.