### PR TITLE
Remove auto height styling

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -691,14 +691,9 @@ export default class Carousel extends React.Component {
 
     const frame = this.frame;
     const childNodes = this.getChildNodes();
-    const firstSlide = childNodes[0];
     const slideHeight = this.getSlideHeight(props, childNodes);
 
     slidesToScroll = props.slidesToScroll;
-
-    if (firstSlide) {
-      firstSlide.style.height = 'auto';
-    }
 
     if (typeof props.slideWidth !== 'number') {
       slideWidth = parseInt(props.slideWidth);


### PR DESCRIPTION
- [x] Quick fix that removes the `auto` height for the first slide. This is no longer needed with the 3 height modes implemented.

- [x] Verified the 3 height modes (max, current, and first) still work

Addresses #306 

cc @ryan-roemer @kenwheeler 