### PR TITLE
Fix lint usage w/ prettier.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,6 +17,7 @@
   },
   "plugins": ["prettier"],
   "rules": {
+    "prettier/prettier": "error",
     "react/no-multi-comp": 0,
     "max-params": 0,
     "no-magic-numbers": 0,

--- a/src/index.js
+++ b/src/index.js
@@ -1025,9 +1025,9 @@ export default class Carousel extends React.Component {
         ? 0
         : this.props.speed;
 
-    const frameStyles = this.getFrameStyles()
-    const touchEvents = this.getTouchEvents()
-    const mouseEvents = this.getMouseEvents()
+    const frameStyles = this.getFrameStyles();
+    const touchEvents = this.getTouchEvents();
+    const mouseEvents = this.getMouseEvents();
 
     return (
       <div


### PR DESCRIPTION
We were missing the `"prettier/prettier": "error"` rule which means that we disabled all style rules and _didn't_ have anything re-added for prettier to fix specifically. :P  This corrects the config and when run we get this (expected) error:

```
$ eslint .

/Users/rye/scm/fmd/nuka-carousel/src/index.js
  1028:46  error  Insert `;`  prettier/prettier
  1029:46  error  Insert `;`  prettier/prettier
  1030:46  error  Insert `;`  prettier/prettier
```

And `eslint . --fix` or `yarn lint --fix` now automagically fixes prettier-based errors!

/cc @kenwheeler @carlospaelinck 