### PR TITLE
prevent default on mouse down click event

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -296,6 +296,10 @@ export default class Carousel extends React.Component {
       onMouseOut: () => this.handleMouseOut(),
 
       onMouseDown: e => {
+        if (e.preventDefault) {
+          e.preventDefault();
+        }
+
         this.touchObject = {
           startX: e.clientX,
           startY: e.clientY


### PR DESCRIPTION
When clicking on an image in Firefox and moving the mouse to swipe the slide, the image will start to drag around. This is the default dragging action in Firefox. To disable image dragging, we have to prevent default action on the mouse down event for the image.