### PR TITLE
Add min-height: 100% to slides

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -814,6 +814,7 @@ export default class Carousel extends React.Component {
       verticalAlign: 'top',
       width: this.props.vertical ? '100%' : this.state.slideWidth,
       height: 'auto',
+      minHeight: '100%',
       boxSizing: 'border-box',
       MozBoxSizing: 'border-box',
       marginLeft: this.props.vertical ? 'auto' : this.props.cellSpacing / 2,


### PR DESCRIPTION
Resolves https://github.com/FormidableLabs/nuka-carousel/issues/317

This ensures that slides are at least as tall as their container. Right now, if you use `heightMode='max'` to ensure that slides are all as tall as the tallest slide, the slide container is sized appropriately but individual slides aren't. Applying a `min-height` lets you style slides more easily within the container, so you can do things like this:

<details>
<summary>Expand/Collapse</summary>

![slides](https://user-images.githubusercontent.com/808159/39158081-ed4a6f74-4712-11e8-8517-508466dad377.gif)

</details>


