### PR TITLE
Adding ability to disable autogenerated style tag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ Now, you can access the application on your localhost at following url: <a href=
 
 Hook to be called after a slide is changed.
 
+#### autoGenerateStyleTag
+`React.PropTypes.bool`
+
+When set to `true`, it will generate a `style` tag to help ensure images are displayed properly.  Defaults to `true`.
+
 #### autoplay
 
 `React.PropTypes.bool`

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Hook to be called after a slide is changed.
 #### autoGenerateStyleTag
 `React.PropTypes.bool`
 
-When set to `true`, it will generate a `style` tag to help ensure images are displayed properly.  Defaults to `true`.
+When set to `true`, it will generate a `style` tag to help ensure images are displayed properly. Set to `false` if you don't want or need the style tag generated. Defaults to `true`.
 
 #### autoplay
 

--- a/src/index.js
+++ b/src/index.js
@@ -1078,10 +1078,12 @@ export default class Carousel extends React.Component {
 
         {this.renderControls()}
 
-        <style
-          type="text/css"
-          dangerouslySetInnerHTML={{ __html: this.getStyleTagStyles() }}
-        />
+        {this.props.autoGenerateStyleTag && (
+          <style
+            type="text/css"
+            dangerouslySetInnerHTML={{ __html: this.getStyleTagStyles() }}
+          />
+        )}
       </div>
     );
   }
@@ -1091,6 +1093,7 @@ Carousel.propTypes = {
   afterSlide: PropTypes.func,
   autoplay: PropTypes.bool,
   autoplayInterval: PropTypes.number,
+  autoGenerateStyleTag: PropTypes.bool,
   beforeSlide: PropTypes.func,
   cellAlign: PropTypes.oneOf(['left', 'center', 'right']),
   cellSpacing: PropTypes.number,
@@ -1131,6 +1134,7 @@ Carousel.defaultProps = {
   afterSlide() {},
   autoplay: false,
   autoplayInterval: 3000,
+  autoGenerateStyleTag: true,
   beforeSlide() {},
   cellAlign: 'left',
   cellSpacing: 0,

--- a/test/specs/carousel.test.js
+++ b/test/specs/carousel.test.js
@@ -349,6 +349,41 @@ describe('<Carousel />', () => {
       wrapper.setProps({ children });
       expect(wrapper).toHaveState({ slideCount: 5 });
     });
+
+    it('should default autoGenerateStyleTag to true', () => {
+      const wrapper = mount(
+        <Carousel>
+          <p>Slide 1</p>
+          <p>Slide 2</p>
+        </Carousel>
+      );
+
+      expect(wrapper).toHaveProp({ autoGenerateStyleTag: true });
+    });
+
+    it('should generate style tag when autoGenerateStyle tag is true', () => {
+      const wrapper = mount(
+        <Carousel autoGenerateStyleTag>
+          <p>Slide 1</p>
+          <p>Slide 2</p>
+        </Carousel>
+      );
+
+      const styleTag = wrapper.find('style');
+      expect(styleTag).toExist();
+    });
+
+    it('should not generate style tag when autoGenerateStyle tag is false', () => {
+      const wrapper = mount(
+        <Carousel autoGenerateStyleTag={false}>
+          <p>Slide 1</p>
+          <p>Slide 2</p>
+        </Carousel>
+      );
+
+      const styleTag = wrapper.find('style');
+      expect(styleTag).not.toExist();
+    });
   });
 
   describe('transitionModes', () => {


### PR DESCRIPTION
Added boolean `autoGenerateStyle` prop that defaults to `true`.  When `true`, carousel will autogenerate a style tag to assist with image rendering, when set to `false` it will not.

This PR is based of PR #183 that is too old to merge.

Closes #182 