### PR TITLE
Cut down object creation during transitions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1025,6 +1025,10 @@ export default class Carousel extends React.Component {
         ? 0
         : this.props.speed;
 
+    const frameStyles = this.getFrameStyles()
+    const touchEvents = this.getTouchEvents()
+    const mouseEvents = this.getMouseEvents()
+
     return (
       <div
         className={['slider', this.props.className || ''].join(' ')}
@@ -1043,9 +1047,9 @@ export default class Carousel extends React.Component {
             <div
               className="slider-frame"
               ref={frame => (this.frame = frame)}
-              style={this.getFrameStyles()}
-              {...this.getTouchEvents()}
-              {...this.getMouseEvents()}
+              style={frameStyles}
+              {...touchEvents}
+              {...mouseEvents}
               onClick={this.handleClick}
             >
               <ul


### PR DESCRIPTION
Hey,  author of react-move here.  Just happen to see https://github.com/FormidableLabs/nuka-carousel/issues/318.  I think this might help.  If I understand correctly, these objects just need to be created once per render of the carousel.  Inside the children function of Animate these objects are being created on each frame of the animation.  I did run the tests on this and everything passed.