### PR TITLE
fix bug that afterSlide hook not firing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -593,6 +593,7 @@ export default class Carousel extends React.Component {
     }
 
     this.props.beforeSlide(this.state.currentSlide, index);
+    const previousSlide = this.state.currentSlide;
 
     this.setState(
       {
@@ -601,7 +602,7 @@ export default class Carousel extends React.Component {
       () =>
         setTimeout(() => {
           this.resetAutoplay();
-          if (index !== this.state.currentSlide) {
+          if (index !== previousSlide) {
             this.props.afterSlide(index);
           }
         }, props.speed)

--- a/test/specs/carousel.test.js
+++ b/test/specs/carousel.test.js
@@ -434,6 +434,30 @@ describe('<Carousel />', () => {
       wrapper = mount(<Carousel>{showSlide && <p>Slide 1</p>}</Carousel>);
       expect(wrapper).toHaveState({ slideCount: 0 });
     });
+
+    it('should call beforeSlide and afterSlide when slide change', async () => {
+      const speed = 500;
+      const beforeSlideSpy = jest.fn();
+      const afterSlideSpy = jest.fn();
+
+      const wrapper = mount(
+        <Carousel
+          slideIndex={0}
+          beforeSlide={beforeSlideSpy}
+          afterSlide={afterSlideSpy}
+          speed={speed}
+        >
+          <p>Slide 1</p>
+          <p>Slide 2</p>
+          <p>Slide 3</p>
+        </Carousel>
+      );
+
+      wrapper.instance().goToSlide(1);
+      await new Promise(resolve => setTimeout(resolve, speed));
+      expect(beforeSlideSpy).toBeCalledWith(0, 1);
+      expect(afterSlideSpy).toBeCalledWith(1);
+    });
   });
 
   describe('transitionModes', () => {


### PR DESCRIPTION
I fixed bug that `afterSlide` hook not firing and added regression test ( issue: #400 ).

I am recognizing #401 and hope that this bug is fixed as soon as possible, but I don't have a authority to push to #401 😢 
So I created new pull request.
However, if you want to respect his contribution, please cherry-pick my commit to his branch and close this PR 😄

Thanks.