### PR TITLE
[MINOR] Add props for how the carousel should calculate height

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 ### SublimeText ###
 *.sublime-workspace
 
+### IDEA files ###
+
+.idea
+
 ### OSX ###
 .DS_Store
 .AppleDouble

--- a/README.md
+++ b/README.md
@@ -150,6 +150,19 @@ Initial height of the slides in pixels.
 
 Initial width of the slides in pixels.
 
+#### heightMode
+`React.PropTypes.oneOf('first', 'max', 'current')`
+
+How the carousel should calculate its height.
+  `first` - Take the height of the first slide (default)
+  `max` - find the max height of a slide in the carousel and apply that
+  `current` - use the height of the current active slide
+
+#### shouldRecalculateHeight
+`React.PropTypes.bool`
+
+Whether or not carousel should recalculate its height when updating. Default is `false`
+
 #### slideIndex
 `React.PropTypes.number`
 

--- a/lib/carousel.js
+++ b/lib/carousel.js
@@ -89,8 +89,10 @@ var Carousel = (0, _createReactClass2.default)({
     edgeEasing: _propTypes2.default.string,
     framePadding: _propTypes2.default.string,
     frameOverflow: _propTypes2.default.string,
+    heightMode: _propTypes2.default.oneOf(['first', 'max', 'current']),
     initialSlideHeight: _propTypes2.default.number,
     initialSlideWidth: _propTypes2.default.number,
+    shouldRecalculateHeight: _propTypes2.default.bool,
     slideIndex: _propTypes2.default.number,
     slidesToShow: _propTypes2.default.number,
     slidesToScroll: _propTypes2.default.oneOfType([_propTypes2.default.number, _propTypes2.default.oneOf(['auto'])]),
@@ -117,6 +119,8 @@ var Carousel = (0, _createReactClass2.default)({
       edgeEasing: 'easeOutElastic',
       framePadding: '0px',
       frameOverflow: 'hidden',
+      heightMode: 'first',
+      shouldRecalculateHeight: false,
       slideIndex: 0,
       slidesToScroll: 1,
       slidesToShow: 1,
@@ -151,6 +155,24 @@ var Carousel = (0, _createReactClass2.default)({
     this.setExternalData();
     if (this.props.autoplay) {
       this.startAutoplay();
+    }
+  },
+  componentWillUpdate: function componentWillUpdate(nextProps, nextState) {
+    if (nextProps.shouldRecalculateHeight) {
+      var height = this.state.slideHeight;
+      var childNodes = this.refs.frame.childNodes[0].childNodes;
+      if (nextProps.heightMode === 'max') {
+        height = this.findMaxHeightSlide(childNodes);
+      }
+      if (nextProps.heightMode === 'current') {
+        height = childNodes[this.state.currentSlide].offsetHeight;
+      }
+      if (nextProps.heightMode === 'first') {
+        height = childNodes[0].offsetHeight;
+      }
+      if (this.state.slideHeight !== height) {
+        this.setDimensions(nextProps);
+      }
     }
   },
   componentWillReceiveProps: function componentWillReceiveProps(nextProps) {
@@ -511,6 +533,7 @@ var Carousel = (0, _createReactClass2.default)({
       self.animateSlide();
       self.resetAutoplay();
       self.setExternalData();
+      self.setDimensions(this.props);
     });
   },
   nextSlide: function nextSlide() {
@@ -653,6 +676,15 @@ var Carousel = (0, _createReactClass2.default)({
       self.setExternalData();
     });
   },
+  findMaxHeightSlide: function findMaxHeightSlide(slides) {
+    var maxHeight = 0;
+    for (var i = 0; i < slides.length; i++) {
+      if (slides[i].offsetHeight > maxHeight) {
+        maxHeight = slides[i].offsetHeight;
+      }
+    }
+    return maxHeight;
+  },
   setDimensions: function setDimensions(props) {
     props = props || this.props;
 
@@ -663,16 +695,25 @@ var Carousel = (0, _createReactClass2.default)({
         frame,
         frameWidth,
         frameHeight,
-        slideHeight;
+        slideHeight,
+        childNodes;
 
     slidesToScroll = props.slidesToScroll;
     frame = this.refs.frame;
-    firstSlide = frame.childNodes[0].childNodes[0];
+    childNodes = frame.childNodes[0].childNodes;
+    firstSlide = childNodes[0];
     if (firstSlide) {
       firstSlide.style.height = 'auto';
       slideHeight = this.props.vertical ? firstSlide.offsetHeight * props.slidesToShow : firstSlide.offsetHeight;
+      if (props.heightMode === 'max') {
+        slideHeight = this.findMaxHeightSlide(childNodes);
+      }
     } else {
       slideHeight = 100;
+    }
+
+    if (props.heightMode === 'current') {
+      slideHeight = childNodes[this.state.currentSlide].offsetHeight;
     }
 
     if (typeof props.slideWidth !== 'number') {

--- a/package.json
+++ b/package.json
@@ -65,17 +65,14 @@
     "react-dom": "^0.14.9 || ^15.3.0 || ^16.0.0"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "gulp test",
+    "dist": "webpack --config webpack.dist.config.js"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/kenwheeler/nuka-carousel.git"
   },
-  "keywords": [
-    "react",
-    "carousel",
-    "nuka"
-  ],
+  "keywords": ["react", "carousel", "nuka"],
   "author": "Ken Wheeler",
   "license": "MIT",
   "bugs": {

--- a/test/specs/carousel.spec.js
+++ b/test/specs/carousel.spec.js
@@ -55,89 +55,89 @@ describe('Carousel', function() {
 
     it('should render a .slider div', function() {
       component = ReactDOM.render(
-          React.createElement(carousel, {},
-            React.createElement('p', null, 'Slide 1'),
-            React.createElement('p', null, 'Slide 2'),
-            React.createElement('p', null, 'Slide 3')
-          ),
-          container
-        );
+        React.createElement(carousel, {},
+          React.createElement('p', null, 'Slide 1'),
+          React.createElement('p', null, 'Slide 2'),
+          React.createElement('p', null, 'Slide 3')
+        ),
+        container
+      );
       var list = TestUtils.scryRenderedDOMComponentsWithClass(
-          component,
-          'slider'
-        );
+        component,
+        'slider'
+      );
       expect(list.length).to.equal(1);
     });
 
     it('should render a .slider-frame div', function() {
       component = ReactDOM.render(
-          React.createElement(carousel, {},
-            React.createElement('p', null, 'Slide 1'),
-            React.createElement('p', null, 'Slide 2'),
-            React.createElement('p', null, 'Slide 3')
-          ),
-          container
-        );
+        React.createElement(carousel, {},
+          React.createElement('p', null, 'Slide 1'),
+          React.createElement('p', null, 'Slide 2'),
+          React.createElement('p', null, 'Slide 3')
+        ),
+        container
+      );
       var list = TestUtils.scryRenderedDOMComponentsWithClass(
-          component,
-          'slider-frame'
-        );
+        component,
+        'slider-frame'
+      );
       expect(list.length).to.equal(1);
     });
 
     it('should render a .slider-list ul', function() {
       component = ReactDOM.render(
-          React.createElement(carousel, {},
-            React.createElement('p', null, 'Slide 1'),
-            React.createElement('p', null, 'Slide 2'),
-            React.createElement('p', null, 'Slide 3')
-          ),
-          container
-        );
+        React.createElement(carousel, {},
+          React.createElement('p', null, 'Slide 1'),
+          React.createElement('p', null, 'Slide 2'),
+          React.createElement('p', null, 'Slide 3')
+        ),
+        container
+      );
       var list = TestUtils.scryRenderedDOMComponentsWithClass(
-          component,
-          'slider-list'
-        );
+        component,
+        'slider-list'
+      );
       expect(list.length).to.equal(1);
     });
 
     it('should render children with a .slider-slide class', function() {
       component = ReactDOM.render(
-          React.createElement(carousel, {},
-            React.createElement('p', null, 'Slide 1'),
-            React.createElement('p', null, 'Slide 2'),
-            React.createElement('p', null, 'Slide 3')
-          ),
-          container
-        );
+        React.createElement(carousel, {},
+          React.createElement('p', null, 'Slide 1'),
+          React.createElement('p', null, 'Slide 2'),
+          React.createElement('p', null, 'Slide 3')
+        ),
+        container
+      );
       var list = TestUtils.scryRenderedDOMComponentsWithClass(
-          component,
-          'slider-slide'
-        );
+        component,
+        'slider-slide'
+      );
       expect(list.length).to.equal(3);
     });
 
     it('should render decorators by default', function() {
       component = ReactDOM.render(
-          React.createElement(carousel, {},
-            React.createElement('p', null, 'Slide 1'),
-            React.createElement('p', null, 'Slide 2'),
-            React.createElement('p', null, 'Slide 3')
-          ),
-          container
-        );
+        React.createElement(carousel, {},
+          React.createElement('p', null, 'Slide 1'),
+          React.createElement('p', null, 'Slide 2'),
+          React.createElement('p', null, 'Slide 3')
+        ),
+        container
+      );
       var decorator1 = TestUtils.scryRenderedDOMComponentsWithClass(
-          component,
-          'slider-decorator-0'
-        );
+        component,
+        'slider-decorator-0'
+      );
       var decorator2 = TestUtils.scryRenderedDOMComponentsWithClass(
-          component,
-          'slider-decorator-1'
-        );
+        component,
+        'slider-decorator-1'
+      );
       var decorator3 = TestUtils.scryRenderedDOMComponentsWithClass(
-          component,
-          'slider-decorator-2'
-        );
+        component,
+        'slider-decorator-2'
+      );
       expect(decorator1.length).to.equal(1);
       expect(decorator2.length).to.equal(1);
       expect(decorator3.length).to.equal(1);
@@ -157,251 +157,251 @@ describe('Carousel', function() {
 
     it('should render with class "slider" with no props supplied', function() {
       component = ReactDOM.render(
-          React.createElement(carousel, {},
-            React.createElement('p', null, 'Slide 1'),
-            React.createElement('p', null, 'Slide 2'),
-            React.createElement('p', null, 'Slide 3')
-          ),
-          container
-        );
+        React.createElement(carousel, {},
+          React.createElement('p', null, 'Slide 1'),
+          React.createElement('p', null, 'Slide 2'),
+          React.createElement('p', null, 'Slide 3')
+        ),
+        container
+      );
       var slider = TestUtils.scryRenderedDOMComponentsWithClass(
-          component,
-          'slider'
-        );
+        component,
+        'slider'
+      );
       expect(slider.length).to.equal(1);
     });
 
     it('should render with class "test" with className supplied', function() {
       component = ReactDOM.render(
-          React.createElement(carousel, {className: 'test'},
-            React.createElement('p', null, 'Slide 1'),
-            React.createElement('p', null, 'Slide 2'),
-            React.createElement('p', null, 'Slide 3')
-          ),
-          container
-        );
+        React.createElement(carousel, { className: 'test' },
+          React.createElement('p', null, 'Slide 1'),
+          React.createElement('p', null, 'Slide 2'),
+          React.createElement('p', null, 'Slide 3')
+        ),
+        container
+      );
       var slider = TestUtils.scryRenderedDOMComponentsWithClass(
-          component,
-          'test'
-        );
+        component,
+        'test'
+      );
       expect(slider.length).to.equal(1);
     });
 
     it('should merge provided styles with the defaults', function() {
       component = ReactDOM.render(
-          React.createElement(carousel, {style: {backgroundColor: 'black'}},
-            React.createElement('p', null, 'Slide 1'),
-            React.createElement('p', null, 'Slide 2'),
-            React.createElement('p', null, 'Slide 3')
-          ),
-          container
-        );
+        React.createElement(carousel, { style: { backgroundColor: 'black' } },
+          React.createElement('p', null, 'Slide 1'),
+          React.createElement('p', null, 'Slide 2'),
+          React.createElement('p', null, 'Slide 3')
+        ),
+        container
+      );
       var slider = TestUtils.findRenderedDOMComponentWithClass(
-          component,
-          'slider'
-        );
+        component,
+        'slider'
+      );
       expect(slider.style.backgroundColor).to.equal('black');
       expect(slider.style.display).to.equal('block');
     });
 
     it('should merge provided styles with the defaults', function() {
       component = ReactDOM.render(
-          React.createElement(carousel, {style: {backgroundColor: 'black'}},
-            React.createElement('p', null, 'Slide 1'),
-            React.createElement('p', null, 'Slide 2'),
-            React.createElement('p', null, 'Slide 3')
-          ),
-          container
-        );
+        React.createElement(carousel, { style: { backgroundColor: 'black' } },
+          React.createElement('p', null, 'Slide 1'),
+          React.createElement('p', null, 'Slide 2'),
+          React.createElement('p', null, 'Slide 3')
+        ),
+        container
+      );
       var slider = TestUtils.findRenderedDOMComponentWithClass(
-          component,
-          'slider'
-        );
+        component,
+        'slider'
+      );
       expect(slider.style.backgroundColor).to.equal('black');
       expect(slider.style.display).to.equal('block');
     });
 
     it('should align to 0 if cellAlign is left', function() {
       component = ReactDOM.render(
-          React.createElement(carousel, {slidesToShow: 3, cellAlign: 'left', width: '500px'},
-            React.createElement('p', null, 'Slide 1'),
-            React.createElement('p', null, 'Slide 2'),
-            React.createElement('p', null, 'Slide 3')
-          ),
-          container
-        );
+        React.createElement(carousel, { slidesToShow: 3, cellAlign: 'left', width: '500px' },
+          React.createElement('p', null, 'Slide 1'),
+          React.createElement('p', null, 'Slide 2'),
+          React.createElement('p', null, 'Slide 3')
+        ),
+        container
+      );
       var slider = TestUtils.findRenderedDOMComponentWithClass(
-          component,
-          'slider-list'
-        );
+        component,
+        'slider-list'
+      );
       expect(slider.style.transform).to.equal('translate3d(0px, 0px, 0)');
     });
 
     it('should align to 200 if cellAlign is center', function() {
       component = ReactDOM.render(
-          React.createElement(carousel, {slidesToShow: 3, cellAlign: 'center', width: '600px'},
-            React.createElement('p', null, 'Slide 1'),
-            React.createElement('p', null, 'Slide 2'),
-            React.createElement('p', null, 'Slide 3')
-          ),
-          container
-        );
+        React.createElement(carousel, { slidesToShow: 3, cellAlign: 'center', width: '600px' },
+          React.createElement('p', null, 'Slide 1'),
+          React.createElement('p', null, 'Slide 2'),
+          React.createElement('p', null, 'Slide 3')
+        ),
+        container
+      );
 
       var slider = TestUtils.findRenderedDOMComponentWithClass(
         component,
-          'slider-list'
-        );
+        'slider-list'
+      );
       expect(slider.style.transform).to.equal('translate3d(200px, 0px, 0)');
     });
 
     it('should align to 400 if cellAlign is right', function() {
       component = ReactDOM.render(
-          React.createElement(carousel, {slidesToShow: 3, cellAlign: 'right', width: '600px'},
-            React.createElement('p', null, 'Slide 1'),
-            React.createElement('p', null, 'Slide 2'),
-            React.createElement('p', null, 'Slide 3')
-          ),
-          container
-        );
+        React.createElement(carousel, { slidesToShow: 3, cellAlign: 'right', width: '600px' },
+          React.createElement('p', null, 'Slide 1'),
+          React.createElement('p', null, 'Slide 2'),
+          React.createElement('p', null, 'Slide 3')
+        ),
+        container
+      );
 
       var slider = TestUtils.findRenderedDOMComponentWithClass(
         component,
-          'slider-list'
-        );
+        'slider-list'
+      );
       expect(slider.style.transform).to.equal('translate3d(400px, 0px, 0)');
     });
 
     it('should set slide width to 200 if cellSpacing is not provided', function() {
       component = ReactDOM.render(
-          React.createElement(carousel, {slidesToShow: 3, width: '600px'},
-            React.createElement('p', null, 'Slide 1'),
-            React.createElement('p', null, 'Slide 2'),
-            React.createElement('p', null, 'Slide 3')
-          ),
-          container
-        );
+        React.createElement(carousel, { slidesToShow: 3, width: '600px' },
+          React.createElement('p', null, 'Slide 1'),
+          React.createElement('p', null, 'Slide 2'),
+          React.createElement('p', null, 'Slide 3')
+        ),
+        container
+      );
 
       var slider = TestUtils.scryRenderedDOMComponentsWithClass(
         component,
-          'slider-slide'
-        );
+        'slider-slide'
+      );
       expect(slider[0].style.width).to.equal('200px');
     });
 
     it('should set slide width to 180 if cellSpacing is set to 30', function() {
       component = ReactDOM.render(
-          React.createElement(carousel, {slidesToShow: 3, cellSpacing: 30, width: '600px'},
-            React.createElement('p', null, 'Slide 1'),
-            React.createElement('p', null, 'Slide 2'),
-            React.createElement('p', null, 'Slide 3')
-          ),
-          container
-        );
+        React.createElement(carousel, { slidesToShow: 3, cellSpacing: 30, width: '600px' },
+          React.createElement('p', null, 'Slide 1'),
+          React.createElement('p', null, 'Slide 2'),
+          React.createElement('p', null, 'Slide 3')
+        ),
+        container
+      );
 
       var slider = TestUtils.scryRenderedDOMComponentsWithClass(
         component,
-          'slider-slide'
-        );
+        'slider-slide'
+      );
       expect(slider[0].style.width).to.equal('180px');
     });
 
     it('should not add mouse handlers if dragging is false', function() {
       component = ReactDOM.render(
-          React.createElement(carousel, {dragging: false},
-            React.createElement('p', null, 'Slide 1'),
-            React.createElement('p', null, 'Slide 2'),
-            React.createElement('p', null, 'Slide 3')
-          ),
-          container
-        );
+        React.createElement(carousel, { dragging: false },
+          React.createElement('p', null, 'Slide 1'),
+          React.createElement('p', null, 'Slide 2'),
+          React.createElement('p', null, 'Slide 3')
+        ),
+        container
+      );
 
       var frame = TestUtils.findRenderedDOMComponentWithClass(
         component,
-          'slider-frame'
-        );
+        'slider-frame'
+      );
       expect(frame.onMouseDown).to.be.undefined;
     });
 
     it('should add mouse handlers if dragging is true', function() {
       component = ReactDOM.render(
-          React.createElement(carousel, {dragging: false},
-            React.createElement('p', null, 'Slide 1'),
-            React.createElement('p', null, 'Slide 2'),
-            React.createElement('p', null, 'Slide 3')
-          ),
-          container
-        );
+        React.createElement(carousel, { dragging: false },
+          React.createElement('p', null, 'Slide 1'),
+          React.createElement('p', null, 'Slide 2'),
+          React.createElement('p', null, 'Slide 3')
+        ),
+        container
+      );
 
       var frame = TestUtils.findRenderedDOMComponentWithClass(
         component,
-          'slider-frame'
-        );
+        'slider-frame'
+      );
       expect(frame.onMouseDown).to.be.defined;
     });
 
     it('should add frame margin if framePadding is supplied a value', function() {
       component = ReactDOM.render(
-          React.createElement(carousel, {framePadding: '40px'},
-            React.createElement('p', null, 'Slide 1'),
-            React.createElement('p', null, 'Slide 2'),
-            React.createElement('p', null, 'Slide 3')
-          ),
-          container
-        );
+        React.createElement(carousel, { framePadding: '40px' },
+          React.createElement('p', null, 'Slide 1'),
+          React.createElement('p', null, 'Slide 2'),
+          React.createElement('p', null, 'Slide 3')
+        ),
+        container
+      );
 
       var frame = TestUtils.findRenderedDOMComponentWithClass(
         component,
-          'slider-frame'
-        );
+        'slider-frame'
+      );
       expect(frame.style.margin).to.equal('40px');
     });
 
     it('should set slideWidth to 1000 if slidesToShow is 1', function() {
       component = ReactDOM.render(
-          React.createElement(carousel, {slidesToShow: 1, width: '1000px'},
-            React.createElement('p', {className: 'test-slide'}, 'Slide 1'),
-            React.createElement('p', null, 'Slide 2'),
-            React.createElement('p', null, 'Slide 3')
-          ),
-          container
-        );
+        React.createElement(carousel, { slidesToShow: 1, width: '1000px' },
+          React.createElement('p', { className: 'test-slide' }, 'Slide 1'),
+          React.createElement('p', null, 'Slide 2'),
+          React.createElement('p', null, 'Slide 3')
+        ),
+        container
+      );
 
       var slide = TestUtils.scryRenderedDOMComponentsWithClass(
         component,
-          'slider-slide'
-        );
+        'slider-slide'
+      );
 
       expect(slide[0].style.width).to.equal('1000px');
     });
 
     it('should set slideWidth to 200 if slidesToShow is 3', function() {
       component = ReactDOM.render(
-          React.createElement(carousel, {slidesToShow: 3, width: '600px'},
-            React.createElement('p', {className: 'test-slide'}, 'Slide 1'),
-            React.createElement('p', null, 'Slide 2'),
-            React.createElement('p', null, 'Slide 3')
-          ),
-          container
-        );
+        React.createElement(carousel, { slidesToShow: 3, width: '600px' },
+          React.createElement('p', { className: 'test-slide' }, 'Slide 1'),
+          React.createElement('p', null, 'Slide 2'),
+          React.createElement('p', null, 'Slide 3')
+        ),
+        container
+      );
 
       var slide = TestUtils.scryRenderedDOMComponentsWithClass(
         component,
-          'slider-slide'
-        );
+        'slider-slide'
+      );
 
       expect(slide[0].style.width).to.equal('200px');
     });
 
     it('should have currentSlide equal 2 for 4 slides if slidesToShow is 2, slidesToScroll is 2, and it advances', function() {
       component = ReactDOM.render(
-          React.createElement(carousel, {slidesToShow: 2, slidesToScroll: 2},
-            React.createElement('p', null, 'Slide 1'),
-            React.createElement('p', null, 'Slide 2'),
-            React.createElement('p', null, 'Slide 3'),
-            React.createElement('p', null, 'Slide 4')
-          ),
-          container
-        );
+        React.createElement(carousel, { slidesToShow: 2, slidesToScroll: 2 },
+          React.createElement('p', null, 'Slide 1'),
+          React.createElement('p', null, 'Slide 2'),
+          React.createElement('p', null, 'Slide 3'),
+          React.createElement('p', null, 'Slide 4')
+        ),
+        container
+      );
 
       component.nextSlide();
 
@@ -410,13 +410,13 @@ describe('Carousel', function() {
 
     it('should have currentSlide equal 1 for 3 slides if slidesToShow is 2, slidesToScroll is 2, and it advances', function() {
       component = ReactDOM.render(
-          React.createElement(carousel, {slidesToShow: 2, slidesToScroll: 2},
-            React.createElement('p', null, 'Slide 1'),
-            React.createElement('p', null, 'Slide 2'),
-            React.createElement('p', null, 'Slide 3')
-          ),
-          container
-        );
+        React.createElement(carousel, { slidesToShow: 2, slidesToScroll: 2 },
+          React.createElement('p', null, 'Slide 1'),
+          React.createElement('p', null, 'Slide 2'),
+          React.createElement('p', null, 'Slide 3')
+        ),
+        container
+      );
 
       component.nextSlide();
 
@@ -425,13 +425,13 @@ describe('Carousel', function() {
 
     it('should set slidesToScroll to passed in slidesToScroll', function() {
       component = ReactDOM.render(
-          React.createElement(carousel, {slidesToScroll: 3, width: '600px'},
-            React.createElement('p', {className: 'test-slide'}, 'Slide 1'),
-            React.createElement('p', null, 'Slide 2'),
-            React.createElement('p', null, 'Slide 3')
-          ),
-          container
-        );
+        React.createElement(carousel, { slidesToScroll: 3, width: '600px' },
+          React.createElement('p', { className: 'test-slide' }, 'Slide 1'),
+          React.createElement('p', null, 'Slide 2'),
+          React.createElement('p', null, 'Slide 3')
+        ),
+        container
+      );
 
       expect(component.state.slidesToScroll).to.equal(3);
     });
@@ -439,8 +439,8 @@ describe('Carousel', function() {
     it('should set slidesToScroll to 2 if slideWidth is 250px and slidesToScroll is auto',
       function() {
         component = ReactDOM.render(
-          React.createElement(carousel, {slideWidth: '250px', width: '600px', slidesToScroll: 'auto'},
-            React.createElement('p', {className: 'test-slide'}, 'Slide 1'),
+          React.createElement(carousel, { slideWidth: '250px', width: '600px', slidesToScroll: 'auto' },
+            React.createElement('p', { className: 'test-slide' }, 'Slide 1'),
             React.createElement('p', null, 'Slide 2'),
             React.createElement('p', null, 'Slide 3')
           ),
@@ -459,9 +459,9 @@ describe('Carousel', function() {
             cellSpacing: 100,
             slidesToScroll: 'auto'
           },
-            React.createElement('p', {className: 'test-slide'}, 'Slide 1'),
-            React.createElement('p', null, 'Slide 2'),
-            React.createElement('p', null, 'Slide 3')
+          React.createElement('p', { className: 'test-slide' }, 'Slide 1'),
+          React.createElement('p', null, 'Slide 2'),
+          React.createElement('p', null, 'Slide 3')
           ),
           container
         );
@@ -472,8 +472,8 @@ describe('Carousel', function() {
     it('should set slidesToScroll to 6 if slideWidth is 100px and slidesToScroll is auto',
       function() {
         component = ReactDOM.render(
-          React.createElement(carousel, {slideWidth: '100px', width: '600px', slidesToScroll: 'auto'},
-            React.createElement('p', {className: 'test-slide'}, 'Slide 1'),
+          React.createElement(carousel, { slideWidth: '100px', width: '600px', slidesToScroll: 'auto' },
+            React.createElement('p', { className: 'test-slide' }, 'Slide 1'),
             React.createElement('p', null, 'Slide 2'),
             React.createElement('p', null, 'Slide 3')
           ),
@@ -481,6 +481,30 @@ describe('Carousel', function() {
         );
 
         expect(component.state.slidesToScroll).to.equal(6);
+      });
+
+    it('should set prop heightMode is "first" by default',
+      function() {
+        component = ReactDOM.render(
+          React.createElement(carousel, null,
+            React.createElement('p', { className: 'test-slide' }, 'Slide 1'),
+          ),
+          container
+        );
+
+        expect(component.props.heightMode).to.equal('first');
+      });
+
+    it('should shouldRecalculateHeight is false by default',
+      function() {
+        component = ReactDOM.render(
+          React.createElement(carousel, null,
+            React.createElement('p', { className: 'test-slide' }, 'Slide 1'),
+          ),
+          container
+        );
+
+        expect(component.props.shouldRecalculateHeight).to.equal(false);
       });
   });
 
@@ -496,13 +520,13 @@ describe('Carousel', function() {
 
     it('should advance if nextSlide() is called', function() {
       component = ReactDOM.render(
-          React.createElement(carousel, null,
-            React.createElement('p', null, 'Slide 1'),
-            React.createElement('p', null, 'Slide 2'),
-            React.createElement('p', null, 'Slide 3')
-          ),
-          container
-        );
+        React.createElement(carousel, null,
+          React.createElement('p', null, 'Slide 1'),
+          React.createElement('p', null, 'Slide 2'),
+          React.createElement('p', null, 'Slide 3')
+        ),
+        container
+      );
 
       component.nextSlide();
 
@@ -511,13 +535,13 @@ describe('Carousel', function() {
 
     it('should not advance if nextSlide() is called and the currentSlide is the last slide', function() {
       component = ReactDOM.render(
-          React.createElement(carousel, null,
-            React.createElement('p', null, 'Slide 1'),
-            React.createElement('p', null, 'Slide 2'),
-            React.createElement('p', null, 'Slide 3')
-          ),
-          container
-        );
+        React.createElement(carousel, null,
+          React.createElement('p', null, 'Slide 1'),
+          React.createElement('p', null, 'Slide 2'),
+          React.createElement('p', null, 'Slide 3')
+        ),
+        container
+      );
 
       component.nextSlide();
       component.nextSlide();
@@ -528,13 +552,13 @@ describe('Carousel', function() {
 
     it('should not go back if previousSlide() is called and the currentSlide is the first slide', function() {
       component = ReactDOM.render(
-          React.createElement(carousel, null,
-            React.createElement('p', null, 'Slide 1'),
-            React.createElement('p', null, 'Slide 2'),
-            React.createElement('p', null, 'Slide 3')
-          ),
-          container
-        );
+        React.createElement(carousel, null,
+          React.createElement('p', null, 'Slide 1'),
+          React.createElement('p', null, 'Slide 2'),
+          React.createElement('p', null, 'Slide 3')
+        ),
+        container
+      );
 
       component.previousSlide();
 
@@ -543,13 +567,13 @@ describe('Carousel', function() {
 
     it('should go back if previousSlide() is called', function() {
       component = ReactDOM.render(
-          React.createElement(carousel, null,
-            React.createElement('p', null, 'Slide 1'),
-            React.createElement('p', null, 'Slide 2'),
-            React.createElement('p', null, 'Slide 3')
-          ),
-          container
-        );
+        React.createElement(carousel, null,
+          React.createElement('p', null, 'Slide 1'),
+          React.createElement('p', null, 'Slide 2'),
+          React.createElement('p', null, 'Slide 3')
+        ),
+        container
+      );
 
       component.nextSlide();
       component.previousSlide();
@@ -559,17 +583,102 @@ describe('Carousel', function() {
 
     it('should go to 2 if goToSlide(2) is called', function() {
       component = ReactDOM.render(
-          React.createElement(carousel, null,
-            React.createElement('p', null, 'Slide 1'),
-            React.createElement('p', null, 'Slide 2'),
-            React.createElement('p', null, 'Slide 3')
-          ),
-          container
-        );
+        React.createElement(carousel, null,
+          React.createElement('p', null, 'Slide 1'),
+          React.createElement('p', null, 'Slide 2'),
+          React.createElement('p', null, 'Slide 3')
+        ),
+        container
+      );
 
       component.goToSlide(2);
 
       expect(component.state.currentSlide).to.equal(2);
+    });
+
+    it('should set height to the tallest slide if heightMode is `max`', function() {
+      component = ReactDOM.render(
+        React.createElement(carousel, { heightMode: 'max' },
+          React.createElement('div', { style: { height: '200px' } }, 'Slide 1'),
+          React.createElement('div', { style: { height: '300px' } }, 'Slide 2'),
+          React.createElement('div', { style: { height: '400px' } }, 'Slide 3'),
+          React.createElement('div', { style: { height: '300px' } }, 'Slide 4'),
+          React.createElement('div', { style: { height: '200px' } }, 'Slide 5'),
+        ),
+        container
+      );
+
+      expect(component.state.slideHeight).to.equal(400);
+    });
+
+    it('should set height to the first slide if heightMode is `first`', function() {
+      component = ReactDOM.render(
+        React.createElement(carousel, { heightMode: 'first' },
+          React.createElement('div', { style: { height: '391px' } }, 'Slide 1'),
+          React.createElement('div', { style: { height: '300px' } }, 'Slide 2'),
+          React.createElement('div', { style: { height: '400px' } }, 'Slide 3'),
+          React.createElement('div', { style: { height: '300px' } }, 'Slide 4'),
+          React.createElement('div', { style: { height: '200px' } }, 'Slide 5'),
+        ),
+        container
+      );
+
+      expect(component.state.slideHeight).to.equal(391);
+    });
+
+    it('should set height to the current slide if heightMode is `current`', function() {
+      component = ReactDOM.render(
+        React.createElement(carousel, { heightMode: 'current', slideIndex: 2 },
+          React.createElement('div', { style: { height: '391px' } }, 'Slide 1'),
+          React.createElement('div', { style: { height: '300px' } }, 'Slide 2'),
+          React.createElement('div', { style: { height: '401px' } }, 'Slide 3'),
+          React.createElement('div', { style: { height: '300px' } }, 'Slide 4'),
+          React.createElement('div', { style: { height: '200px' } }, 'Slide 5'),
+        ),
+        container
+      );
+
+      expect(component.state.slideHeight).to.equal(401);
+    });
+
+    it('should set height to the first slide if heightMode is `first`', function() {
+      component = ReactDOM.render(
+        React.createElement(carousel, { heightMode: 'first' },
+          React.createElement('div', { style: { height: '391px' } }, 'Slide 1'),
+          React.createElement('div', { style: { height: '300px' } }, 'Slide 2'),
+          React.createElement('div', { style: { height: '400px' } }, 'Slide 3'),
+          React.createElement('div', { style: { height: '300px' } }, 'Slide 4'),
+          React.createElement('div', { style: { height: '200px' } }, 'Slide 5'),
+        ),
+        container
+      );
+
+      expect(component.state.slideHeight).to.equal(391);
+    });
+
+    it('should correctly recalculate if shouldRecalculateHeight is true', function() {
+      var unstableStyles = {
+        style: {
+          height: '400px'
+        }
+      };
+      component = ReactDOM.render(
+        React.createElement(carousel, { heightMode: 'max', shouldRecalculateHeight: true },
+          React.createElement('div', { style: { height: '200px' } }, 'Slide 1'),
+          React.createElement('div', { style: { height: '300px' } }, 'Slide 2'),
+          React.createElement('div', { style: { height: '400px' } }, 'Slide 3'),
+          React.createElement('div', { style: { height: '300px' } }, 'Slide 4'),
+          React.createElement('div', { style: { height: '200px' } }, 'Slide 5'),
+        ),
+        container
+      );
+
+      var frame = component.refs.frame;
+      var thirdSlide = frame.childNodes[0].childNodes[2];
+      thirdSlide.style.height = '600px';
+      component.forceUpdate();
+
+      expect(component.state.slideHeight).to.equal(600);
     });
 
   });


### PR DESCRIPTION
Adds four props to how the carousel should calculate the height. `first` , `max` or `current`, as well as a prop that indicates whether the height needs to be recalculated on update. Based on PR #279 

cc @ryan-roemer @kenwheeler @ajoshi0