### PR TITLE
Add ability to use translate over translate3d

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,11 @@ Animation duration.
 
 Enable touch swipe/dragging
 
+### use3d
+`React.PropTypes.bool`
+
+Enable to use CSS property translate3d instead of translate, this can change scroll performance. Defaults to `true`.
+
 #### vertical
 `React.PropTypes.bool`
 

--- a/lib/carousel.js
+++ b/lib/carousel.js
@@ -97,6 +97,7 @@ var Carousel = (0, _createReactClass2.default)({
     slideWidth: _propTypes2.default.oneOfType([_propTypes2.default.string, _propTypes2.default.number]),
     speed: _propTypes2.default.number,
     swiping: _propTypes2.default.bool,
+    use3d: _propTypes2.default.bool,
     vertical: _propTypes2.default.bool,
     width: _propTypes2.default.string,
     wrapAround: _propTypes2.default.bool
@@ -123,6 +124,7 @@ var Carousel = (0, _createReactClass2.default)({
       slideWidth: 1,
       speed: 500,
       swiping: true,
+      use3d: true,
       vertical: false,
       width: '100%',
       wrapAround: false
@@ -726,10 +728,17 @@ var Carousel = (0, _createReactClass2.default)({
 
   // Styles
 
+  getTranslate: function getTranslate(value) {
+    if (this.props.use3d) {
+      return 'translate3d(' + value + ', 0)';
+    }
+
+    return 'translate(' + value + ')';
+  },
   getListStyles: function getListStyles() {
     var listWidth = this.state.slideWidth * _react2.default.Children.count(this.props.children);
     var spacingOffset = this.props.cellSpacing * _react2.default.Children.count(this.props.children);
-    var transform = 'translate3d(' + this.getTweeningValue('left') + 'px, ' + this.getTweeningValue('top') + 'px, 0)';
+    var transform = this.getTranslate('' + this.getTweeningValue('left') + 'px, ' + this.getTweeningValue('top') + 'px');
     return {
       transform: transform,
       WebkitTransform: transform,
@@ -753,8 +762,8 @@ var Carousel = (0, _createReactClass2.default)({
       height: this.props.vertical ? this.state.frameWidth || 'initial' : 'auto',
       margin: this.props.framePadding,
       padding: 0,
-      transform: 'translate3d(0, 0, 0)',
-      WebkitTransform: 'translate3d(0, 0, 0)',
+      transform: this.getTranslate('0, 0'),
+      WebkitTransform: this.getTranslate('0, 0'),
       msTransform: 'translate(0, 0)',
       boxSizing: 'border-box',
       MozBoxSizing: 'border-box'

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -81,6 +81,7 @@ const Carousel = createReactClass({
     slideWidth: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     speed: PropTypes.number,
     swiping: PropTypes.bool,
+    use3d: PropTypes.bool,
     vertical: PropTypes.bool,
     width: PropTypes.string,
     wrapAround: PropTypes.bool,
@@ -107,6 +108,7 @@ const Carousel = createReactClass({
       slideWidth: 1,
       speed: 500,
       swiping: true,
+      use3d: true,
       vertical: false,
       width: '100%',
       wrapAround: false,
@@ -846,17 +848,20 @@ const Carousel = createReactClass({
 
   // Styles
 
+  getTranslate (value) {
+    if (this.props.use3d) {
+      return 'translate3d(' + value + ', 0)';
+    }
+
+    return 'translate(' + value + ')';
+  },
+
   getListStyles() {
     var listWidth =
       this.state.slideWidth * React.Children.count(this.props.children);
     var spacingOffset =
       this.props.cellSpacing * React.Children.count(this.props.children);
-    var transform =
-      'translate3d(' +
-      this.getTweeningValue('left') +
-      'px, ' +
-      this.getTweeningValue('top') +
-      'px, 0)';
+    var transform = this.getTranslate('' + this.getTweeningValue('left') + 'px, ' + this.getTweeningValue('top') + 'px');
     return {
       transform,
       WebkitTransform: transform,
@@ -890,8 +895,8 @@ const Carousel = createReactClass({
       height: this.props.vertical ? this.state.frameWidth || 'initial' : 'auto',
       margin: this.props.framePadding,
       padding: 0,
-      transform: 'translate3d(0, 0, 0)',
-      WebkitTransform: 'translate3d(0, 0, 0)',
+      transform: this.getTranslate('0, 0'),
+      WebkitTransform: this.getTranslate('0, 0'),
       msTransform: 'translate(0, 0)',
       boxSizing: 'border-box',
       MozBoxSizing: 'border-box',

--- a/test/specs/carousel.spec.js
+++ b/test/specs/carousel.spec.js
@@ -482,6 +482,40 @@ describe('Carousel', function() {
 
         expect(component.state.slidesToScroll).to.equal(6);
       });
+
+    it('should not use translate3d when use3d is false',
+      function () {
+        component = ReactDOM.render(
+          React.createElement(carousel, {slidesToShow: 3, cellAlign: 'left', width: '500px', use3d: false},
+            React.createElement('p', null, 'Slide 1'),
+            React.createElement('p', null, 'Slide 2'),
+            React.createElement('p', null, 'Slide 3')
+          ),
+          container
+        );
+        var slider = TestUtils.findRenderedDOMComponentWithClass(
+          component,
+          'slider-list'
+        );
+        expect(slider.style.transform).to.equal('translate(0px, 0px)');
+      });
+
+    it('should align to 200 if cellAlign is center also when use3d is false ', function() {
+      component = ReactDOM.render(
+        React.createElement(carousel, {slidesToShow: 3, cellAlign: 'center', width: '600px', use3d: false},
+          React.createElement('p', null, 'Slide 1'),
+          React.createElement('p', null, 'Slide 2'),
+          React.createElement('p', null, 'Slide 3')
+        ),
+        container
+      );
+
+      var slider = TestUtils.findRenderedDOMComponentWithClass(
+        component,
+        'slider-list'
+      );
+      expect(slider.style.transform).to.equal('translate(200px, 0px)');
+    });
   });
 
   describe('Methods', function() {


### PR DESCRIPTION
The webapp I'm working on was having scroll performance issues on Chrome for Android for the entire page, the swiping through carousel did work correct. When debugging this issue I noticed nuka-carousel component was causing this issue. When using `translate` instead of `translate3d` it was fixed. I think this is because the content of my slides where to heavy for `translate3d`