### PR TITLE
Fix Render <li> element even one child exists

### DIFF
--- a/src/carousel.js
+++ b/src/carousel.js
@@ -166,10 +166,7 @@ const Carousel = createReactClass({
 
   render() {
     var self = this;
-    var children =
-      React.Children.count(this.props.children) > 1
-        ? this.formatChildren(this.props.children)
-        : this.props.children;
+    var children = this.formatChildren(this.props.children);
     return (
       <div
         className={['slider', this.props.className || ''].join(' ')}


### PR DESCRIPTION
Fixed Render <li> element even one child exists
Resolving Issue #234
https://github.com/FormidableLabs/nuka-carousel/issues/234