### PR TITLE
Add changes from PR#148 to the source & fix getSlideTargetPosition

### DIFF
--- a/lib/carousel.js
+++ b/lib/carousel.js
@@ -663,7 +663,8 @@ var Carousel = (0, _createReactClass2.default)({
         frame,
         frameWidth,
         frameHeight,
-        slideHeight;
+        slideHeight,
+        toScroll;
 
     slidesToScroll = props.slidesToScroll;
     frame = this.refs.frame;
@@ -693,7 +694,8 @@ var Carousel = (0, _createReactClass2.default)({
     frameWidth = props.vertical ? frameHeight : frame.offsetWidth;
 
     if (props.slidesToScroll === 'auto') {
-      slidesToScroll = Math.floor(frameWidth / (slideWidth + props.cellSpacing));
+      toScroll = frameWidth / (slideWidth + props.cellSpacing);
+      slidesToScroll = props.slideWidth === 1 ? Math.ceil(toScroll) : Math.floor(toScroll);
     }
 
     this.setState({
@@ -785,7 +787,7 @@ var Carousel = (0, _createReactClass2.default)({
     var end = (this.state.slideWidth + this.props.cellSpacing) * slidesToShow * -1;
 
     if (this.props.wrapAround) {
-      var slidesBefore = Math.ceil(positionValue / this.state.slideWidth);
+      var slidesBefore = Math.ceil(positionValue / (this.state.slideWidth + this.props.cellSpacing));
       if (this.state.slideCount - slidesBefore <= index) {
         return (this.state.slideWidth + this.props.cellSpacing) * (this.state.slideCount - index) * -1;
       }
@@ -797,7 +799,7 @@ var Carousel = (0, _createReactClass2.default)({
       }
 
       if (index <= slidesAfter - 1) {
-        return (this.state.slideWidth + this.props.cellSpacing) * (this.state.slideCount + index);
+        return slidesBefore < 0 ? (this.state.slideWidth + this.props.cellSpacing) * (this.state.slideCount + index) : 0;
       }
     }
 

--- a/lib/carousel.js
+++ b/lib/carousel.js
@@ -799,7 +799,7 @@ var Carousel = (0, _createReactClass2.default)({
       }
 
       if (index <= slidesAfter - 1) {
-        return slidesBefore < 0 ? (this.state.slideWidth + this.props.cellSpacing) * (this.state.slideCount + index) : 0;
+        return (this.state.slideWidth + this.props.cellSpacing) * (slidesBefore < 0 ? this.state.slideCount + index : index);
       }
     }
 

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -948,7 +948,7 @@ const Carousel = createReactClass({
       }
 
       if (index <= slidesAfter - 1) {
-        return slidesBefore < 0 ? (this.state.slideWidth + this.props.cellSpacing) * (this.state.slideCount + index) : 0;
+        return (this.state.slideWidth + this.props.cellSpacing) * (slidesBefore < 0 ? this.state.slideCount + index : index);
       }
     }
 

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -776,7 +776,8 @@ const Carousel = createReactClass({
       frame,
       frameWidth,
       frameHeight,
-      slideHeight;
+      slideHeight,
+      toScroll;
 
     slidesToScroll = props.slidesToScroll;
     frame = this.refs.frame;
@@ -809,9 +810,8 @@ const Carousel = createReactClass({
     frameWidth = props.vertical ? frameHeight : frame.offsetWidth;
 
     if (props.slidesToScroll === 'auto') {
-      slidesToScroll = Math.floor(
-        frameWidth / (slideWidth + props.cellSpacing)
-      );
+      toScroll = frameWidth / (slideWidth + props.cellSpacing);
+      slidesToScroll = props.slideWidth === 1 ? Math.ceil(toScroll) : Math.floor(toScroll);
     }
 
     this.setState(
@@ -926,7 +926,8 @@ const Carousel = createReactClass({
       (this.state.slideWidth + this.props.cellSpacing) * slidesToShow * -1;
 
     if (this.props.wrapAround) {
-      var slidesBefore = Math.ceil(positionValue / this.state.slideWidth);
+      var slidesBefore = Math.ceil(positionValue /
+        (this.state.slideWidth + this.props.cellSpacing));
       if (this.state.slideCount - slidesBefore <= index) {
         return (
           (this.state.slideWidth + this.props.cellSpacing) *
@@ -947,10 +948,7 @@ const Carousel = createReactClass({
       }
 
       if (index <= slidesAfter - 1) {
-        return (
-          (this.state.slideWidth + this.props.cellSpacing) *
-          (this.state.slideCount + index)
-        );
+        return slidesBefore < 0 ? (this.state.slideWidth + this.props.cellSpacing) * (this.state.slideCount + index) : 0;
       }
     }
 


### PR DESCRIPTION
Attempt to fix the behavior described in the following issues:
- https://github.com/FormidableLabs/nuka-carousel/issues/225
- https://github.com/FormidableLabs/nuka-carousel/issues/184
- https://github.com/FormidableLabs/nuka-carousel/issues/140

The fix in [PR#148](https://github.com/FormidableLabs/nuka-carousel/pull/148) by @nowarkdev introduces changes in the source that [are not reflected](https://github.com/FormidableLabs/nuka-carousel/pull/148/files?diff=split) in the lib.

This PR puts changes from [PR#148](https://github.com/FormidableLabs/nuka-carousel/pull/148) in the source file and also fixes a minor bug in `getSlideTargetPosition`.