### PR TITLE
Prevent click events only when swiping

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ export default class Carousel extends React.Component {
     super(...arguments);
 
     this.displayName = 'Carousel';
-    this.clickSafe = true;
+    this.clickDisabled = false;
     this.touchObject = {};
     this.controlsMap = [
       { funcName: 'renderTopLeftControls', key: 'TopLeft' },
@@ -345,7 +345,7 @@ export default class Carousel extends React.Component {
               Math.sqrt(Math.pow(e.clientX - this.touchObject.startX, 2))
             );
 
-        this.clickSafe = false;
+        this.clickDisabled = true;
         this.touchObject = {
           startX: this.touchObject.startX,
           startY: this.touchObject.startY,
@@ -412,7 +412,7 @@ export default class Carousel extends React.Component {
   }
 
   handleClick(event) {
-    if (this.clickSafe === false) {
+    if (this.clickDisabled === true) {
       event.preventDefault();
       event.stopPropagation();
 
@@ -448,9 +448,9 @@ export default class Carousel extends React.Component {
       this.goToSlide(this.state.currentSlide);
     }
 
-    // wait for `handleClick` event before resetting clickSafe
+    // wait for `handleClick` event before resetting clickDisabled
     setTimeout(() => {
-      this.clickSafe = true;
+      this.clickDisabled = false;
     }, 200);
     this.touchObject = {};
 

--- a/src/index.js
+++ b/src/index.js
@@ -345,6 +345,7 @@ export default class Carousel extends React.Component {
               Math.sqrt(Math.pow(e.clientX - this.touchObject.startX, 2))
             );
 
+        this.clickSafe = false;
         this.touchObject = {
           startX: this.touchObject.startX,
           startY: this.touchObject.startY,
@@ -411,7 +412,7 @@ export default class Carousel extends React.Component {
   }
 
   handleClick(event) {
-    if (this.clickSafe === true) {
+    if (this.clickSafe === false) {
       event.preventDefault();
       event.stopPropagation();
 
@@ -421,15 +422,6 @@ export default class Carousel extends React.Component {
     }
   }
   handleSwipe() {
-    if (
-      typeof this.touchObject.length !== 'undefined' &&
-      this.touchObject.length > 44
-    ) {
-      this.clickSafe = true;
-    } else {
-      this.clickSafe = false;
-    }
-
     let slidesToShow = this.state.slidesToShow;
     if (this.props.slidesToScroll === 'auto') {
       slidesToShow = this.state.slidesToScroll;
@@ -456,6 +448,10 @@ export default class Carousel extends React.Component {
       this.goToSlide(this.state.currentSlide);
     }
 
+    // wait for `handleClick` event before resetting clickSafe
+    setTimeout(() => {
+      this.clickSafe = true;
+    }, 200);
     this.touchObject = {};
 
     this.setState({


### PR DESCRIPTION
### Description

Great library, but it is taking too much responsibility for handling click events than it should and is therefore causing side-effects for users of this library. For example,

https://github.com/FormidableLabs/nuka-carousel/issues/421
https://github.com/FormidableLabs/nuka-carousel/issues/399
https://github.com/FormidableLabs/nuka-carousel/pull/346
https://github.com/FormidableLabs/nuka-carousel/issues/168
https://github.com/FormidableLabs/nuka-carousel/pull/190
https://github.com/FormidableLabs/nuka-carousel/pull/266
https://github.com/FormidableLabs/nuka-carousel/pull/200

Fixes issue: https://github.com/FormidableLabs/nuka-carousel/issues/168

First off, I don't think a library like this should EVER swallow all click events from happening! I mean, this literally kills all click events unless we want dragging to be true. This is not a good DX nor UX for endusers of any kind. It is also causes indeterministic behavior (see above issues).

Therefore, why not just disable/prevent click events only when swiping?

#### Type of Change

Simple class property `clickDisabled` that disables click events when swiping.

- [x] Bug fix - Improved experience for developers and end users by only disabling click events when swiping (AKA if `dragging` is true).
- [x] Breaking Change - Because this re-enables propagation and does NOT prevent default browser click behavior, this could affect users of this library who are not properly handling their own event propagation.

This should NOT cause any regressions as far as https://github.com/FormidableLabs/nuka-carousel/pull/220 is concerned. Also, only the developers of an application that use this library know how to handle their own click events; this library should not try to account for click behavior by disabling click events altogether.

### How Has This Been Tested?

`yarn run check && yarn run test-e2e`

I also tested this within our own web app and the demo of this library. The idea is that we disable all click events ONLY when dragging/swiping, then reenable `clickSafe` behavior after the swiping is done.