### PR TITLE
Adding in Fade Transitions to Nuka

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Hook to be called before a slide is changed.
 
 When displaying more than one slide, sets which position to anchor the current slide to.
 
+Is overridden to `left` when `transitionMode="fade"`.
+
 #### cellSpacing
 
 `React.PropTypes.number`
@@ -92,6 +94,12 @@ Enable mouse swipe/dragging
 
 Animation easing function. See valid easings here: [D3 Easing Functions](https://github.com/d3/d3-ease).
 
+#### edgeEasing
+
+`React.PropTypes.string`
+
+Animation easing function when swipe exceeds edge. See valid easings here: [D3 Easing Functions](https://github.com/d3/d3-ease).
+
 #### framePadding
 
 `React.PropTypes.string`
@@ -104,13 +112,7 @@ Used to set the margin of the slider frame. Accepts any string dimension value s
 
 Used to set overflow style property on slider frame. Defaults to `hidden`.
 
-#### edgeEasing
-
-`React.PropTypes.string`
-
-Animation easing function when swipe exceeds edge. See valid easings here: [D3 Easing Functions](https://github.com/d3/d3-ease).
-
-### heightMode
+#### heightMode
 
 `React.PropTypes.oneOf(['first', 'current', 'max'])`
 
@@ -166,6 +168,8 @@ Manually set the index of the slide to be shown.
 
 Slides to show at once.
 
+Will be cast to an `integer` when `transitionMode="fade"`.
+
 #### slidesToScroll
 
 ```
@@ -176,6 +180,8 @@ slidesToScroll: React.PropTypes.oneOfType([
 ```
 
 Slides to scroll at once. Set to `"auto"` to always scroll the current number of visible slides.
+
+Is overridden to `slidesToShow` when `transitionMode="fade"`.
 
 #### slideWidth
 
@@ -194,6 +200,12 @@ Animation duration.
 `React.PropTypes.bool`
 
 Enable touch swipe/dragging
+
+#### transitionMode
+
+`React.PropTypes.oneOf(['scroll', 'fade'])`
+
+Set the way slides transition from one to the next. Defaults to `scroll`.
 
 #### vertical
 

--- a/demo/app.js
+++ b/demo/app.js
@@ -13,7 +13,8 @@ class App extends React.Component {
       wrapAround: false,
       underlineHeader: false,
       slidesToShow: 1.0,
-      cellAlign: 'left'
+      cellAlign: 'left',
+      transitionMode: 'scroll'
     };
 
     this.handleImageClick = this.handleImageClick.bind(this);
@@ -27,6 +28,7 @@ class App extends React.Component {
     return (
       <div style={{ width: '50%', margin: 'auto' }}>
         <Carousel
+          transitionMode={this.state.transitionMode}
           cellAlign={this.state.cellAlign}
           slidesToShow={this.state.slidesToShow}
           wrapAround={this.state.wrapAround}
@@ -77,6 +79,16 @@ class App extends React.Component {
             </button>
             <button
               onClick={() =>
+                this.setState({
+                  transitionMode:
+                    this.state.transitionMode === 'fade' ? 'scroll' : 'fade'
+                })
+              }
+            >
+              Toggle Fade {this.state.transitionMode === 'fade' ? 'Off' : 'On'}
+            </button>
+            <button
+              onClick={() =>
                 this.setState(prevState => ({
                   wrapAround: !prevState.wrapAround
                 }))
@@ -86,32 +98,34 @@ class App extends React.Component {
             </button>
           </div>
         </div>
-        <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-          {this.state.slidesToShow > 1.0 && (
-            <div>
-              <button onClick={() => this.setState({ cellAlign: 'left' })}>
-                Left
-              </button>
-              <button onClick={() => this.setState({ cellAlign: 'center' })}>
-                Center
-              </button>
-              <button onClick={() => this.setState({ cellAlign: 'right' })}>
-                Right
+        {this.state.transitionMode !== 'fade' && (
+          <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+            {this.state.slidesToShow > 1.0 && (
+              <div>
+                <button onClick={() => this.setState({ cellAlign: 'left' })}>
+                  Left
+                </button>
+                <button onClick={() => this.setState({ cellAlign: 'center' })}>
+                  Center
+                </button>
+                <button onClick={() => this.setState({ cellAlign: 'right' })}>
+                  Right
+                </button>
+              </div>
+            )}
+            <div style={{ marginLeft: 'auto' }}>
+              <button
+                onClick={() =>
+                  this.setState({
+                    slidesToShow: this.state.slidesToShow > 1.0 ? 1.0 : 1.25
+                  })
+                }
+              >
+                Toggle Partially Visible Slides
               </button>
             </div>
-          )}
-          <div style={{ marginLeft: 'auto' }}>
-            <button
-              onClick={() =>
-                this.setState({
-                  slidesToShow: this.state.slidesToShow > 1.0 ? 1.0 : 1.25
-                })
-              }
-            >
-              Toggle Partially Visible Slides
-            </button>
           </div>
-        </div>
+        )}
       </div>
     );
   }

--- a/src/all-transitions.js
+++ b/src/all-transitions.js
@@ -1,0 +1,7 @@
+import ScrollTransition from './transitions/scroll-transition';
+import FadeTransition from './transitions/fade-transition';
+
+export default {
+  fade: FadeTransition,
+  scroll: ScrollTransition
+};

--- a/src/index.js
+++ b/src/index.js
@@ -944,7 +944,8 @@ export default class Carousel extends React.Component {
       cellSpacing: this.props.cellSpacing,
       vertical: this.props.vertical,
       dragging: this.props.dragging,
-      wrapAround: this.props.wrapAround
+      wrapAround: this.props.wrapAround,
+      slidesToShow: this.props.slidesToShow
     };
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import ExecutionEnvironment from 'exenv';
 import Animate from 'react-move/Animate';
 import * as easing from 'd3-ease';
 import { PagingDots, PreviousButton, NextButton } from './default-controls';
-import ScrollTransition from './transitions/scroll-transition';
+import Transitions from './all-transitions';
 
 const addEvent = function(elem, type, eventHandle) {
   if (elem === null || typeof elem === 'undefined') {
@@ -985,6 +985,7 @@ export default class Carousel extends React.Component {
     const frameStyles = this.getFrameStyles();
     const touchEvents = this.getTouchEvents();
     const mouseEvents = this.getMouseEvents();
+    const TransitionControl = Transitions[this.props.transitionMode];
 
     return (
       <div
@@ -1010,13 +1011,13 @@ export default class Carousel extends React.Component {
               {...mouseEvents}
               onClick={this.handleClick}
             >
-              <ScrollTransition
+              <TransitionControl
                 {...this.getTransitionProps()}
                 deltaX={tx}
                 deltaY={ty}
               >
                 {this.props.children}
-              </ScrollTransition>
+              </TransitionControl>
             </div>
           )}
         />
@@ -1045,6 +1046,7 @@ Carousel.propTypes = {
   frameOverflow: PropTypes.string,
   framePadding: PropTypes.string,
   heightMode: PropTypes.oneOf(['first', 'current', 'max']),
+  transitionMode: PropTypes.oneOf(['scroll', 'fade']),
   initialSlideHeight: PropTypes.number,
   initialSlideWidth: PropTypes.number,
   onResize: PropTypes.func,
@@ -1084,6 +1086,7 @@ Carousel.defaultProps = {
   framePadding: '0px',
   frameOverflow: 'hidden',
   heightMode: 'first',
+  transitionMode: 'scroll',
   onResize() {},
   slideIndex: 0,
   slidesToScroll: 1,

--- a/src/index.js
+++ b/src/index.js
@@ -753,13 +753,7 @@ export default class Carousel extends React.Component {
 
   getSlideHeight(props, childNodes = []) {
     const { heightMode, vertical } = props;
-    // in 'fade' mode, non-visible slides have height of 0
-    // so to get height of "firstSlide" we'll just use current
-    const firstSlide =
-      this.props.transitionMode === 'fade'
-        ? childNodes[this.state.currentSlide]
-        : childNodes[0];
-
+    const firstSlide = childNodes[0];
     if (firstSlide && heightMode === 'first') {
       return vertical
         ? firstSlide.offsetHeight * this.state.slidesToShow

--- a/src/transitions/fade-transition.js
+++ b/src/transitions/fade-transition.js
@@ -118,7 +118,7 @@ export default class FadeTransition extends React.Component {
       slideA = this.fadeFromSlide;
       slideB = this.props.currentSlide;
     }
-    console.log(`${slideA} | ${slideB} | ${fade}`);
+
     const slideAInfo = {
       key: this.getSlideIndex(
         slideA,

--- a/src/transitions/fade-transition.js
+++ b/src/transitions/fade-transition.js
@@ -53,13 +53,13 @@ export default class FadeTransition extends React.Component {
     });
   }
 
-  getSlideStyles(index, opacity) {
-    return opacity[index]
+  getSlideStyles(index, data) {
+    return data[index]
       ? {
           position: 'absolute',
-          left: 0,
+          left: data[index].left,
           top: 0,
-          opacity: opacity[index],
+          opacity: data[index].opacity,
           display: 'block',
           listStyleType: 'none',
           verticalAlign: 'top',
@@ -118,27 +118,46 @@ export default class FadeTransition extends React.Component {
       slideA = this.fadeFromSlide;
       slideB = this.props.currentSlide;
     }
+    console.log(`${slideA} | ${slideB} | ${fade}`);
+    const slideAInfo = {
+      key: this.getSlideIndex(
+        slideA,
+        this.props.slideCount,
+        this.props.wrapAround
+      ),
+      raw: slideA
+    };
+
+    const slideBInfo = {
+      key: this.getSlideIndex(
+        slideB,
+        this.props.slideCount,
+        this.props.wrapAround
+      ),
+      raw: slideB
+    };
 
     const opacity = this.getSlideOpacity(
-      {
-        key: this.getSlideIndex(
-          slideA,
-          this.props.slideCount,
-          this.props.wrapAround
-        ),
-        raw: slideA
-      },
-      {
-        key: this.getSlideIndex(
-          slideB,
-          this.props.slideCount,
-          this.props.wrapAround
-        ),
-        raw: slideB
-      },
-      fade
+      slideAInfo,
+      slideBInfo,
+      fade,
+      this.props.slidesToShow
     );
-    const children = this.formatChildren(this.props.children, opacity);
+
+    const data = {};
+    for (let i = 0; i < this.props.slidesToShow; i++) {
+      data[slideAInfo.key + i] = {
+        opacity: opacity[slideAInfo.key],
+        left: this.props.slideWidth * i
+      };
+
+      data[slideBInfo.key + i] = {
+        opacity: opacity[slideBInfo.key],
+        left: this.props.slideWidth * i
+      };
+    }
+
+    const children = this.formatChildren(this.props.children, data);
 
     return (
       <ul className="slider-list" style={this.getContainerStyles()}>
@@ -161,7 +180,8 @@ FadeTransition.propTypes = {
   cellSpacing: PropTypes.number,
   vertical: PropTypes.bool,
   dragging: PropTypes.bool,
-  wrapAround: PropTypes.bool
+  wrapAround: PropTypes.bool,
+  slidesToShow: PropTypes.number
 };
 
 FadeTransition.defaultProps = {
@@ -177,5 +197,6 @@ FadeTransition.defaultProps = {
   cellSpacing: 0,
   vertical: false,
   dragging: false,
-  wrapAround: false
+  wrapAround: false,
+  slidesToShow: 1
 };

--- a/src/transitions/fade-transition.js
+++ b/src/transitions/fade-transition.js
@@ -61,28 +61,25 @@ export default class FadeTransition extends React.Component {
   }
 
   getSlideStyles(index, data) {
-    return data[index]
-      ? {
-          position: 'absolute',
-          left: data[index].left,
-          top: 0,
-          opacity: data[index].opacity,
-          display: 'block',
-          listStyleType: 'none',
-          verticalAlign: 'top',
-          width: this.props.slideWidth,
-          height: 'auto',
-          minHeight: '100%',
-          boxSizing: 'border-box',
-          MozBoxSizing: 'border-box',
-          marginLeft: this.props.cellSpacing / 2,
-          marginRight: this.props.cellSpacing / 2,
-          marginTop: 'auto',
-          marginBottom: 'auto'
-        }
-      : {
-          display: 'none'
-        };
+    return {
+      position: 'absolute',
+      visibility: data[index] ? 'inherit' : 'hidden',
+      left: data[index] ? data[index].left : 0,
+      top: 0,
+      opacity: data[index] ? data[index].opacity : 0,
+      display: 'block',
+      listStyleType: 'none',
+      verticalAlign: 'top',
+      width: this.props.slideWidth,
+      height: 'auto',
+      minHeight: '100%',
+      boxSizing: 'border-box',
+      MozBoxSizing: 'border-box',
+      marginLeft: this.props.cellSpacing / 2,
+      marginRight: this.props.cellSpacing / 2,
+      marginTop: 'auto',
+      marginBottom: 'auto'
+    };
   }
 
   getContainerStyles() {

--- a/src/transitions/fade-transition.js
+++ b/src/transitions/fade-transition.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default class FadeTransition extends React.Component {
+  render() {
+    const fadePosition =
+      -(this.props.deltaX || this.props.deltaY) / this.props.slideWidth;
+
+    return <h1>{fadePosition}</h1>;
+  }
+}
+
+FadeTransition.propTypes = {
+  deltaX: PropTypes.number,
+  deltaY: PropTypes.number,
+  slideWidth: PropTypes.number,
+  slideHeight: PropTypes.number,
+  slideCount: PropTypes.number,
+  currentSlide: PropTypes.number,
+  isWrappingAround: PropTypes.bool,
+  top: PropTypes.number,
+  left: PropTypes.number,
+  cellSpacing: PropTypes.number,
+  vertical: PropTypes.bool,
+  dragging: PropTypes.bool,
+  wrapAround: PropTypes.bool
+};
+
+FadeTransition.defaultProps = {
+  deltaX: 0,
+  deltaY: 0,
+  slideWidth: 0,
+  slideHeight: 0,
+  slideCount: 0,
+  currentSlide: 0,
+  isWrappingAround: false,
+  top: 0,
+  left: 0,
+  cellSpacing: 0,
+  vertical: false,
+  dragging: false,
+  wrapAround: false
+};

--- a/src/transitions/fade-transition.js
+++ b/src/transitions/fade-transition.js
@@ -2,11 +2,96 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 export default class FadeTransition extends React.Component {
-  render() {
-    const fadePosition =
-      -(this.props.deltaX || this.props.deltaY) / this.props.slideWidth;
+  getSlideIndex(position, count) {
+    return position > 0 ? position % count : (count + position % count) % count;
+  }
 
-    return <h1>{fadePosition}</h1>;
+  getSlideOpacity(fade) {
+    const active = {};
+    const floor = Math.floor(fade);
+    const ceil = Math.ceil(fade);
+    const slideA = this.getSlideIndex(floor, this.props.slideCount);
+
+    if (floor === ceil) {
+      active[slideA] = 1;
+    } else {
+      const slideB = this.getSlideIndex(ceil, this.props.slideCount);
+      active[slideA] = ceil - fade;
+      active[slideB] = fade - floor;
+    }
+
+    return active;
+  }
+
+  formatChildren(children, fade) {
+    const opacity = this.getSlideOpacity(fade);
+
+    return React.Children.map(children, (child, index) => {
+      return (
+        <li
+          className="slider-slide"
+          style={this.getSlideStyles(index, fade, opacity)}
+          key={index}
+        >
+          {child}
+        </li>
+      );
+    });
+  }
+
+  getSlideStyles(index, fade, opacity) {
+    return opacity[index]
+      ? {
+          position: 'absolute',
+          left: 0,
+          top: 0,
+          opacity: opacity[index],
+          display: 'block',
+          listStyleType: 'none',
+          verticalAlign: 'top',
+          width: this.props.slideWidth,
+          height: 'auto',
+          minHeight: '100%',
+          boxSizing: 'border-box',
+          MozBoxSizing: 'border-box',
+          marginLeft: this.props.cellSpacing / 2,
+          marginRight: this.props.cellSpacing / 2,
+          marginTop: 'auto',
+          marginBottom: 'auto'
+        }
+      : {
+          display: 'none'
+        };
+  }
+
+  getContainerStyles() {
+    const width = this.props.slideWidth * this.props.slidesToShow;
+
+    return {
+      display: 'block',
+      margin: this.props.vertical
+        ? `${this.props.cellSpacing / 2 * -1}px 0px`
+        : `0px ${this.props.cellSpacing / 2 * -1}px`,
+      padding: 0,
+      height: this.props.slideHeight,
+      width,
+      cursor: this.props.dragging === true ? 'pointer' : 'inherit',
+      boxSizing: 'border-box',
+      MozBoxSizing: 'border-box',
+      touchAction: 'none'
+    };
+  }
+
+  render() {
+    const fade =
+      -(this.props.deltaX || this.props.deltaY) / this.props.slideWidth;
+    const children = this.formatChildren(this.props.children, fade);
+
+    return (
+      <ul className="slider-list" style={this.getContainerStyles()}>
+        {children}
+      </ul>
+    );
   }
 }
 

--- a/src/transitions/fade-transition.js
+++ b/src/transitions/fade-transition.js
@@ -7,33 +7,17 @@ export default class FadeTransition extends React.Component {
     this.fadeFromSlide = props.currentSlide;
   }
 
-  getSlideDistance(slideA, slideB, count, wrapAround) {
-    if (wrapAround) {
-      return count - Math.abs(slideA - slideB) % count;
-    } else {
-      return Math.abs(slideA - slideB);
-    }
-  }
-
-  getSlideIndex(position, count, wrapAround) {
-    if (wrapAround) {
-      return position > 0
-        ? position % count
-        : (count + position % count) % count;
-    } else {
-      return Math.min(Math.max(0, position), count - 1);
-    }
-  }
-
   getSlideOpacity(slideAInfo, slideBInfo, inBetweenPosition) {
     const opacity = {};
 
     if (slideAInfo.key === slideBInfo.key) {
       opacity[slideAInfo.key] = 1;
     } else {
-      const distance = slideAInfo.raw - slideBInfo.raw;
-      opacity[slideAInfo.key] = (inBetweenPosition - slideBInfo.raw) / distance;
-      opacity[slideBInfo.key] = (slideAInfo.raw - inBetweenPosition) / distance;
+      const distance = slideAInfo.target - slideBInfo.target;
+      opacity[slideAInfo.key] =
+        (inBetweenPosition - slideBInfo.target) / distance;
+      opacity[slideBInfo.key] =
+        (slideAInfo.target - inBetweenPosition) / distance;
     }
 
     return opacity;
@@ -100,59 +84,46 @@ export default class FadeTransition extends React.Component {
     const fade =
       -(this.props.deltaX || this.props.deltaY) / this.props.slideWidth;
 
-    let slideA = Math.floor(fade);
-    let slideB = Math.ceil(fade);
-
-    if (slideA === slideB) {
-      this.fadeFromSlide = slideA;
+    if (parseInt(fade) === fade) {
+      this.fadeFromSlide = fade;
     }
 
-    if (
-      this.getSlideDistance(
-        this.props.currentSlide,
-        this.fadeFromSlide,
-        this.props.slideCount,
-        this.props.isWrappingAround
-      ) > 1
-    ) {
-      slideA = this.fadeFromSlide;
-      slideB = this.props.currentSlide;
-    }
-
-    const slideAInfo = {
-      key: this.getSlideIndex(
-        slideA,
-        this.props.slideCount,
-        this.props.wrapAround
-      ),
-      raw: slideA
+    const fadeFromInfo = {
+      key: this.fadeFromSlide,
+      target: this.fadeFromSlide
     };
 
-    const slideBInfo = {
-      key: this.getSlideIndex(
-        slideB,
-        this.props.slideCount,
-        this.props.wrapAround
-      ),
-      raw: slideB
+    let targetFadeTo = this.props.currentSlide;
+    if (this.fadeFromSlide > fade && this.fadeFromSlide === 0) {
+      targetFadeTo = this.fadeFromSlide - this.props.slidesToShow;
+    } else if (
+      this.fadeFromSlide < fade &&
+      this.fadeFromSlide + this.props.slidesToShow > this.props.slideCount - 1
+    ) {
+      targetFadeTo = this.fadeFromSlide + this.props.slidesToShow;
+    }
+
+    const fadeToInfo = {
+      key: this.props.currentSlide,
+      target: targetFadeTo
     };
 
     const opacity = this.getSlideOpacity(
-      slideAInfo,
-      slideBInfo,
+      fadeFromInfo,
+      fadeToInfo,
       fade,
       this.props.slidesToShow
     );
 
     const data = {};
     for (let i = 0; i < this.props.slidesToShow; i++) {
-      data[slideAInfo.key + i] = {
-        opacity: opacity[slideAInfo.key],
+      data[fadeFromInfo.key + i] = {
+        opacity: opacity[fadeFromInfo.key],
         left: this.props.slideWidth * i
       };
 
-      data[slideBInfo.key + i] = {
-        opacity: opacity[slideBInfo.key],
+      data[fadeToInfo.key + i] = {
+        opacity: opacity[fadeToInfo.key],
         left: this.props.slideWidth * i
       };
     }

--- a/src/transitions/fade-transition.js
+++ b/src/transitions/fade-transition.js
@@ -21,26 +21,26 @@ export default class FadeTransition extends React.Component {
     });
   }
 
-  getSlideOpacityAndLeftMap(fadeFrom, fade) {
-    // Figure out which slide to fade to
-    let fadeTo = this.props.currentSlide;
+  getSlideOpacityAndLeftMap(fadeFrom, fadeTo, fade) {
+    // Figure out which position to fade to
+    let fadeToPosition = fadeTo;
     if (fadeFrom > fade && fadeFrom === 0) {
-      fadeTo = fadeFrom - this.props.slidesToShow;
+      fadeToPosition = fadeFrom - this.props.slidesToShow;
     } else if (
       fadeFrom < fade &&
       fadeFrom + this.props.slidesToShow > this.props.slideCount - 1
     ) {
-      fadeTo = fadeFrom + this.props.slidesToShow;
+      fadeToPosition = fadeFrom + this.props.slidesToShow;
     }
 
     // Calculate opacity for active slides
     const opacity = {};
-    if (fadeFrom === this.props.currentSlide) {
+    if (fadeFrom === fadeTo) {
       opacity[fadeFrom] = 1;
     } else {
-      const distance = fadeFrom - fadeTo;
-      opacity[fadeFrom] = (fade - fadeTo) / distance;
-      opacity[this.props.currentSlide] = (fadeFrom - fade) / distance;
+      const distance = fadeFrom - fadeToPosition;
+      opacity[fadeFrom] = (fade - fadeToPosition) / distance;
+      opacity[fadeTo] = (fadeFrom - fade) / distance;
     }
 
     // Calculate left for slides and merge in opacity
@@ -51,8 +51,8 @@ export default class FadeTransition extends React.Component {
         left: this.props.slideWidth * i
       };
 
-      map[this.props.currentSlide + i] = {
-        opacity: opacity[this.props.currentSlide],
+      map[fadeTo + i] = {
+        opacity: opacity[fadeTo],
         left: this.props.slideWidth * i
       };
     }
@@ -113,6 +113,7 @@ export default class FadeTransition extends React.Component {
 
     const opacityAndLeftMap = this.getSlideOpacityAndLeftMap(
       this.fadeFromSlide,
+      this.props.currentSlide,
       fade
     );
 

--- a/src/transitions/scroll-transition.js
+++ b/src/transitions/scroll-transition.js
@@ -1,0 +1,177 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default class ScrollTransition extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.getListStyles = this.getListStyles.bind(this);
+  }
+
+  getSlideDirection(start, end, isWrapping) {
+    let direction = 0;
+    if (start === end) return direction;
+
+    if (isWrapping) {
+      direction = start < end ? -1 : 1;
+    } else {
+      direction = start < end ? 1 : -1;
+    }
+
+    return direction;
+  }
+
+  getSlideTargetPosition(index, positionValue) {
+    let targetPosition =
+      (this.props.slideWidth + this.props.cellSpacing) * index;
+    const startSlide = Math.min(
+      Math.abs(Math.floor(positionValue / this.props.slideWidth)),
+      this.props.slideCount - 1
+    );
+
+    if (this.props.wrapAround && index !== startSlide) {
+      const direction = this.getSlideDirection(
+        startSlide,
+        this.props.currentSlide,
+        this.props.isWrappingAround
+      );
+      let slidesBefore = Math.floor((this.props.slideCount - 1) / 2);
+      let slidesAfter = this.props.slideCount - slidesBefore - 1;
+
+      if (direction < 0) {
+        const temp = slidesBefore;
+        slidesBefore = slidesAfter;
+        slidesAfter = temp;
+      }
+
+      const distanceFromStart = Math.abs(startSlide - index);
+      if (index < startSlide) {
+        if (distanceFromStart > slidesBefore) {
+          targetPosition =
+            (this.props.slideWidth + this.props.cellSpacing) *
+            (this.props.slideCount + index);
+        }
+      } else if (distanceFromStart > slidesAfter) {
+        targetPosition =
+          (this.props.slideWidth + this.props.cellSpacing) *
+          (this.props.slideCount - index) *
+          -1;
+      }
+    }
+
+    return targetPosition;
+  }
+
+  formatChildren(children) {
+    const positionValue = this.props.vertical
+      ? this.props.top
+      : this.props.left;
+    return React.Children.map(children, (child, index) => {
+      return (
+        <li
+          className="slider-slide"
+          style={this.getSlideStyles(index, positionValue)}
+          key={index}
+        >
+          {child}
+        </li>
+      );
+    });
+  }
+
+  getSlideStyles(index, positionValue) {
+    const targetPosition = this.getSlideTargetPosition(index, positionValue);
+    return {
+      position: 'absolute',
+      left: this.props.vertical ? 0 : targetPosition,
+      top: this.props.vertical ? targetPosition : 0,
+      display: this.props.vertical ? 'block' : 'inline-block',
+      listStyleType: 'none',
+      verticalAlign: 'top',
+      width: this.props.vertical ? '100%' : this.props.slideWidth,
+      height: 'auto',
+      minHeight: '100%',
+      boxSizing: 'border-box',
+      MozBoxSizing: 'border-box',
+      marginLeft: this.props.vertical ? 'auto' : this.props.cellSpacing / 2,
+      marginRight: this.props.vertical ? 'auto' : this.props.cellSpacing / 2,
+      marginTop: this.props.vertical ? this.props.cellSpacing / 2 : 'auto',
+      marginBottom: this.props.vertical ? this.props.cellSpacing / 2 : 'auto'
+    };
+  }
+
+  getListStyles(styles) {
+    const { deltaX, deltaY } = styles;
+    const listWidth =
+      this.props.slideWidth * React.Children.count(this.props.children);
+    const spacingOffset =
+      this.props.cellSpacing * React.Children.count(this.props.children);
+    const transform = `translate3d(${deltaX}px, ${deltaY}px, 0)`;
+    return {
+      transform,
+      WebkitTransform: transform,
+      msTransform: `translate(${deltaX}px, ${deltaY}px)`,
+      position: 'relative',
+      display: 'block',
+      margin: this.props.vertical
+        ? `${this.props.cellSpacing / 2 * -1}px 0px`
+        : `0px ${this.props.cellSpacing / 2 * -1}px`,
+      padding: 0,
+      height: this.props.vertical
+        ? listWidth + spacingOffset
+        : this.props.slideHeight,
+      width: this.props.vertical ? 'auto' : listWidth + spacingOffset,
+      cursor: this.props.dragging === true ? 'pointer' : 'inherit',
+      boxSizing: 'border-box',
+      MozBoxSizing: 'border-box',
+      touchAction: 'none'
+    };
+  }
+
+  render() {
+    const children = this.formatChildren(this.props.children);
+    const deltaX = this.props.deltaX;
+    const deltaY = this.props.deltaY;
+
+    return (
+      <ul
+        className="slider-list"
+        style={this.getListStyles({ deltaX, deltaY })}
+      >
+        {children}
+      </ul>
+    );
+  }
+}
+
+ScrollTransition.propTypes = {
+  deltaX: PropTypes.number,
+  deltaY: PropTypes.number,
+  slideWidth: PropTypes.number,
+  slideHeight: PropTypes.number,
+  slideCount: PropTypes.number,
+  currentSlide: PropTypes.number,
+  isWrappingAround: PropTypes.bool,
+  top: PropTypes.number,
+  left: PropTypes.number,
+  cellSpacing: PropTypes.number,
+  vertical: PropTypes.bool,
+  dragging: PropTypes.bool,
+  wrapAround: PropTypes.bool
+};
+
+ScrollTransition.defaultProps = {
+  deltaX: 0,
+  deltaY: 0,
+  slideWidth: 0,
+  slideHeight: 0,
+  slideCount: 0,
+  currentSlide: 0,
+  isWrappingAround: false,
+  top: 0,
+  left: 0,
+  cellSpacing: 0,
+  vertical: false,
+  dragging: false,
+  wrapAround: false
+};

--- a/test/e2e/carousel.test.js
+++ b/test/e2e/carousel.test.js
@@ -67,7 +67,7 @@ describe('Nuka Carousel', () => {
 
       defaultNavigationAndLoading();
 
-      it('should set currentSlide opacity to 1 and display to block', async () => {
+      it('should set currentSlide opacity to 1 and visibility to inherit', async () => {
         const activeSlide = 3;
         await expect(page).toClick('button', { text: `${activeSlide}` });
         await page.waitFor(600); // need to let slide transition complete
@@ -75,14 +75,14 @@ describe('Nuka Carousel', () => {
         const styles = await page.evaluate(
           getStyles,
           `.slider-slide:nth-child(${activeSlide})`,
-          ['opacity', 'display']
+          ['opacity', 'visibility']
         );
 
         await expect(styles.opacity).toMatch('1');
-        await expect(styles.display).toMatch('block');
+        await expect(styles.visibility).toMatch('visible');
       });
 
-      it('should set hidden slides display to "none"', async () => {
+      it('should set hidden slides visibility to hidden', async () => {
         const activeSlide = 4;
         const slideCount = 6;
         await expect(page).toClick('button', { text: `${activeSlide}` });
@@ -93,10 +93,10 @@ describe('Nuka Carousel', () => {
             const styles = await page.evaluate(
               getStyles,
               `.slider-slide:nth-child(${i + 1})`,
-              ['display']
+              ['visibility']
             );
 
-            await expect(styles.display).toMatch('none');
+            await expect(styles.visibility).toMatch('hidden');
           }
         }
       });

--- a/test/specs/carousel.test.js
+++ b/test/specs/carousel.test.js
@@ -299,7 +299,7 @@ describe('<Carousel />', () => {
     });
   });
 
-  describe('transitionModes - scroll', () => {
+  describe('transitionModes', () => {
     describe('scroll', () => {
       it('should default to scroll mode', () => {
         const wrapper = mount(

--- a/test/specs/carousel.test.js
+++ b/test/specs/carousel.test.js
@@ -299,6 +299,134 @@ describe('<Carousel />', () => {
     });
   });
 
+  describe('transitionModes - scroll', () => {
+    describe('scroll', () => {
+      it('should default to scroll mode', () => {
+        const wrapper = mount(
+          <Carousel>
+            <p>Slide 1</p>
+          </Carousel>
+        );
+
+        expect(wrapper).toHaveProp({ transitionMode: 'scroll' });
+      });
+
+      it('should allow users to set fractional slidesToShow', () => {
+        const wrapper = mount(
+          <Carousel slidesToShow={1.5}>
+            <p>Slide 1</p>
+          </Carousel>
+        );
+
+        expect(wrapper).toHaveState({ slidesToShow: 1.5 });
+      });
+
+      it('should not set slidesToScroll automatically equal to slidesToShow', () => {
+        const wrapper = mount(
+          <Carousel slidesToShow={2}>
+            <p>Slide 1</p>
+          </Carousel>
+        );
+
+        expect(wrapper).toHaveState({ slidesToScroll: 1 });
+      });
+
+      it('should set cellAlign state to prop value', () => {
+        const centerWrapper = mount(
+          <Carousel cellAlign="center">
+            <p>Slide 1</p>
+          </Carousel>
+        );
+
+        expect(centerWrapper).toHaveState({ cellAlign: 'center' });
+
+        const rightWrapper = mount(
+          <Carousel cellAlign="right">
+            <p>Slide 1</p>
+          </Carousel>
+        );
+
+        expect(rightWrapper).toHaveState({ cellAlign: 'right' });
+
+        const defaultWrapper = mount(
+          <Carousel>
+            <p>Slide 1</p>
+          </Carousel>
+        );
+
+        expect(defaultWrapper).toHaveState({ cellAlign: 'left' });
+      });
+    });
+
+    describe('fade', () => {
+      it('should allow user to set transitionMode to fade', () => {
+        const wrapper = mount(
+          <Carousel transitionMode="fade">
+            <p>Slide 1</p>
+          </Carousel>
+        );
+
+        expect(wrapper).toHaveProp({ transitionMode: 'fade' });
+      });
+
+      it('should not allow users to set fractional slidesToShow', () => {
+        const wrapper = mount(
+          <Carousel transitionMode="fade" slidesToShow={1.5}>
+            <p>Slide 1</p>
+          </Carousel>
+        );
+
+        expect(wrapper).toHaveState({ slidesToShow: 1 });
+      });
+
+      it('should default slidesToScroll equal to slidesToShow', () => {
+        const wrapper = mount(
+          <Carousel transitionMode="fade" slidesToShow={2}>
+            <p>Slide 1</p>
+          </Carousel>
+        );
+
+        expect(wrapper).toHaveState({ slidesToScroll: 2 });
+      });
+
+      it('should override slidesToScroll value with slidesToShow value', () => {
+        const wrapper = mount(
+          <Carousel transitionMode="fade" slidesToShow={2} slidesToScroll={3}>
+            <p>Slide 1</p>
+          </Carousel>
+        );
+
+        expect(wrapper).toHaveState({ slidesToScroll: 2 });
+      });
+
+      it('should set cellAlign to "left" regardless of prop', () => {
+        const centerWrapper = mount(
+          <Carousel transitionMode="fade" cellAlign="center">
+            <p>Slide 1</p>
+          </Carousel>
+        );
+
+        expect(centerWrapper).toHaveState({ cellAlign: 'left' });
+
+        const rightWrapper = mount(
+          <Carousel transitionMode="fade" cellAlign="right">
+            <p>Slide 1</p>
+          </Carousel>
+        );
+
+        expect(rightWrapper).toHaveState({ cellAlign: 'left' });
+
+        const defaultWrapper = mount(
+          <Carousel transitionMode="fade">
+            <p>Slide 1</p>
+          </Carousel>
+        );
+
+        expect(defaultWrapper).toHaveState({ cellAlign: 'left' });
+      });
+    });
+  });
+
   describe('methods', () => {
     it('should call setDimensions callback after setState', () => {
       const onResizeSpy = jest.fn();

--- a/test/specs/carousel.test.js
+++ b/test/specs/carousel.test.js
@@ -286,12 +286,14 @@ describe('<Carousel />', () => {
       const elems = ['Slide 2', 'Slide 3', 'Slide 4'];
       const wrapper = mount(
         <Carousel>
-          <p>Static Slide</p>
+          <p key="Static Slide">Static Slide</p>
           {elems.map(e => `<p key={${e}}>${e}</e>`)}
         </Carousel>
       );
       expect(wrapper).toHaveState({ slideCount: 4 });
-      const children = wrapper.props().children.concat(<p>Slide 4</p>);
+      const children = wrapper
+        .props()
+        .children.concat(<p key="Slide 5">Slide 4</p>);
       wrapper.setProps({ children });
       expect(wrapper).toHaveState({ slideCount: 5 });
     });
@@ -407,58 +409,6 @@ describe('<Carousel />', () => {
       expect(wrapper).toHaveState({ currentSlide: 2 });
       nextButton.simulate('click');
       expect(wrapper).toHaveState({ currentSlide: 0 });
-    });
-
-    describe('#getSlideDirection', () => {
-      let instance;
-
-      beforeEach(async () => {
-        const wrapper = mount(
-          <Carousel>
-            <p>Slide 1</p>
-            <p>Slide 2</p>
-            <p>Slide 3</p>
-          </Carousel>
-        );
-        instance = wrapper.instance();
-      });
-
-      it('should return zero if start and end slide are the same regardless of isWrapping', () => {
-        expect(instance.getSlideDirection(2, 2, true)).toEqual(0);
-        expect(instance.getSlideDirection(2, 2, false)).toEqual(0);
-      });
-
-      it('should return -1 if isWrapping is true and start is less than end', () => {
-        const isWrapping = true;
-        const start = 0;
-        const end = 6;
-
-        expect(instance.getSlideDirection(start, end, isWrapping)).toEqual(-1);
-      });
-
-      it('should return 1 if isWrapping is true and start is greater than end', () => {
-        const isWrapping = true;
-        const start = 6;
-        const end = 0;
-
-        expect(instance.getSlideDirection(start, end, isWrapping)).toEqual(1);
-      });
-
-      it('should return 1 if isWrapping is false and start is less than end', () => {
-        const isWrapping = false;
-        const start = 0;
-        const end = 6;
-
-        expect(instance.getSlideDirection(start, end, isWrapping)).toEqual(1);
-      });
-
-      it('should return -1 if isWrapping is false and start is greater than end', () => {
-        const isWrapping = false;
-        const start = 6;
-        const end = 0;
-
-        expect(instance.getSlideDirection(start, end, isWrapping)).toEqual(-1);
-      });
     });
   });
 

--- a/test/specs/fade-transition.test.js
+++ b/test/specs/fade-transition.test.js
@@ -1,0 +1,197 @@
+/*eslint max-nested-callbacks: ["error", 5]*/
+import FadeTransition from '../../src/transitions/fade-transition';
+
+describe('<FadeTransition />', () => {
+  describe('#getSlideOpacityAndLeftMap', () => {
+    let instance;
+
+    describe('single slide transition', () => {
+      const slideCount = 4;
+
+      const verifyMapForSingleSlide = (map, fadeFrom, fadeTo, fromOpacity) => {
+        const toOpacity = 1.0 - fromOpacity;
+
+        for (let i = 0; i < slideCount; i++) {
+          switch (i) {
+            case fadeFrom:
+              expect(map[i].opacity).toEqual(fromOpacity);
+              expect(map[i].left).toEqual(0);
+              break;
+            case fadeTo:
+              expect(map[i].opacity).toEqual(toOpacity);
+              expect(map[i].left).toEqual(0);
+              break;
+            default:
+              expect(map[i]).toBeUndefined();
+              break;
+          }
+        }
+      };
+
+      beforeEach(async () => {
+        const wrapper = mount(
+          <FadeTransition slideCount={slideCount} slideWidth={100}>
+            <p>Slide 1</p>
+            <p>Slide 2</p>
+            <p>Slide 3</p>
+            <p>Slide 4</p>
+          </FadeTransition>
+        );
+
+        instance = wrapper.instance();
+      });
+
+      it('should calculate opacity & left for only 1 slide if fadeFrom equals fadeTo', () => {
+        const fadeFrom = 2;
+        const fadeTo = 2;
+        const fade = 0;
+
+        const map = instance.getSlideOpacityAndLeftMap(fadeFrom, fadeTo, fade);
+
+        verifyMapForSingleSlide(map, fadeFrom, fadeTo, 1);
+      });
+
+      it('should calculate opacity & left between two slides next to each other', () => {
+        const fadeFrom = 2;
+        const fadeTo = 3;
+        const fade = 2.75;
+
+        const map = instance.getSlideOpacityAndLeftMap(fadeFrom, fadeTo, fade);
+
+        verifyMapForSingleSlide(map, fadeFrom, fadeTo, 0.25);
+      });
+
+      it('should calculate opacity & left between two slides further apart', () => {
+        const fadeFrom = 1;
+        const fadeTo = 3;
+        const fade = 2;
+
+        const map = instance.getSlideOpacityAndLeftMap(fadeFrom, fadeTo, fade);
+
+        verifyMapForSingleSlide(map, fadeFrom, fadeTo, 0.5);
+      });
+
+      it('should calculate opacity & left when wrapping around first slide to last', () => {
+        const fadeFrom = 0;
+        const fadeTo = slideCount - 1;
+        const fade = -0.75;
+
+        const map = instance.getSlideOpacityAndLeftMap(fadeFrom, fadeTo, fade);
+
+        verifyMapForSingleSlide(map, fadeFrom, fadeTo, 0.25);
+      });
+
+      it('should calculate opacity & left when wrapping around last slide to first', () => {
+        const fadeFrom = slideCount - 1;
+        const fadeTo = 0;
+        const fade = fadeFrom + 0.75;
+
+        const map = instance.getSlideOpacityAndLeftMap(fadeFrom, fadeTo, fade);
+
+        verifyMapForSingleSlide(map, fadeFrom, fadeTo, 0.25);
+      });
+    });
+
+    describe('multple slide transtion', () => {
+      const slidesToShow = 2;
+      const slideCount = 6;
+      const slideWidth = 100;
+
+      const verifyMapForMultipleSlides = (
+        map,
+        fadeFrom,
+        fadeTo,
+        fromOpacity
+      ) => {
+        const toOpacity = 1.0 - fromOpacity;
+
+        for (let i = 0; i < slideCount; i++) {
+          switch (i) {
+            case fadeFrom:
+            case fadeFrom + 1:
+              expect(map[i].opacity).toEqual(fromOpacity);
+              expect(map[i].left).toEqual((i - fadeFrom) * slideWidth);
+              break;
+            case fadeTo:
+            case fadeTo + 1:
+              expect(map[i].opacity).toEqual(toOpacity);
+              expect(map[i].left).toEqual((i - fadeTo) * slideWidth);
+              break;
+            default:
+              expect(map[i]).toBeUndefined();
+              break;
+          }
+        }
+      };
+
+      beforeEach(async () => {
+        const wrapper = mount(
+          <FadeTransition
+            slidesToShow={slidesToShow}
+            slideCount={slideCount}
+            slideWidth={slideWidth}
+          >
+            <p>Slide 1</p>
+            <p>Slide 2</p>
+            <p>Slide 3</p>
+            <p>Slide 4</p>
+            <p>Slide 5</p>
+            <p>Slide 6</p>
+          </FadeTransition>
+        );
+
+        instance = wrapper.instance();
+      });
+
+      it(`should calculate opacity & left for only ${slidesToShow} slides if fadeFrom equals fadeTo`, () => {
+        const fadeFrom = 2;
+        const fadeTo = 2;
+        const fade = 0;
+
+        const map = instance.getSlideOpacityAndLeftMap(fadeFrom, fadeTo, fade);
+
+        verifyMapForMultipleSlides(map, fadeFrom, fadeTo, 1);
+      });
+
+      it('should calculate opacity & left between two slide pages next to each other', () => {
+        const fadeFrom = 0;
+        const fadeTo = 2;
+        const fade = 1.5;
+
+        const map = instance.getSlideOpacityAndLeftMap(fadeFrom, fadeTo, fade);
+
+        verifyMapForMultipleSlides(map, fadeFrom, fadeTo, 0.25);
+      });
+
+      it('should calculate opacity & left between two slide pages further apart', () => {
+        const fadeFrom = 0;
+        const fadeTo = 4;
+        const fade = 2;
+
+        const map = instance.getSlideOpacityAndLeftMap(fadeFrom, fadeTo, fade);
+
+        verifyMapForMultipleSlides(map, fadeFrom, fadeTo, 0.5);
+      });
+
+      it('should calculate opacity & left when wrapping around first slide page to last', () => {
+        const fadeFrom = 0;
+        const fadeTo = slideCount - slidesToShow;
+        const fade = -1.5;
+
+        const map = instance.getSlideOpacityAndLeftMap(fadeFrom, fadeTo, fade);
+
+        verifyMapForMultipleSlides(map, fadeFrom, fadeTo, 0.25);
+      });
+
+      it('should calculate opacity & left when wrapping around last slide page to first', () => {
+        const fadeFrom = slideCount - slidesToShow;
+        const fadeTo = 0;
+        const fade = fadeFrom + 1.0;
+
+        const map = instance.getSlideOpacityAndLeftMap(fadeFrom, fadeTo, fade);
+
+        verifyMapForMultipleSlides(map, fadeFrom, fadeTo, 0.5);
+      });
+    });
+  });
+});

--- a/test/specs/scroll-transition.test.js
+++ b/test/specs/scroll-transition.test.js
@@ -2,57 +2,55 @@
 import ScrollTransition from '../../src/transitions/scroll-transition';
 
 describe('<ScrollTransition />', () => {
-  describe('methods', () => {
-    describe('#getSlideDirection', () => {
-      let instance;
+  describe('#getSlideDirection', () => {
+    let instance;
 
-      beforeEach(async () => {
-        const wrapper = mount(
-          <ScrollTransition>
-            <p>Slide 1</p>
-            <p>Slide 2</p>
-            <p>Slide 3</p>
-          </ScrollTransition>
-        );
-        instance = wrapper.instance();
-      });
+    beforeEach(async () => {
+      const wrapper = mount(
+        <ScrollTransition>
+          <p>Slide 1</p>
+          <p>Slide 2</p>
+          <p>Slide 3</p>
+        </ScrollTransition>
+      );
+      instance = wrapper.instance();
+    });
 
-      it('should return zero if start and end slide are the same regardless of isWrapping', () => {
-        expect(instance.getSlideDirection(2, 2, true)).toEqual(0);
-        expect(instance.getSlideDirection(2, 2, false)).toEqual(0);
-      });
+    it('should return zero if start and end slide are the same regardless of isWrapping', () => {
+      expect(instance.getSlideDirection(2, 2, true)).toEqual(0);
+      expect(instance.getSlideDirection(2, 2, false)).toEqual(0);
+    });
 
-      it('should return -1 if isWrapping is true and start is less than end', () => {
-        const isWrapping = true;
-        const start = 0;
-        const end = 6;
+    it('should return -1 if isWrapping is true and start is less than end', () => {
+      const isWrapping = true;
+      const start = 0;
+      const end = 6;
 
-        expect(instance.getSlideDirection(start, end, isWrapping)).toEqual(-1);
-      });
+      expect(instance.getSlideDirection(start, end, isWrapping)).toEqual(-1);
+    });
 
-      it('should return 1 if isWrapping is true and start is greater than end', () => {
-        const isWrapping = true;
-        const start = 6;
-        const end = 0;
+    it('should return 1 if isWrapping is true and start is greater than end', () => {
+      const isWrapping = true;
+      const start = 6;
+      const end = 0;
 
-        expect(instance.getSlideDirection(start, end, isWrapping)).toEqual(1);
-      });
+      expect(instance.getSlideDirection(start, end, isWrapping)).toEqual(1);
+    });
 
-      it('should return 1 if isWrapping is false and start is less than end', () => {
-        const isWrapping = false;
-        const start = 0;
-        const end = 6;
+    it('should return 1 if isWrapping is false and start is less than end', () => {
+      const isWrapping = false;
+      const start = 0;
+      const end = 6;
 
-        expect(instance.getSlideDirection(start, end, isWrapping)).toEqual(1);
-      });
+      expect(instance.getSlideDirection(start, end, isWrapping)).toEqual(1);
+    });
 
-      it('should return -1 if isWrapping is false and start is greater than end', () => {
-        const isWrapping = false;
-        const start = 6;
-        const end = 0;
+    it('should return -1 if isWrapping is false and start is greater than end', () => {
+      const isWrapping = false;
+      const start = 6;
+      const end = 0;
 
-        expect(instance.getSlideDirection(start, end, isWrapping)).toEqual(-1);
-      });
+      expect(instance.getSlideDirection(start, end, isWrapping)).toEqual(-1);
     });
   });
 });

--- a/test/specs/scroll-transition.test.js
+++ b/test/specs/scroll-transition.test.js
@@ -1,0 +1,58 @@
+/*eslint max-nested-callbacks: ["error", 4]*/
+import ScrollTransition from '../../src/transitions/scroll-transition';
+
+describe('<ScrollTransition />', () => {
+  describe('methods', () => {
+    describe('#getSlideDirection', () => {
+      let instance;
+
+      beforeEach(async () => {
+        const wrapper = mount(
+          <ScrollTransition>
+            <p>Slide 1</p>
+            <p>Slide 2</p>
+            <p>Slide 3</p>
+          </ScrollTransition>
+        );
+        instance = wrapper.instance();
+      });
+
+      it('should return zero if start and end slide are the same regardless of isWrapping', () => {
+        expect(instance.getSlideDirection(2, 2, true)).toEqual(0);
+        expect(instance.getSlideDirection(2, 2, false)).toEqual(0);
+      });
+
+      it('should return -1 if isWrapping is true and start is less than end', () => {
+        const isWrapping = true;
+        const start = 0;
+        const end = 6;
+
+        expect(instance.getSlideDirection(start, end, isWrapping)).toEqual(-1);
+      });
+
+      it('should return 1 if isWrapping is true and start is greater than end', () => {
+        const isWrapping = true;
+        const start = 6;
+        const end = 0;
+
+        expect(instance.getSlideDirection(start, end, isWrapping)).toEqual(1);
+      });
+
+      it('should return 1 if isWrapping is false and start is less than end', () => {
+        const isWrapping = false;
+        const start = 0;
+        const end = 6;
+
+        expect(instance.getSlideDirection(start, end, isWrapping)).toEqual(1);
+      });
+
+      it('should return -1 if isWrapping is false and start is greater than end', () => {
+        const isWrapping = false;
+        const start = 6;
+        const end = 0;
+
+        expect(instance.getSlideDirection(start, end, isWrapping)).toEqual(-1);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Nuka carousel now supports fade transitions.

Overall work:
- Existing scroll logic was removed from `index.js` and placed into a new file `scroll-transition.js`.
- All the new fade transition logic is in the file `fade-transition.js`

Things to note when in `fade` mode:
- `slidesToShow` gets parsed to an `int`, the fade logic does _not_ support partially visible slides, but it _does_ support multiple slides (i.e. 1, 2, 3, etc...).
- `slidesToScroll` gets set to `slidesToShow`, so fading across multiple slides means they get swapped out 1x1, 2x2, etc..
- `cellAlign` gets automatically set to `left` because a `cellAlign` of `center` with multiple slides would result in partial slides, and a `cellAlign` of right breaks the current fade logic and getting it fully supported would require further refactoring of `index.js` (and this PR is already big enough).  

This feature closes #86 