### PR TITLE
Allow Clicking on Elements in Carousel when Dragging is Disabled

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,7 @@ export default class Carousel extends React.Component {
     super(...arguments);
 
     this.displayName = 'Carousel';
-    this.clickSafe = true;
+    this.clickSafe = false;
     this.controlsMap = [
       { func: this.props.renderTopLeftControls, key: 'TopLeft' },
       { func: this.props.renderTopCenterControls, key: 'TopCenter' },
@@ -144,6 +144,8 @@ export default class Carousel extends React.Component {
   getTouchEvents() {
     if (this.props.swiping === false) {
       return null;
+    } else {
+      self.clickSafe = true;
     }
 
     return {


### PR DESCRIPTION
#### What does this PR do? 
Adds fix that enables clicking on elements in a Carousel when dragging is disabled. This fix addresses an old issue (#168) from 2016 that was resolved in an old PR (#190) from 2017, but was never merged in. 

The library has since been updated causing that old PR to have breaking changes. This PR is an updated version of that fix for Nuka Carousel v4.2.1