### PR TITLE
minHeight prevents slides from recalculating their height

### DIFF
--- a/src/transitions/fade-transition.js
+++ b/src/transitions/fade-transition.js
@@ -72,7 +72,6 @@ export default class FadeTransition extends React.Component {
       verticalAlign: 'top',
       width: this.props.slideWidth,
       height: 'auto',
-      minHeight: '100%',
       boxSizing: 'border-box',
       MozBoxSizing: 'border-box',
       marginLeft: this.props.cellSpacing / 2,

--- a/src/transitions/scroll-transition.js
+++ b/src/transitions/scroll-transition.js
@@ -90,7 +90,6 @@ export default class ScrollTransition extends React.Component {
       verticalAlign: 'top',
       width: this.props.vertical ? '100%' : this.props.slideWidth,
       height: 'auto',
-      minHeight: '100%',
       boxSizing: 'border-box',
       MozBoxSizing: 'border-box',
       marginLeft: this.props.vertical ? 'auto' : this.props.cellSpacing / 2,


### PR DESCRIPTION
On window resize, the minHeight: 100% property was preventing the correct calculation of slide height. I tested this with `heightMode: max` and `vertical: true` props. Slides are responsive to window resizing and slides with different heights are not affected.

fixes #353, fixes #394 