### PR TITLE
Handle swipe properly when carousel has one slide and disable the arrows

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -10,9 +10,13 @@ class App extends React.Component {
     this.state = { slideIndex: 0, length: 6, wrapAround: false };
   }
 
+  getStyleTagStyles() {
+    return '.slider-list img {width: 100%; display: block;}';
+  }
+
   render() {
     return (
-      <div style={{ width: '50%', margin: 'auto' }}>
+      <div style={{ width: '70%', margin: 'auto' }}>
         <Carousel
           wrapAround={this.state.wrapAround}
           slideIndex={this.state.slideIndex}
@@ -46,6 +50,15 @@ class App extends React.Component {
             <button
               onClick={() =>
                 this.setState({
+                  length: 1
+                })
+              }
+            >
+              1 Slide Only
+            </button>
+            <button
+              onClick={() =>
+                this.setState({
                   length: 2
                 })
               }
@@ -63,6 +76,11 @@ class App extends React.Component {
             </button>
           </div>
         </div>
+
+        <style
+          type="text/css"
+          dangerouslySetInnerHTML={{ __html: this.getStyleTagStyles() }}
+        />
       </div>
     );
   }

--- a/src/default-controls.js
+++ b/src/default-controls.js
@@ -22,7 +22,7 @@ export class PreviousButton extends React.Component {
   render() {
     const disabled =
       (this.props.currentSlide === 0 && !this.props.wrapAround) ||
-      this.props.slideCount === 0;
+      this.props.slideCount <= 1;
     return (
       <button
         style={defaultButtonStyles(disabled)}
@@ -46,8 +46,10 @@ export class NextButton extends React.Component {
   }
   render() {
     const disabled =
-      this.props.currentSlide + this.props.slidesToScroll >=
-        this.props.slideCount && !this.props.wrapAround;
+      this.props.slideCount <= 1 ||
+      (this.props.currentSlide + this.props.slidesToScroll >=
+        this.props.slideCount &&
+        !this.props.wrapAround);
     return (
       <button
         style={defaultButtonStyles(disabled)}

--- a/src/index.js
+++ b/src/index.js
@@ -70,6 +70,10 @@ export default class Carousel extends React.Component {
     this.handleMouseOut = this.handleMouseOut.bind(this);
     this.handleClick = this.handleClick.bind(this);
     this.handleSwipe = this.handleSwipe.bind(this);
+    this.handleSwipeToNextSlide = this.handleSwipeToNextSlide.bind(this);
+    this.handleSwipeToPreviousSlide = this.handleSwipeToPreviousSlide.bind(
+      this
+    );
     this.swipeDirection = this.swipeDirection.bind(this);
     this.autoplayIterator = this.autoplayIterator.bind(this);
     this.startAutoplay = this.startAutoplay.bind(this);
@@ -317,6 +321,35 @@ export default class Carousel extends React.Component {
     }
   }
 
+  handleSwipeToNextSlide() {
+    let slidesToShow = this.props.slidesToShow;
+    if (this.props.slidesToScroll === 'auto') {
+      slidesToShow = this.state.slidesToScroll;
+    }
+
+    if (
+      React.Children.count(this.props.children) === 1 ||
+      (this.state.currentSlide >=
+        React.Children.count(this.props.children) - slidesToShow &&
+        !this.props.wrapAround)
+    ) {
+      this.setState({ easing: easing[this.props.edgeEasing] });
+    } else {
+      this.nextSlide();
+    }
+  }
+
+  handleSwipeToPreviousSlide() {
+    if (
+      React.Children.count(this.props.children) === 1 ||
+      (this.state.currentSlide <= 0 && !this.props.wrapAround)
+    ) {
+      this.setState({ easing: easing[this.props.edgeEasing] });
+    } else {
+      this.previousSlide();
+    }
+  }
+
   handleSwipe() {
     if (
       typeof this.touchObject.length !== 'undefined' &&
@@ -334,21 +367,9 @@ export default class Carousel extends React.Component {
 
     if (this.touchObject.length > this.state.slideWidth / slidesToShow / 5) {
       if (this.touchObject.direction === 1) {
-        if (
-          this.state.currentSlide >=
-            React.Children.count(this.props.children) - slidesToShow &&
-          !this.props.wrapAround
-        ) {
-          this.setState({ easing: easing[this.props.edgeEasing] });
-        } else {
-          this.nextSlide();
-        }
+        this.handleSwipeToNextSlide();
       } else if (this.touchObject.direction === -1) {
-        if (this.state.currentSlide <= 0 && !this.props.wrapAround) {
-          this.setState({ easing: easing[this.props.edgeEasing] });
-        } else {
-          this.previousSlide();
-        }
+        this.handleSwipeToPreviousSlide();
       }
     } else {
       this.goToSlide(this.state.currentSlide);
@@ -876,10 +897,6 @@ export default class Carousel extends React.Component {
     };
   }
 
-  getStyleTagStyles() {
-    return '.slider-slide > img {width: 100%; display: block;}';
-  }
-
   getDecoratorStyles(position) {
     switch (position) {
       case 'TopLeft': {
@@ -1063,11 +1080,6 @@ export default class Carousel extends React.Component {
         />
 
         {this.renderControls()}
-
-        <style
-          type="text/css"
-          dangerouslySetInnerHTML={{ __html: this.getStyleTagStyles() }}
-        />
       </div>
     );
   }


### PR DESCRIPTION
* Extend the demo to include option for showing only one slide
* Disable the arrows when there is only one slide
* When swiping and there is only one slide, apply easing, instead of going to the next/previous slide

* Move getStyleTagStyles from carousel to the demo app (the user should be responsible to apply the proper styles of the slides)