### PR TITLE
Ensure setDimensions is called when slide changes and heightMode = current

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Pause autoPlay when mouse is over carousel. Defaults to `true`.
 
 A set of eight render props for rendering controls in different positions around the carousel.
 
-- Valid render props for the eight positions are `renderTopLeftControls`, `renderTopCenterControls`, `renderTopRightControls`, `renderCenterLeftControls`, `renderCenterCenterControls`, `renderCenterRightControls`, `renderBottomLeftControls`, `renderBottomCenterControls`, and `renderBottomRightControls`.
+* Valid render props for the eight positions are `renderTopLeftControls`, `renderTopCenterControls`, `renderTopRightControls`, `renderCenterLeftControls`, `renderCenterCenterControls`, `renderCenterRightControls`, `renderBottomLeftControls`, `renderBottomCenterControls`, and `renderBottomRightControls`.
 
 ```jsx
 <Carousel
@@ -166,7 +166,7 @@ A set of eight render props for rendering controls in different positions around
 </Carousel>
 ```
 
-- The function returns the props for `goToSlide`, `nextSlide` and `previousSlide` functions in addition to `slideCount` and `currentSlide` values.
+* The function returns the props for `goToSlide`, `nextSlide` and `previousSlide` functions in addition to `slideCount` and `currentSlide` values.
 
 #### slideIndex
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Now, you can access the application on your localhost at following url: <a href=
 Hook to be called after a slide is changed.
 
 #### autoGenerateStyleTag
+
 `React.PropTypes.bool`
 
 When set to `true`, it will generate a `style` tag to help ensure images are displayed properly. Set to `false` if you don't want or need the style tag generated. Defaults to `true`.
@@ -135,13 +136,19 @@ Initial height of the slides in pixels.
 
 Initial width of the slides in pixels.
 
+#### pauseOnHover
+
+`React.PropTypes.bool`
+
+Pause autoPlay when mouse is over carousel. Defaults to `true`.
+
 #### render\*Controls
 
 `React.PropTypes.func`
 
 A set of eight render props for rendering controls in different positions around the carousel.
 
-* Valid render props for the eight positions are `renderTopLeftControls`, `renderTopCenterControls`, `renderTopRightControls`, `renderCenterLeftControls`, `renderCenterCenterControls`, `renderCenterRightControls`, `renderBottomLeftControls`, `renderBottomCenterControls`, and `renderBottomRightControls`.
+- Valid render props for the eight positions are `renderTopLeftControls`, `renderTopCenterControls`, `renderTopRightControls`, `renderCenterLeftControls`, `renderCenterCenterControls`, `renderCenterRightControls`, `renderBottomLeftControls`, `renderBottomCenterControls`, and `renderBottomRightControls`.
 
 ```jsx
 <Carousel
@@ -159,7 +166,7 @@ A set of eight render props for rendering controls in different positions around
 </Carousel>
 ```
 
-* The function returns the props for `goToSlide`, `nextSlide` and `previousSlide` functions in addition to `slideCount` and `currentSlide` values.
+- The function returns the props for `goToSlide`, `nextSlide` and `previousSlide` functions in addition to `slideCount` and `currentSlide` values.
 
 #### slideIndex
 

