### PR TITLE
Add touch-action to frame to improve pan handling

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -799,7 +799,8 @@ export default class Carousel extends React.Component {
       WebkitTransform: 'translate3d(0, 0, 0)',
       msTransform: 'translate(0, 0)',
       boxSizing: 'border-box',
-      MozBoxSizing: 'border-box'
+      MozBoxSizing: 'border-box',
+      touchAction: `pinch-zoom ${this.props.vertical ? 'pan-x' : 'pan-y'}`
     };
   }
 


### PR DESCRIPTION
This adds `touch-action` to the carousel frame to allow for single direction panning with passive event listeners.

With the release of v56, Chrome made all `document` level touch listeners passive. React doesn't currently have any way to work around this (see discussion in https://github.com/facebook/react/issues/8968), so if you want to use an active event listener that allows `ev.preventDefault()` you have to register event listeners manually instead of using React's event system.

That's OK, but the Chrome team suggests using the `touch-action` property to denote what actions are allowed on an element instead, which is what I've done here (see https://bugs.chromium.org/p/chromium/issues/detail?id=639227).

With `touch-action` we can declare that an element allows pans in a given direction as well as pinch to zoom. In our case, we let the browser handle pans counter to the carousel's axis (i.e. vertical page scrolling if the carousel is horizontal) but not pans along the carousel's axis. This does the same job that our `preventDefault` call in the `touchMove` handler does in browsers that aren't using passive event listeners.

Resolves #319 