### PR TITLE
Bug/first last partial wrap around

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -11,7 +11,9 @@ class App extends React.Component {
       slideIndex: 0,
       length: 6,
       wrapAround: false,
-      underlineHeader: false
+      underlineHeader: false,
+      slidesToShow: 1.0,
+      cellAlign: 'left'
     };
 
     this.handleImageClick = this.handleImageClick.bind(this);
@@ -25,6 +27,8 @@ class App extends React.Component {
     return (
       <div style={{ width: '50%', margin: 'auto' }}>
         <Carousel
+          cellAlign={this.state.cellAlign}
+          slidesToShow={this.state.slidesToShow}
           wrapAround={this.state.wrapAround}
           slideIndex={this.state.slideIndex}
           renderTopCenterControls={({ currentSlide }) => (
@@ -79,6 +83,32 @@ class App extends React.Component {
               }
             >
               Toggle Wrap Around
+            </button>
+          </div>
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+          {this.state.slidesToShow > 1.0 && (
+            <div>
+              <button onClick={() => this.setState({ cellAlign: 'left' })}>
+                Left
+              </button>
+              <button onClick={() => this.setState({ cellAlign: 'center' })}>
+                Center
+              </button>
+              <button onClick={() => this.setState({ cellAlign: 'right' })}>
+                Right
+              </button>
+            </div>
+          )}
+          <div style={{ marginLeft: 'auto' }}>
+            <button
+              onClick={() =>
+                this.setState({
+                  slidesToShow: this.state.slidesToShow > 1.0 ? 1.0 : 1.25
+                })
+              }
+            >
+              Toggle Partially Visible Slides
             </button>
           </div>
         </div>

--- a/src/index.js
+++ b/src/index.js
@@ -483,9 +483,9 @@ export default class Carousel extends React.Component {
           prevState => ({
             left: this.props.vertical
               ? 0
-              : this.getTargetLeft(-1, prevState.currentSlide),
+              : this.getTargetLeft(0, prevState.currentSlide),
             top: this.props.vertical
-              ? this.getTargetLeft(-1, prevState.currentSlide)
+              ? this.getTargetLeft(0, prevState.currentSlide)
               : 0,
             currentSlide: endSlide,
             isWrappingAround: true,
@@ -851,42 +851,58 @@ export default class Carousel extends React.Component {
   }
 
   getSlideTargetPosition(index, positionValue) {
-    const slidesToShow = this.state.frameWidth / this.state.slideWidth;
-    const targetPosition =
+    let targetPosition =
       (this.state.slideWidth + this.props.cellSpacing) * index;
-    const end =
-      (this.state.slideWidth + this.props.cellSpacing) * slidesToShow * -1;
+    const centerSlide = Math.abs(
+      Math.floor(positionValue / this.state.slideWidth)
+    );
+    if (this.props.wrapAround && index !== centerSlide) {
+      const slidesBefore = Math.floor((this.state.slideCount - 1) / 2);
+      const slidesAfter = this.state.slideCount - slidesBefore - 1;
+      const distanceFromCurrent = Math.abs(centerSlide - index);
 
-    if (
-      this.props.wrapAround &&
-      (this.state.isWrappingAround || this.state.dragging)
-    ) {
-      const slidesBefore = Math.ceil(positionValue / this.state.slideWidth);
-      if (this.state.slideCount - slidesBefore <= index) {
-        return (
+      if (index < centerSlide) {
+        if (distanceFromCurrent > slidesBefore) {
+          targetPosition =
+            (this.state.slideWidth + this.props.cellSpacing) *
+            (this.state.slideCount + index);
+        }
+      } else if (distanceFromCurrent > slidesAfter) {
+        targetPosition =
           (this.state.slideWidth + this.props.cellSpacing) *
           (this.state.slideCount - index) *
-          -1
-        );
+          -1;
       }
 
-      let slidesAfter = Math.ceil(
-        (Math.abs(positionValue) - Math.abs(end)) / this.state.slideWidth
-      );
+      // const slidesBefore = Math.ceil(positionValue / this.state.slideWidth);
+      // if (this.state.slideCount - slidesBefore <= index) {
+      //   return (
+      //     (this.state.slideWidth + this.props.cellSpacing) *
+      //     (this.state.slideCount - index) *
+      //     -1
+      //   );
+      // }
 
-      if (this.state.slideWidth !== 1) {
-        slidesAfter = Math.ceil(
-          (Math.abs(positionValue) - this.state.slideWidth) /
-            this.state.slideWidth
-        );
-      }
+      // const slidesToShow = this.state.frameWidth / this.state.slideWidth;
+      // const end =
+      //   (this.state.slideWidth + this.props.cellSpacing) * slidesToShow * -1;
+      // let slidesAfter = Math.ceil(
+      //   (Math.abs(positionValue) - Math.abs(end)) / this.state.slideWidth
+      // );
 
-      if (index <= slidesAfter - 1) {
-        return (
-          (this.state.slideWidth + this.props.cellSpacing) *
-          (this.state.slideCount + index)
-        );
-      }
+      // if (this.state.slideWidth !== 1) {
+      //   slidesAfter = Math.ceil(
+      //     (Math.abs(positionValue) - this.state.slideWidth) /
+      //       this.state.slideWidth
+      //   );
+      // }
+
+      // if (index <= slidesAfter - 1) {
+      //   return (
+      //     (this.state.slideWidth + this.props.cellSpacing) *
+      //     (this.state.slideCount + index)
+      //   );
+      // }
     }
 
     return targetPosition;

--- a/src/index.js
+++ b/src/index.js
@@ -113,11 +113,40 @@ export default class Carousel extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     const slideCount = React.Children.count(nextProps.children);
+    const slideCountChanged = slideCount !== this.state.slideCount;
+
     this.setState({ slideCount });
     if (slideCount <= this.state.currentSlide) {
       this.goToSlide(Math.max(slideCount - 1, 0));
     }
-    this.setDimensions(nextProps);
+
+    const updateDimensions =
+      slideCountChanged ||
+      ((curr, next, keys) => {
+        let shouldUpdate = false;
+
+        for (let i = 0; i < keys.length; i++) {
+          if (curr[keys[i]] !== next[keys[i]]) {
+            shouldUpdate = true;
+            break;
+          }
+        }
+
+        return shouldUpdate;
+      })(this.props, nextProps, [
+        'cellSpacing',
+        'vertical',
+        'slideWidth',
+        'slideHeight',
+        'heightMode',
+        'slidesToScroll',
+        'slidesToShow'
+      ]);
+
+    if (updateDimensions) {
+      this.setDimensions(nextProps);
+    }
+
     if (
       this.props.slideIndex !== nextProps.slideIndex &&
       nextProps.slideIndex !== this.state.currentSlide &&

--- a/src/index.js
+++ b/src/index.js
@@ -886,14 +886,14 @@ export default class Carousel extends React.Component {
         slidesAfter = temp;
       }
 
-      const distanceFromCurrent = Math.abs(startSlide - index);
+      const distanceFromStart = Math.abs(startSlide - index);
       if (index < startSlide) {
-        if (distanceFromCurrent > slidesBefore) {
+        if (distanceFromStart > slidesBefore) {
           targetPosition =
             (this.state.slideWidth + this.props.cellSpacing) *
             (this.state.slideCount + index);
         }
-      } else if (distanceFromCurrent > slidesAfter) {
+      } else if (distanceFromStart > slidesAfter) {
         targetPosition =
           (this.state.slideWidth + this.props.cellSpacing) *
           (this.state.slideCount - index) *

--- a/src/index.js
+++ b/src/index.js
@@ -850,18 +850,44 @@ export default class Carousel extends React.Component {
     };
   }
 
+  getSlideDirection(start, end, isWrapping) {
+    let direction = 0;
+    if (start === end) return direction;
+
+    if (isWrapping) {
+      direction = start < end ? -1 : 1;
+    } else {
+      direction = start < end ? 1 : -1;
+    }
+
+    return direction;
+  }
+
   getSlideTargetPosition(index, positionValue) {
     let targetPosition =
       (this.state.slideWidth + this.props.cellSpacing) * index;
-    const centerSlide = Math.abs(
-      Math.floor(positionValue / this.state.slideWidth)
+    const startSlide = Math.min(
+      Math.abs(Math.floor(positionValue / this.state.slideWidth)),
+      this.state.slideCount - 1
     );
-    if (this.props.wrapAround && index !== centerSlide) {
-      const slidesBefore = Math.floor((this.state.slideCount - 1) / 2);
-      const slidesAfter = this.state.slideCount - slidesBefore - 1;
-      const distanceFromCurrent = Math.abs(centerSlide - index);
 
-      if (index < centerSlide) {
+    if (this.props.wrapAround && index !== startSlide) {
+      const direction = this.getSlideDirection(
+        startSlide,
+        this.state.currentSlide,
+        this.state.isWrappingAround
+      );
+      let slidesBefore = Math.floor((this.state.slideCount - 1) / 2);
+      let slidesAfter = this.state.slideCount - slidesBefore - 1;
+
+      if (direction < 0) {
+        const temp = slidesBefore;
+        slidesBefore = slidesAfter;
+        slidesAfter = temp;
+      }
+
+      const distanceFromCurrent = Math.abs(startSlide - index);
+      if (index < startSlide) {
         if (distanceFromCurrent > slidesBefore) {
           targetPosition =
             (this.state.slideWidth + this.props.cellSpacing) *

--- a/src/index.js
+++ b/src/index.js
@@ -899,36 +899,6 @@ export default class Carousel extends React.Component {
           (this.state.slideCount - index) *
           -1;
       }
-
-      // const slidesBefore = Math.ceil(positionValue / this.state.slideWidth);
-      // if (this.state.slideCount - slidesBefore <= index) {
-      //   return (
-      //     (this.state.slideWidth + this.props.cellSpacing) *
-      //     (this.state.slideCount - index) *
-      //     -1
-      //   );
-      // }
-
-      // const slidesToShow = this.state.frameWidth / this.state.slideWidth;
-      // const end =
-      //   (this.state.slideWidth + this.props.cellSpacing) * slidesToShow * -1;
-      // let slidesAfter = Math.ceil(
-      //   (Math.abs(positionValue) - Math.abs(end)) / this.state.slideWidth
-      // );
-
-      // if (this.state.slideWidth !== 1) {
-      //   slidesAfter = Math.ceil(
-      //     (Math.abs(positionValue) - this.state.slideWidth) /
-      //       this.state.slideWidth
-      //   );
-      // }
-
-      // if (index <= slidesAfter - 1) {
-      //   return (
-      //     (this.state.slideWidth + this.props.cellSpacing) *
-      //     (this.state.slideCount + index)
-      //   );
-      // }
     }
 
     return targetPosition;

--- a/test/e2e/carousel.test.js
+++ b/test/e2e/carousel.test.js
@@ -301,7 +301,7 @@ describe('Nuka Carousel', () => {
           ['left', 'width']
         );
         const correctLeft = -parseFloat(styles.width);
-        expect(`${styles.left}`).toMatch(`${correctLeft}px`);
+        expect(`${approximately(styles.left, correctLeft)}`).toMatch('true');
       });
 
       it('should partially show first slide when on last slide.', async () => {
@@ -313,7 +313,6 @@ describe('Nuka Carousel', () => {
         );
         const slideCount = (await page.$$('.slider-slide')).length;
         const correctLeft = parseFloat(styles.width) * slideCount;
-        expect(`${styles.left}`).toMatch(`${correctLeft}px`);
         expect(`${approximately(styles.left, correctLeft)}`).toMatch('true');
       });
 

--- a/test/e2e/carousel.test.js
+++ b/test/e2e/carousel.test.js
@@ -221,6 +221,8 @@ describe('Nuka Carousel', () => {
       return Math.abs(parseFloat(a) - parseFloat(b)) < 0.25;
     };
 
+    const transitionSpeed = 500;
+
     beforeEach(async () => {
       await page.setViewport({
         width: 1024,
@@ -251,6 +253,7 @@ describe('Nuka Carousel', () => {
 
       it('should not partially show first slide when on last slide.', async () => {
         await expect(page).toClick('button', { text: '6' });
+        await page.waitFor(transitionSpeed); // need to let slide transition complete
         const styles = await page.evaluate(
           getStyles,
           '.slider-slide:first-child',
@@ -262,6 +265,7 @@ describe('Nuka Carousel', () => {
       it('should partially show previous and next slide when on a middle slide.', async () => {
         const slide = 3;
         await expect(page).toClick('button', { text: `${slide}` });
+        await page.waitFor(transitionSpeed); // need to let slide transition complete
 
         const prevSlide = slide - 1;
         const prevStyles = await page.evaluate(
@@ -306,6 +310,7 @@ describe('Nuka Carousel', () => {
 
       it('should partially show first slide when on last slide.', async () => {
         await expect(page).toClick('button', { text: '6' });
+        await page.waitFor(transitionSpeed); // need to let slide transition complete
         const styles = await page.evaluate(
           getStyles,
           '.slider-slide:first-child',
@@ -319,6 +324,7 @@ describe('Nuka Carousel', () => {
       it('should partially show previous and next slide when on a middle slide.', async () => {
         const slide = 3;
         await expect(page).toClick('button', { text: `${slide}` });
+        await page.waitFor(transitionSpeed); // need to let slide transition complete
 
         const prevSlide = slide - 1;
         const prevStyles = await page.evaluate(

--- a/test/e2e/carousel.test.js
+++ b/test/e2e/carousel.test.js
@@ -207,7 +207,7 @@ describe('Nuka Carousel', () => {
     });
   });
 
-  describe.only('Neighboring Slide Visibility and Slide Alignment', () => {
+  describe('Neighboring Slide Visibility and Slide Alignment', () => {
     const getStyles = (selector, keys) => {
       const e = document.querySelector(selector);
       const styles = window.getComputedStyle(e);

--- a/test/specs/carousel.test.js
+++ b/test/specs/carousel.test.js
@@ -408,6 +408,58 @@ describe('<Carousel />', () => {
       nextButton.simulate('click');
       expect(wrapper).toHaveState({ currentSlide: 0 });
     });
+
+    describe('#getSlideDirection', () => {
+      let instance;
+
+      beforeEach(async () => {
+        const wrapper = mount(
+          <Carousel>
+            <p>Slide 1</p>
+            <p>Slide 2</p>
+            <p>Slide 3</p>
+          </Carousel>
+        );
+        instance = wrapper.instance();
+      });
+
+      it('should return zero if start and end slide are the same regardless of isWrapping', () => {
+        expect(instance.getSlideDirection(2, 2, true)).toEqual(0);
+        expect(instance.getSlideDirection(2, 2, false)).toEqual(0);
+      });
+
+      it('should return -1 if isWrapping is true and start is less than end', () => {
+        const isWrapping = true;
+        const start = 0;
+        const end = 6;
+
+        expect(instance.getSlideDirection(start, end, isWrapping)).toEqual(-1);
+      });
+
+      it('should return 1 if isWrapping is true and start is greater than end', () => {
+        const isWrapping = true;
+        const start = 6;
+        const end = 0;
+
+        expect(instance.getSlideDirection(start, end, isWrapping)).toEqual(1);
+      });
+
+      it('should return 1 if isWrapping is false and start is less than end', () => {
+        const isWrapping = false;
+        const start = 0;
+        const end = 6;
+
+        expect(instance.getSlideDirection(start, end, isWrapping)).toEqual(1);
+      });
+
+      it('should return -1 if isWrapping is false and start is greater than end', () => {
+        const isWrapping = false;
+        const start = 6;
+        const end = 0;
+
+        expect(instance.getSlideDirection(start, end, isWrapping)).toEqual(-1);
+      });
+    });
   });
 
   describe('Controls', () => {


### PR DESCRIPTION
I'm re-working some of the wrapAround logic so the current slide always has slides positioned before and after to help prevent slides blinking into existence when cycling through them.

This is a PR will closes #324 , closes #194 , closes #340 