--- a/demo/app.js
+++ b/demo/app.js
@@ -33,7 +33,6 @@ class App extends React.Component {
           slidesToShow={this.state.slidesToShow}
           wrapAround={this.state.wrapAround}
           slideIndex={this.state.slideIndex}
-          heightMode="current"
           renderTopCenterControls={({ currentSlide }) => (
             <div
               style={{
@@ -56,7 +55,6 @@ class App extends React.Component {
                   1}`}
                 key={color}
                 onClick={this.handleImageClick}
-                style={{ height: 100 * (index + 1) }}
               />
             ))}
         </Carousel>

--- a/demo/app.js
+++ b/demo/app.js
@@ -14,7 +14,8 @@ class App extends React.Component {
       underlineHeader: false,
       slidesToShow: 1.0,
       cellAlign: 'left',
-      transitionMode: 'scroll'
+      transitionMode: 'scroll',
+      heightMode: 'max'
     };
 
     this.handleImageClick = this.handleImageClick.bind(this);
@@ -33,6 +34,7 @@ class App extends React.Component {
           slidesToShow={this.state.slidesToShow}
           wrapAround={this.state.wrapAround}
           slideIndex={this.state.slideIndex}
+          heightMode={this.state.heightMode}
           renderTopCenterControls={({ currentSlide }) => (
             <div
               style={{
@@ -47,16 +49,18 @@ class App extends React.Component {
             </div>
           )}
         >
-          {colors
-            .slice(0, this.state.length)
-            .map((color, index) => (
-              <img
-                src={`http://placehold.it/1000x400/${color}/ffffff/&text=slide${index +
-                  1}`}
-                key={color}
-                onClick={this.handleImageClick}
-              />
-            ))}
+          {colors.slice(0, this.state.length).map((color, index) => (
+            <img
+              src={`http://placehold.it/1000x400/${color}/ffffff/&text=slide${index +
+                1}`}
+              key={color}
+              onClick={this.handleImageClick}
+              style={{
+                height:
+                  this.state.heightMode === 'current' ? 100 * (index + 1) : 400
+              }}
+            />
+          ))}
         </Carousel>
         <div style={{ display: 'flex', justifyContent: 'space-between' }}>
           <div>
@@ -122,6 +126,18 @@ class App extends React.Component {
                 }
               >
                 Toggle Partially Visible Slides
+              </button>
+              <button
+                onClick={() => {
+                  console.log(this.state.heightMode);
+
+                  this.setState({
+                    heightMode:
+                      this.state.heightMode === 'current' ? 'max' : 'current'
+                  });
+                }}
+              >
+                Toggle Height Mode Current
               </button>
             </div>
           </div>

--- a/demo/app.js
+++ b/demo/app.js
@@ -33,6 +33,7 @@ class App extends React.Component {
           slidesToShow={this.state.slidesToShow}
           wrapAround={this.state.wrapAround}
           slideIndex={this.state.slideIndex}
+          heightMode="current"
           renderTopCenterControls={({ currentSlide }) => (
             <div
               style={{
@@ -55,6 +56,7 @@ class App extends React.Component {
                   1}`}
                 key={color}
                 onClick={this.handleImageClick}
+                style={{ height: 100 * (index + 1) }}
               />
             ))}
         </Carousel>

--- a/demo/app.js
+++ b/demo/app.js
@@ -128,14 +128,12 @@ class App extends React.Component {
                 Toggle Partially Visible Slides
               </button>
               <button
-                onClick={() => {
-                  console.log(this.state.heightMode);
-
+                onClick={() =>
                   this.setState({
                     heightMode:
                       this.state.heightMode === 'current' ? 'max' : 'current'
-                  });
-                }}
+                  })
+                }
               >
                 Toggle Height Mode Current
               </button>

