### PR TITLE
Add some tweakability

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,11 @@ Manually set slideWidth. If you want hard pixel widths, use a string like `slide
 
 Animation duration.
 
+#### swipeDetectionSensitivity
+`React.PropTypes.number`
+
+Amount of pixels dragged to be detected as swipe. Defaults to `slideWidth / slidesToShow / 5`.
+
 #### swiping
 `React.PropTypes.bool`
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,11 @@ Initial height of the slides in pixels.
 
 Initial width of the slides in pixels.
 
+#### preventMultiFingerSwipe
+`React.PropTypes.bool`
+
+Stop detecting touch events as swipe or drag if there is multiple touch points active. Defaults to false.
+
 #### slideIndex
 `React.PropTypes.number`
 

--- a/lib/carousel.js
+++ b/lib/carousel.js
@@ -91,6 +91,7 @@ var Carousel = (0, _createReactClass2.default)({
     frameOverflow: _propTypes2.default.string,
     initialSlideHeight: _propTypes2.default.number,
     initialSlideWidth: _propTypes2.default.number,
+    preventMultiFingerSwipe: _propTypes2.default.bool,
     swipeDetectionSensitivity: _propTypes2.default.number,
     slideIndex: _propTypes2.default.number,
     slidesToShow: _propTypes2.default.number,
@@ -118,6 +119,7 @@ var Carousel = (0, _createReactClass2.default)({
       edgeEasing: 'easeOutElastic',
       framePadding: '0px',
       frameOverflow: 'hidden',
+      preventMultiFingerSwipe: false,
       slideIndex: 0,
       slidesToScroll: 1,
       slidesToShow: 1,
@@ -252,27 +254,29 @@ var Carousel = (0, _createReactClass2.default)({
         self.handleMouseOver();
       },
       onTouchMove: function onTouchMove(e) {
-        var direction = self.swipeDirection(self.touchObject.startX, e.touches[0].pageX, self.touchObject.startY, e.touches[0].pageY);
+        if (!this.props.preventMultiFingerSwipe || this.props.preventMultiFinterSwipe && e.touches.length === 1) {
+          var direction = self.swipeDirection(self.touchObject.startX, e.touches[0].pageX, self.touchObject.startY, e.touches[0].pageY);
 
-        if (direction !== 0) {
-          e.preventDefault();
+          if (direction !== 0) {
+            e.preventDefault();
+          }
+
+          var length = self.props.vertical ? Math.round(Math.sqrt(Math.pow(e.touches[0].pageY - self.touchObject.startY, 2))) : Math.round(Math.sqrt(Math.pow(e.touches[0].pageX - self.touchObject.startX, 2)));
+
+          self.touchObject = {
+            startX: self.touchObject.startX,
+            startY: self.touchObject.startY,
+            endX: e.touches[0].pageX,
+            endY: e.touches[0].pageY,
+            length: length,
+            direction: direction
+          };
+
+          self.setState({
+            left: self.props.vertical ? 0 : self.getTargetLeft(self.touchObject.length * self.touchObject.direction),
+            top: self.props.vertical ? self.getTargetLeft(self.touchObject.length * self.touchObject.direction) : 0
+          });
         }
-
-        var length = self.props.vertical ? Math.round(Math.sqrt(Math.pow(e.touches[0].pageY - self.touchObject.startY, 2))) : Math.round(Math.sqrt(Math.pow(e.touches[0].pageX - self.touchObject.startX, 2)));
-
-        self.touchObject = {
-          startX: self.touchObject.startX,
-          startY: self.touchObject.startY,
-          endX: e.touches[0].pageX,
-          endY: e.touches[0].pageY,
-          length: length,
-          direction: direction
-        };
-
-        self.setState({
-          left: self.props.vertical ? 0 : self.getTargetLeft(self.touchObject.length * self.touchObject.direction),
-          top: self.props.vertical ? self.getTargetLeft(self.touchObject.length * self.touchObject.direction) : 0
-        });
       },
       onTouchEnd: function onTouchEnd(e) {
         self.handleSwipe(e);
@@ -377,35 +381,36 @@ var Carousel = (0, _createReactClass2.default)({
     }
   },
   handleSwipe: function handleSwipe(e) {
-
-    if (typeof this.touchObject.length !== 'undefined' && this.touchObject.length > 44) {
-      this.clickSafe = true;
-    } else {
-      this.clickSafe = false;
-    }
-
-    var slidesToShow = this.props.slidesToShow;
-    if (this.props.slidesToScroll === 'auto') {
-      slidesToShow = this.state.slidesToScroll;
-    }
-
-    var sensitivity = this.props.swipeDetectionSensitivity || this.state.slideWidth / slidesToShow / 5;
-    if (this.touchObject.length > sensitivity) {
-      if (this.touchObject.direction === 1) {
-        if (this.state.currentSlide >= _react2.default.Children.count(this.props.children) - slidesToShow && !this.props.wrapAround) {
-          this.animateSlide(_reactTweenState2.default.easingTypes[this.props.edgeEasing]);
-        } else {
-          this.nextSlide();
-        }
-      } else if (this.touchObject.direction === -1) {
-        if (this.state.currentSlide <= 0 && !this.props.wrapAround) {
-          this.animateSlide(_reactTweenState2.default.easingTypes[this.props.edgeEasing]);
-        } else {
-          this.previousSlide();
-        }
+    if (!this.props.preventMultiFingerSwipe || this.props.preventMultiFingerSwipe && this.touches.length <= 1) {
+      if (typeof this.touchObject.length !== 'undefined' && this.touchObject.length > 44) {
+        this.clickSafe = true;
+      } else {
+        this.clickSafe = false;
       }
-    } else {
-      this.goToSlide(this.state.currentSlide);
+
+      var slidesToShow = this.props.slidesToShow;
+      if (this.props.slidesToScroll === 'auto') {
+        slidesToShow = this.state.slidesToScroll;
+      }
+
+      var sensitivity = this.props.swipeDetectionSensitivity || this.state.slideWidth / slidesToShow / 5;
+      if (this.touchObject.length > sensitivity) {
+        if (this.touchObject.direction === 1) {
+          if (this.state.currentSlide >= _react2.default.Children.count(this.props.children) - slidesToShow && !this.props.wrapAround) {
+            this.animateSlide(_reactTweenState2.default.easingTypes[this.props.edgeEasing]);
+          } else {
+            this.nextSlide();
+          }
+        } else if (this.touchObject.direction === -1) {
+          if (this.state.currentSlide <= 0 && !this.props.wrapAround) {
+            this.animateSlide(_reactTweenState2.default.easingTypes[this.props.edgeEasing]);
+          } else {
+            this.previousSlide();
+          }
+        }
+      } else {
+        this.goToSlide(this.state.currentSlide);
+      }
     }
 
     this.touchObject = {};

--- a/lib/carousel.js
+++ b/lib/carousel.js
@@ -381,7 +381,7 @@ var Carousel = (0, _createReactClass2.default)({
     }
   },
   handleSwipe: function handleSwipe(e) {
-    if (!this.props.preventMultiFingerSwipe || this.props.preventMultiFingerSwipe && this.touches.length <= 1) {
+    if (!this.props.preventMultiFingerSwipe || this.props.preventMultiFingerSwipe && e.touches.length <= 1) {
       if (typeof this.touchObject.length !== 'undefined' && this.touchObject.length > 44) {
         this.clickSafe = true;
       } else {

--- a/lib/carousel.js
+++ b/lib/carousel.js
@@ -254,7 +254,7 @@ var Carousel = (0, _createReactClass2.default)({
         self.handleMouseOver();
       },
       onTouchMove: function onTouchMove(e) {
-        if (!this.props.preventMultiFingerSwipe || this.props.preventMultiFinterSwipe && e.touches.length === 1) {
+        if (e.touches.length === 1 || !this.props.preventMultiFingerSwipe) {
           var direction = self.swipeDirection(self.touchObject.startX, e.touches[0].pageX, self.touchObject.startY, e.touches[0].pageY);
 
           if (direction !== 0) {
@@ -381,7 +381,7 @@ var Carousel = (0, _createReactClass2.default)({
     }
   },
   handleSwipe: function handleSwipe(e) {
-    if (!this.props.preventMultiFingerSwipe || this.props.preventMultiFingerSwipe && e.touches.length <= 1) {
+    if (e.touches.length <= 1 || !this.props.preventMultiFingerSwipe) {
       if (typeof this.touchObject.length !== 'undefined' && this.touchObject.length > 44) {
         this.clickSafe = true;
       } else {

--- a/lib/carousel.js
+++ b/lib/carousel.js
@@ -381,7 +381,7 @@ var Carousel = (0, _createReactClass2.default)({
     }
   },
   handleSwipe: function handleSwipe(e) {
-    if (e.touches.length <= 1 || !this.props.preventMultiFingerSwipe) {
+    if (typeof e.touches === 'undefined' || e.touches.length <= 1 || !this.props.preventMultiFingerSwipe) {
       if (typeof this.touchObject.length !== 'undefined' && this.touchObject.length > 44) {
         this.clickSafe = true;
       } else {

--- a/lib/carousel.js
+++ b/lib/carousel.js
@@ -91,6 +91,7 @@ var Carousel = (0, _createReactClass2.default)({
     frameOverflow: _propTypes2.default.string,
     initialSlideHeight: _propTypes2.default.number,
     initialSlideWidth: _propTypes2.default.number,
+    swipeDetectionSensitivity: _propTypes2.default.number,
     slideIndex: _propTypes2.default.number,
     slidesToShow: _propTypes2.default.number,
     slidesToScroll: _propTypes2.default.oneOfType([_propTypes2.default.number, _propTypes2.default.oneOf(['auto'])]),
@@ -376,6 +377,7 @@ var Carousel = (0, _createReactClass2.default)({
     }
   },
   handleSwipe: function handleSwipe(e) {
+
     if (typeof this.touchObject.length !== 'undefined' && this.touchObject.length > 44) {
       this.clickSafe = true;
     } else {
@@ -387,7 +389,8 @@ var Carousel = (0, _createReactClass2.default)({
       slidesToShow = this.state.slidesToScroll;
     }
 
-    if (this.touchObject.length > this.state.slideWidth / slidesToShow / 5) {
+    var sensitivity = this.props.swipeDetectionSensitivity || this.state.slideWidth / slidesToShow / 5;
+    if (this.touchObject.length > sensitivity) {
       if (this.touchObject.direction === 1) {
         if (this.state.currentSlide >= _react2.default.Children.count(this.props.children) - slidesToShow && !this.props.wrapAround) {
           this.animateSlide(_reactTweenState2.default.easingTypes[this.props.edgeEasing]);

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -423,7 +423,7 @@ const Carousel = createReactClass({
   },
 
   handleSwipe(e) {
-    if (!this.props.preventMultiFingerSwipe || (this.props.preventMultiFingerSwipe && this.touches.length <= 1)) {
+    if (!this.props.preventMultiFingerSwipe || (this.props.preventMultiFingerSwipe && e.touches.length <= 1)) {
       if (
         typeof this.touchObject.length !== 'undefined' &&
         this.touchObject.length > 44

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -251,7 +251,7 @@ const Carousel = createReactClass({
         self.handleMouseOver();
       },
       onTouchMove(e) {
-        if (!this.props.preventMultiFingerSwipe || (this.props.preventMultiFinterSwipe && e.touches.length === 1) ) {
+        if (e.touches.length === 1 || !this.props.preventMultiFingerSwipe) {
           var direction = self.swipeDirection(
             self.touchObject.startX,
             e.touches[0].pageX,
@@ -423,7 +423,7 @@ const Carousel = createReactClass({
   },
 
   handleSwipe(e) {
-    if (!this.props.preventMultiFingerSwipe || (this.props.preventMultiFingerSwipe && e.touches.length <= 1)) {
+    if (e.touches.length <= 1 || !this.props.preventMultiFingerSwipe) {
       if (
         typeof this.touchObject.length !== 'undefined' &&
         this.touchObject.length > 44

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -72,6 +72,7 @@ const Carousel = createReactClass({
     frameOverflow: PropTypes.string,
     initialSlideHeight: PropTypes.number,
     initialSlideWidth: PropTypes.number,
+    swipeDetectionSensitivity: PropTypes.number,
     slideIndex: PropTypes.number,
     slidesToShow: PropTypes.number,
     slidesToScroll: PropTypes.oneOfType([
@@ -418,6 +419,7 @@ const Carousel = createReactClass({
   },
 
   handleSwipe(e) {
+
     if (
       typeof this.touchObject.length !== 'undefined' &&
       this.touchObject.length > 44
@@ -432,7 +434,8 @@ const Carousel = createReactClass({
       slidesToShow = this.state.slidesToScroll;
     }
 
-    if (this.touchObject.length > this.state.slideWidth / slidesToShow / 5) {
+    const sensitivity = this.props.swipeDetectionSensitivity || this.state.slideWidth / slidesToShow / 5;
+    if (this.touchObject.length > sensitivity) {
       if (this.touchObject.direction === 1) {
         if (
           this.state.currentSlide >=

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -423,7 +423,7 @@ const Carousel = createReactClass({
   },
 
   handleSwipe(e) {
-    if (e.touches.length <= 1 || !this.props.preventMultiFingerSwipe) {
+    if (typeof e.touches === 'undefined' || e.touches.length <= 1 || !this.props.preventMultiFingerSwipe) {
       if (
         typeof this.touchObject.length !== 'undefined' &&
         this.touchObject.length > 44


### PR DESCRIPTION
I needed to fork this library to get some control over multi finger detection & swipe detection sensitivity. It would be easier if these controls were tweakable in this tool. If you have suggestions how to make these tweaks more flexible/versatile or opinion if you even want these updates in nuka-carousel are appreciated - just to know if we should stay with this forked version or wait for these updates to be implemented in offical nuka-carousel version.

Two new props:
* preventMultiFingerSwipe
* swipeDetectionSensitivity