### PR TITLE
Fixed offset for non-left aligns and > 1 slidesToShow

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -509,7 +509,8 @@ export default class Carousel extends React.Component {
     }
     if (
       this.state.currentSlide >= childrenCount - slidesToShow &&
-      !this.props.wrapAround
+      !this.props.wrapAround &&
+      this.props.cellAlign === 'left'
     ) {
       return;
     }
@@ -521,12 +522,12 @@ export default class Carousel extends React.Component {
         this.goToSlide(this.state.currentSlide + this.state.slidesToScroll);
         return;
       }
-      this.goToSlide(
-        Math.min(
-          this.state.currentSlide + this.state.slidesToScroll,
-          childrenCount - slidesToShow
-        )
-      );
+      const offset = this.state.currentSlide + this.state.slidesToScroll;
+      const nextSlideIndex =
+        this.props.cellAlign !== 'left'
+          ? offset
+          : Math.min(offset, childrenCount - slidesToShow);
+      this.goToSlide(nextSlideIndex);
     }
   }
 

--- a/test/specs/carousel.test.js
+++ b/test/specs/carousel.test.js
@@ -129,6 +129,46 @@ describe('<Carousel />', () => {
       expect(slider).toHaveStyle('transform', 'translate3d(0px, 0px, 0)');
     });
 
+    it('should allow navigation to the last slide for center align and > 1 slidesToShow.', () => {
+      const wrapper = mount(
+        <Carousel cellAlign="center" slidesToShow={3}>
+          <p>Slide 1</p>
+          <p>Slide 2</p>
+          <p>Slide 3</p>
+          <p>Slide 4</p>
+          <p>Slide 5</p>
+          <p>Slide 6</p>
+        </Carousel>
+      );
+      const nextButton = wrapper.find('.slider-control-centerright button');
+      nextButton.simulate('click');
+      nextButton.simulate('click');
+      nextButton.simulate('click');
+      nextButton.simulate('click');
+      nextButton.simulate('click');
+      expect(wrapper).toHaveState({ currentSlide: 5 });
+    });
+
+    it('should allow navigation to the last slide for right align and > 1 slidesToShow.', () => {
+      const wrapper = mount(
+        <Carousel cellAlign="right" slidesToShow={2}>
+          <p>Slide 1</p>
+          <p>Slide 2</p>
+          <p>Slide 3</p>
+          <p>Slide 4</p>
+          <p>Slide 5</p>
+          <p>Slide 6</p>
+        </Carousel>
+      );
+      const nextButton = wrapper.find('.slider-control-centerright button');
+      nextButton.simulate('click');
+      nextButton.simulate('click');
+      nextButton.simulate('click');
+      nextButton.simulate('click');
+      nextButton.simulate('click');
+      expect(wrapper).toHaveState({ currentSlide: 5 });
+    });
+
     it('should adjust the slide index when children count change.', () => {
       const wrapper = mount(
         <Carousel slideIndex={2}>


### PR DESCRIPTION
Previously when using a non-left cell align and showing more than 1 slide at a time, you were not able to see all the slides.

The fix allows the carousel to now offset correctly based on the alignment.

The new tests with the prior code:
<img width="621" alt="before-fix" src="https://user-images.githubusercontent.com/1738349/37661559-17ce18a0-2c23-11e8-91fc-6770143f25d6.PNG">

cc @ryan-roemer @kenwheeler 

Addresses #278 