### PR TITLE
Fix rendering of a single child in carousel

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1037,10 +1037,7 @@ export default class Carousel extends React.Component {
   }
 
   render() {
-    const children =
-      React.Children.count(this.props.children) > 1
-        ? this.formatChildren(this.props.children)
-        : this.props.children;
+    const children = this.formatChildren(this.props.children);
     const duration =
       this.state.dragging || this.state.resetWrapAroundPosition
         ? 0

--- a/test/specs/carousel.test.js
+++ b/test/specs/carousel.test.js
@@ -62,6 +62,16 @@ describe('<Carousel />', () => {
       expect(children).toHaveLength(3);
     });
 
+    it('should render a single child with the `slider-slide` class.', () => {
+      const wrapper = mount(
+        <Carousel>
+          <p>Slide 1</p>
+        </Carousel>
+      );
+      const children = wrapper.find('.slider-slide');
+      expect(children).toHaveLength(1);
+    });
+
     it('should render controls by default.', () => {
       const wrapper = mount(
         <Carousel>


### PR DESCRIPTION
Resolves #234.

This fixes an issue where we weren't wrapping a single child element in the slide markup, including the `li` element that wraps the slides and related styles. This meant that the result wasn't semantically correct, and also wasn't styled correctly.

Apologies to @kosiakMD who fixed this in https://github.com/FormidableLabs/nuka-carousel/pull/247. I tried to rebase that PR but there was some git weirdness somewhere way back and my powers weren't strong enough to overcome it.

#### Screenshots

##### Before

![localhost_8080_ 1](https://user-images.githubusercontent.com/808159/39334727-af744284-4964-11e8-8efa-757002d62269.png)

##### After

![localhost_8080_](https://user-images.githubusercontent.com/808159/39334733-b2677dda-4964-11e8-8a0e-0a809222d3cb.png)
