### PR TITLE
Prevent Carousel from rendering empty <li> tags for non-React children.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -122,7 +122,7 @@ export default class Carousel extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    const slideCount = React.Children.count(nextProps.children);
+    const slideCount = this.getValidChildren(nextProps.children).length;
     const slideCountChanged = slideCount !== this.state.slideCount;
 
     this.setState({ slideCount });
@@ -413,8 +413,7 @@ export default class Carousel extends React.Component {
     if (this.touchObject.length > this.state.slideWidth / slidesToShow / 5) {
       if (this.touchObject.direction === 1) {
         if (
-          this.state.currentSlide >=
-            React.Children.count(this.props.children) - slidesToShow &&
+          this.state.currentSlide >= this.state.slideCount - slidesToShow &&
           !this.props.wrapAround
         ) {
           this.setState({ easing: easing[this.props.edgeEasing] });
@@ -507,11 +506,11 @@ export default class Carousel extends React.Component {
   goToSlide(index) {
     this.setState({ easing: easing[this.props.easing] });
 
-    if (index >= React.Children.count(this.props.children) || index < 0) {
+    if (index >= this.state.slideCount || index < 0) {
       if (!this.props.wrapAround) {
         return;
       }
-      if (index >= React.Children.count(this.props.children)) {
+      if (index >= this.state.slideCount) {
         this.props.beforeSlide(this.state.currentSlide, 0);
         this.setState(
           prevState => ({
@@ -545,8 +544,7 @@ export default class Carousel extends React.Component {
         );
         return;
       } else {
-        const endSlide =
-          React.Children.count(this.props.children) - this.state.slidesToScroll;
+        const endSlide = this.state.slideCount - this.state.slidesToScroll;
         this.props.beforeSlide(this.state.currentSlide, endSlide);
         this.setState(
           prevState => ({
@@ -592,7 +590,7 @@ export default class Carousel extends React.Component {
   }
 
   nextSlide() {
-    const childrenCount = React.Children.count(this.props.children);
+    const childrenCount = this.state.slideCount;
     let slidesToShow = this.state.slidesToShow;
 
     if (this.props.slidesToScroll === 'auto') {
@@ -732,7 +730,7 @@ export default class Carousel extends React.Component {
       {
         slideHeight,
         frameWidth: this.props.vertical ? frameHeight : '100%',
-        slideCount: React.Children.count(this.props.children),
+        slideCount: this.getValidChildren(this.props.children).length,
         slideWidth
       },
       () => {
@@ -824,6 +822,11 @@ export default class Carousel extends React.Component {
         this.setLeft();
       }
     );
+  }
+
+  getValidChildren(children) {
+    // .toArray automatically removes invalid React children
+    return React.Children.toArray(children);
   }
 
   getChildNodes() {
@@ -1040,6 +1043,7 @@ export default class Carousel extends React.Component {
     const touchEvents = this.getTouchEvents();
     const mouseEvents = this.getMouseEvents();
     const TransitionControl = Transitions[this.props.transitionMode];
+    const validChildren = this.getValidChildren(this.props.children);
 
     return (
       <div
@@ -1070,7 +1074,7 @@ export default class Carousel extends React.Component {
                 deltaX={tx}
                 deltaY={ty}
               >
-                {this.props.children}
+                {validChildren}
               </TransitionControl>
             </div>
           )}

--- a/test/specs/carousel.test.js
+++ b/test/specs/carousel.test.js
@@ -88,6 +88,20 @@ describe('<Carousel />', () => {
       expect(decorator2).toHaveLength(1);
       expect(decorator3).toHaveLength(1);
     });
+
+    it('should ignore null/undefined child elements', () => {
+      const wrapper = mount(
+        <Carousel>
+          <p>Slide 1</p>
+          <p>Slide 2</p>
+          <p>Slide 3</p>
+          {null}
+          {undefined}
+        </Carousel>
+      );
+
+      expect(wrapper.find('.slider-list').children()).toHaveLength(3);
+    });
   });
 
   describe('Props', () => {

--- a/test/specs/carousel.test.js
+++ b/test/specs/carousel.test.js
@@ -363,6 +363,20 @@ describe('<Carousel />', () => {
       wrapper.setProps({ children });
       expect(wrapper).toHaveState({ slideCount: 5 });
     });
+
+    it('should set slideCount to equal the amount of valid react children', () => {
+      const wrapper = mount(
+        <Carousel>
+          <p>Slide 1</p>
+          <p>Slide 2</p>
+          <p>Slide 3</p>
+          {null}
+          {undefined}
+        </Carousel>
+      );
+
+      expect(wrapper).toHaveState({ slideCount: 3 });
+    });
   });
 
   describe('transitionModes', () => {

--- a/test/specs/carousel.test.js
+++ b/test/specs/carousel.test.js
@@ -89,7 +89,7 @@ describe('<Carousel />', () => {
       expect(decorator3).toHaveLength(1);
     });
 
-    it('should ignore null/undefined child elements', () => {
+    it('should ignore non-component child elements', () => {
       const wrapper = mount(
         <Carousel>
           <p>Slide 1</p>
@@ -97,10 +97,22 @@ describe('<Carousel />', () => {
           <p>Slide 3</p>
           {null}
           {undefined}
+          {false}
+          {true}
         </Carousel>
       );
 
       expect(wrapper.find('.slider-list').children()).toHaveLength(3);
+    });
+
+    it('should not render child elements if logic to generate slides does not return valid components', () => {
+      let showSlide = true;
+      let wrapper = mount(<Carousel>{showSlide && <p>Slide 1</p>}</Carousel>);
+      expect(wrapper.find('.slider-list').children()).toHaveLength(1);
+
+      showSlide = false;
+      wrapper = mount(<Carousel>{showSlide && <p>Slide 1</p>}</Carousel>);
+      expect(wrapper.find('.slider-list').children()).toHaveLength(0);
     });
   });
 
@@ -376,6 +388,16 @@ describe('<Carousel />', () => {
       );
 
       expect(wrapper).toHaveState({ slideCount: 3 });
+    });
+
+    it('should set slideCount to 0 if logic to render slides does not return valid components', () => {
+      let showSlide = true;
+      let wrapper = mount(<Carousel>{showSlide && <p>Slide 1</p>}</Carousel>);
+      expect(wrapper).toHaveState({ slideCount: 1 });
+
+      showSlide = false;
+      wrapper = mount(<Carousel>{showSlide && <p>Slide 1</p>}</Carousel>);
+      expect(wrapper).toHaveState({ slideCount: 0 });
     });
   });
 


### PR DESCRIPTION
Refactored calls to `props.children` to use `getValidChildren` which filters out non-component (null, undefined, etc...) elements for use in the carousel.

This PR is based off of PR #68 which is too old to merge.