### PR TITLE
Enable passing currentSlide props

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -124,6 +124,14 @@ export default class Carousel extends React.Component {
     ) {
       this.goToSlide(nextProps.slideIndex);
     }
+    
+    if (
+      this.props.currentSlide !== nextProps.currentSlide &&
+      nextProps.currentSlide !== this.state.currentSlide
+    ) {
+      this.setState({currentSlide: nextProps.currentSlide});
+    }
+    
     if (this.props.autoplay !== nextProps.autoplay) {
       if (nextProps.autoplay) {
         this.startAutoplay();


### PR DESCRIPTION
I needed to be able to set currentSlide index to change currently displayed slide without animation.