--- a/src/index.js
+++ b/src/index.js
@@ -184,7 +184,6 @@ export default class Carousel extends React.Component {
   componentDidUpdate(nextProps, nextState) {
     const slideChanged = nextState.currentSlide !== this.state.currentSlide;
     const heightModeChanged = nextProps.heightMode !== this.props.heightMode;
-    
     if (slideChanged || heightModeChanged) {
       this.setDimensions();
     }

--- a/src/index.js
+++ b/src/index.js
@@ -121,15 +121,6 @@ export default class Carousel extends React.Component {
     }
   }
 
-  componentDidUpdate(nextProps, nextState) {
-    const slideChanged = nextState.currentSlide !== this.state.currentSlide;
-    const heightModeChanged = nextProps.heightMode !== this.props.heightMode;    
-
-    if (slideChanged || heightModeChanged) {
-      this.setDimensions();
-    }
-  }
-
   componentWillReceiveProps(nextProps) {
     const slideCount = this.getValidChildren(nextProps.children).length;
     const slideCountChanged = slideCount !== this.state.slideCount;
@@ -187,6 +178,15 @@ export default class Carousel extends React.Component {
       } else {
         this.stopAutoplay();
       }
+    }
+  }
+
+  componentDidUpdate(nextProps, nextState) {
+    const slideChanged = nextState.currentSlide !== this.state.currentSlide;
+    const heightModeChanged = nextProps.heightMode !== this.props.heightMode;
+    
+    if (slideChanged || heightModeChanged) {
+      this.setDimensions();
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -128,8 +128,6 @@ export default class Carousel extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    console.log(nextProps);
-
     const slideCount = this.getValidChildren(nextProps.children).length;
     const slideCountChanged = slideCount !== this.state.slideCount;
     this.setState({
@@ -167,8 +165,6 @@ export default class Carousel extends React.Component {
         'transitionMode',
         'cellAlign'
       ]);
-
-    console.log(updateDimensions);
 
     if (updateDimensions) {
       this.setDimensions(nextProps);

--- a/src/index.js
+++ b/src/index.js
@@ -377,11 +377,15 @@ export default class Carousel extends React.Component {
   }
 
   handleMouseOver() {
-    this.pauseAutoplay();
+    if (this.props.pauseOnHover) {
+      this.pauseAutoplay();
+    }
   }
 
   handleMouseOut() {
-    this.unpauseAutoplay();
+    if (this.autoplayPaused) {
+      this.unpauseAutoplay();
+    }
   }
 
   handleClick(event) {
@@ -1111,6 +1115,7 @@ Carousel.propTypes = {
   initialSlideHeight: PropTypes.number,
   initialSlideWidth: PropTypes.number,
   onResize: PropTypes.func,
+  pauseOnHover: PropTypes.bool,
   renderTopLeftControls: PropTypes.func,
   renderTopCenterControls: PropTypes.func,
   renderTopRightControls: PropTypes.func,
@@ -1154,6 +1159,7 @@ Carousel.defaultProps = {
   slidesToScroll: 1,
   slidesToShow: 1,
   style: {},
+  pauseOnHover: true,
   renderCenterLeftControls: props => <PreviousButton {...props} />,
   renderCenterRightControls: props => <NextButton {...props} />,
   renderBottomCenterControls: props => <PagingDots {...props} />,

--- a/src/index.js
+++ b/src/index.js
@@ -122,7 +122,10 @@ export default class Carousel extends React.Component {
   }
 
   componentDidUpdate(nextProps, nextState) {
-    if (nextState.currentSlide !== this.state.currentSlide) {
+    const slideChanged = nextState.currentSlide !== this.state.currentSlide;
+    const heightModeChanged = nextProps.heightMode !== this.props.heightMode;    
+
+    if (slideChanged || heightModeChanged) {
       this.setDimensions();
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -121,7 +121,15 @@ export default class Carousel extends React.Component {
     }
   }
 
+  componentDidUpdate(nextProps, nextState) {
+    if (nextState.currentSlide !== this.state.currentSlide) {
+      this.setDimensions();
+    }
+  }
+
   componentWillReceiveProps(nextProps) {
+    console.log(nextProps);
+
     const slideCount = this.getValidChildren(nextProps.children).length;
     const slideCountChanged = slideCount !== this.state.slideCount;
     this.setState({
@@ -159,6 +167,8 @@ export default class Carousel extends React.Component {
         'transitionMode',
         'cellAlign'
       ]);
+
+    console.log(updateDimensions);
 
     if (updateDimensions) {
       this.setDimensions(nextProps);


### PR DESCRIPTION
This pull request fixes an issue where `heightMode = 'current'` was not working. The problem was caused by the fact that the method setDimensions, which is responsible for setting the height of the current slide, was only being called in componentDidMount.

I added setDimensions to componentDidUpdate, with a check to make sure that the slide or the heightMode changed. I also added a heightMode toggle to the demo that switches between max and current.
