### PR TITLE
Visibility of slider is set to 'inherit' instead of 'visible'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -868,7 +868,7 @@ export default class Carousel extends React.Component {
       height: 'auto',
       boxSizing: 'border-box',
       MozBoxSizing: 'border-box',
-      visibility: this.state.slideWidth ? 'visible' : 'hidden'
+      visibility: this.state.slideWidth ? 'inherit' : 'hidden'
     };
   }
 

--- a/test/e2e/carousel.test.js
+++ b/test/e2e/carousel.test.js
@@ -49,6 +49,24 @@ describe('Nuka Carousel', () => {
       await expect(page).toClick('button', { text: 'NEXT' });
       await expect(page).toMatch('Nuka Carousel: Slide 1');
     });
+
+    it('should be hidden if containing div visibility is set to hidden', async () => {
+      const visibleStyles = await page.evaluate(getStyles, `.slider`, [
+        'visibility'
+      ]);
+
+      await expect(visibleStyles.visibility).toMatch('visible');
+
+      await page.evaluate(() => {
+        document.getElementById('content').style.visibility = 'hidden';
+      });
+
+      const hiddenStyles = await page.evaluate(getStyles, `.slider`, [
+        'visibility'
+      ]);
+
+      await expect(hiddenStyles.visibility).toMatch('hidden');
+    });
   };
 
   beforeEach(async () => {


### PR DESCRIPTION
This is a quick fix that was address in the old (and unmerge-able) PR #81 

The change was approved back when it was written, but never merged in so I'm creating this PR for the record and going to merge in quickly.

Fixes #80 