### PR TITLE
Prevent setState after component Unmounts

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -436,7 +436,9 @@ export default class Carousel extends React.Component {
   // Action Methods
 
   goToSlide(index) {
-    this.setState({ easing: easing[this.props.easing] });
+    if (!this.mounted) return;
+
+    if (this.mounted) this.setState({ easing: easing[this.props.easing] });
 
     if (index >= React.Children.count(this.props.children) || index < 0) {
       if (!this.props.wrapAround) {

--- a/src/index.js
+++ b/src/index.js
@@ -464,14 +464,16 @@ export default class Carousel extends React.Component {
           }),
           () =>
             setTimeout(() => {
-              this.setState(
-                { isWrappingAround: false, resetWrapAroundPosition: true },
-                () => {
-                  this.setState({ resetWrapAroundPosition: false });
-                  this.props.afterSlide(0);
-                  this.resetAutoplay();
-                }
-              );
+              if (this.mounted) {
+                this.setState(
+                  { isWrappingAround: false, resetWrapAroundPosition: true },
+                  () => {
+                    this.setState({ resetWrapAroundPosition: false });
+                    this.props.afterSlide(0);
+                    this.resetAutoplay();
+                  }
+                );
+              }
             }, this.props.speed)
         );
         return;
@@ -493,14 +495,16 @@ export default class Carousel extends React.Component {
           }),
           () =>
             setTimeout(() => {
-              this.setState(
-                { isWrappingAround: false, resetWrapAroundPosition: true },
-                () => {
-                  this.setState({ resetWrapAroundPosition: false });
-                  this.props.afterSlide(endSlide);
-                  this.resetAutoplay();
-                }
-              );
+              if (this.mounted) {
+                this.setState(
+                  {isWrappingAround: false, resetWrapAroundPosition: true},
+                  () => {
+                    this.setState({resetWrapAroundPosition: false});
+                    this.props.afterSlide(endSlide);
+                    this.resetAutoplay();
+                  }
+                );
+              }
             }, this.props.speed)
         );
         return;


### PR DESCRIPTION
Hi @kenwheeler ,

I am currently facing an issue where nuka carousel continues to setState in the function goToSlide after the component unmount. Attached is a screenshot of what happens.

![setstate](https://user-images.githubusercontent.com/8574893/40911290-088bb9c6-6821-11e8-88ab-09e2379872b2.png)

As such, I did a fork and added a few checks in the function to check if component did unmount. If it does, it will not proceed with the setState. Hope you will be able to look at it and merge into master. Feel free to let me know if you have comments or advise to do it better. 

Thanks for your time!

Best Regards
Stanley Ong
