### PR TITLE
Fix vertical scrolling/panning over the carousel

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -837,7 +837,7 @@ export default class Carousel extends React.Component {
       cursor: this.state.dragging === true ? 'pointer' : 'inherit',
       boxSizing: 'border-box',
       MozBoxSizing: 'border-box',
-      touchAction: 'none'
+      touchAction: `pinch-zoom ${this.props.vertical ? 'pan-x' : 'pan-y'}`
     };
   }
 


### PR DESCRIPTION
The `touch-action: none` addition in PR #365 / #366 made it impossible to have vertical scrolling/panning over the carousel on touch devices. This comes from the docs referenced in PR #365: 

> If you have a horizontal carousel consider applying touch-action: pan-y pinch-zoom to it so that the user can still scroll vertically and zoom as normal.

