### PR TITLE
update external control of carousel state example

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ export default class extends React.Component {
     return (
       <Carousel
         slideIndex={this.state.slideIndex}
-        afterSlide={slideIndex => this.setState({ slideIndex })}
+        afterSlide={slideIndex => this.setState({ currentSlide: slideIndex })}
       >
         <img src="http://placehold.it/1000x400/ffffff/c0392b/&text=slide1" />
         <img src="http://placehold.it/1000x400/ffffff/c0392b/&text=slide2" />


### PR DESCRIPTION
### Description

Notice there were a lot of issues surrounding external controls and the `afterSlide` props function. 
```
  <Carousel
        slideIndex={this.state.slideIndex}
        afterSlide={slideIndex => this.setState({ slideIndex })}
      >
  ```

But in the code base there is nothing looking for an external `this.state.slideIndex`. So now React is batching two states that are out of sync with each other. I believe the README should be like this.

```
  <Carousel
        slideIndex={this.state.slideIndex}
        afterSlide={slideIndex => this.setState({ currentSlide: slideIndex })}
      >
```
I this way the external slideIndex is in sync with nuka-carousel's state. This should fix all issues surrounding `afterSlide`. If nuka-carousel  is suppose to recognize the external slideIndex some refactoring of the code base will be needed. 

### How Has This Been Tested?

Manually tested 

### Checklist: (Feel free to delete this section upon completion)

- [ ] My code follows the style guidelines of this project (I have run `yarn lint`)
