### PR TITLE
 Add prop to enable/disable pauseOnHover

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Pause autoPlay when mouse is over carousel. Defaults to `true`.
 
 A set of eight render props for rendering controls in different positions around the carousel.
 
-- Valid render props for the eight positions are `renderTopLeftControls`, `renderTopCenterControls`, `renderTopRightControls`, `renderCenterLeftControls`, `renderCenterCenterControls`, `renderCenterRightControls`, `renderBottomLeftControls`, `renderBottomCenterControls`, and `renderBottomRightControls`.
+* Valid render props for the eight positions are `renderTopLeftControls`, `renderTopCenterControls`, `renderTopRightControls`, `renderCenterLeftControls`, `renderCenterCenterControls`, `renderCenterRightControls`, `renderBottomLeftControls`, `renderBottomCenterControls`, and `renderBottomRightControls`.
 
 ```jsx
 <Carousel
@@ -166,7 +166,7 @@ A set of eight render props for rendering controls in different positions around
 </Carousel>
 ```
 
-- The function returns the props for `goToSlide`, `nextSlide` and `previousSlide` functions in addition to `slideCount` and `currentSlide` values.
+* The function returns the props for `goToSlide`, `nextSlide` and `previousSlide` functions in addition to `slideCount` and `currentSlide` values.
 
 #### slideIndex
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Now, you can access the application on your localhost at following url: <a href=
 Hook to be called after a slide is changed.
 
 #### autoGenerateStyleTag
+
 `React.PropTypes.bool`
 
 When set to `true`, it will generate a `style` tag to help ensure images are displayed properly. Set to `false` if you don't want or need the style tag generated. Defaults to `true`.
@@ -135,13 +136,19 @@ Initial height of the slides in pixels.
 
 Initial width of the slides in pixels.
 
+#### pauseOnHover
+
+`React.PropTypes.bool`
+
+Pause autoPlay when mouse is over carousel. Defaults to `true`.
+
 #### render\*Controls
 
 `React.PropTypes.func`
 
 A set of eight render props for rendering controls in different positions around the carousel.
 
-* Valid render props for the eight positions are `renderTopLeftControls`, `renderTopCenterControls`, `renderTopRightControls`, `renderCenterLeftControls`, `renderCenterCenterControls`, `renderCenterRightControls`, `renderBottomLeftControls`, `renderBottomCenterControls`, and `renderBottomRightControls`.
+- Valid render props for the eight positions are `renderTopLeftControls`, `renderTopCenterControls`, `renderTopRightControls`, `renderCenterLeftControls`, `renderCenterCenterControls`, `renderCenterRightControls`, `renderBottomLeftControls`, `renderBottomCenterControls`, and `renderBottomRightControls`.
 
 ```jsx
 <Carousel
@@ -159,7 +166,7 @@ A set of eight render props for rendering controls in different positions around
 </Carousel>
 ```
 
-* The function returns the props for `goToSlide`, `nextSlide` and `previousSlide` functions in addition to `slideCount` and `currentSlide` values.
+- The function returns the props for `goToSlide`, `nextSlide` and `previousSlide` functions in addition to `slideCount` and `currentSlide` values.
 
 #### slideIndex
 

--- a/src/index.js
+++ b/src/index.js
@@ -377,11 +377,15 @@ export default class Carousel extends React.Component {
   }
 
   handleMouseOver() {
-    this.pauseAutoplay();
+    if (this.props.pauseOnHover) {
+      this.pauseAutoplay();
+    }
   }
 
   handleMouseOut() {
-    this.unpauseAutoplay();
+    if (this.autoplayPaused) {
+      this.unpauseAutoplay();
+    }
   }
 
   handleClick(event) {
@@ -1111,6 +1115,7 @@ Carousel.propTypes = {
   initialSlideHeight: PropTypes.number,
   initialSlideWidth: PropTypes.number,
   onResize: PropTypes.func,
+  pauseOnHover: PropTypes.bool,
   renderTopLeftControls: PropTypes.func,
   renderTopCenterControls: PropTypes.func,
   renderTopRightControls: PropTypes.func,
@@ -1154,6 +1159,7 @@ Carousel.defaultProps = {
   slidesToScroll: 1,
   slidesToShow: 1,
   style: {},
+  pauseOnHover: true,
   renderCenterLeftControls: props => <PreviousButton {...props} />,
   renderCenterRightControls: props => <NextButton {...props} />,
   renderBottomCenterControls: props => <PagingDots {...props} />,


### PR DESCRIPTION
This enables the developer to allow autoPlay to run, even while the carousel is being hovered over.

A use case for this would be where the carousel is a full page landing section. If the page loads with the user's mouse anywhere in the viewport, without the option to disable pauseOnHover, autoPlay will be paused until the user scrolls the page.