### PR TITLE
Chore/#427 infinite animaiton

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -503,7 +503,7 @@ export default class Carousel extends React.Component {
     const xDist = x1 - x2;
     const yDist = y1 - y2;
     const r = Math.atan2(yDist, xDist);
-    let swipeAngle = Math.round((r * 180) / Math.PI);
+    let swipeAngle = Math.round(r * 180 / Math.PI);
 
     if (swipeAngle < 0) {
       swipeAngle = 360 - Math.abs(swipeAngle);
@@ -865,9 +865,9 @@ export default class Carousel extends React.Component {
     if (typeof props.slideWidth !== 'number') {
       slideWidth = parseInt(props.slideWidth);
     } else if (props.vertical) {
-      slideWidth = (slideHeight / slidesToShow) * props.slideWidth;
+      slideWidth = slideHeight / slidesToShow * props.slideWidth;
     } else {
-      slideWidth = (frame.offsetWidth / slidesToShow) * props.slideWidth;
+      slideWidth = frame.offsetWidth / slidesToShow * props.slideWidth;
     }
 
     if (!props.vertical) {

--- a/src/index.js
+++ b/src/index.js
@@ -39,6 +39,7 @@ export default class Carousel extends React.Component {
 
     this.displayName = 'Carousel';
     this.clickDisabled = false;
+    this.isTransitioning = false;
     this.touchObject = {};
     this.controlsMap = [
       { funcName: 'renderTopLeftControls', key: 'TopLeft' },
@@ -502,7 +503,7 @@ export default class Carousel extends React.Component {
     const xDist = x1 - x2;
     const yDist = y1 - y2;
     const r = Math.atan2(yDist, xDist);
-    let swipeAngle = Math.round(r * 180 / Math.PI);
+    let swipeAngle = Math.round((r * 180) / Math.PI);
 
     if (swipeAngle < 0) {
       swipeAngle = 360 - Math.abs(swipeAngle);
@@ -568,10 +569,16 @@ export default class Carousel extends React.Component {
       props = this.props;
     }
 
+    if (this.isTransitioning) {
+      return;
+    }
+
     this.setState({ easing: easing[props.easing] });
+    this.isTransitioning = true;
 
     if (index >= this.state.slideCount || index < 0) {
       if (!props.wrapAround) {
+        this.isTransitioning = false;
         return;
       }
       if (index >= this.state.slideCount) {
@@ -599,7 +606,10 @@ export default class Carousel extends React.Component {
               this.setState(
                 { isWrappingAround: false, resetWrapAroundPosition: true },
                 () => {
-                  this.setState({ resetWrapAroundPosition: false });
+                  this.setState({
+                    resetWrapAroundPosition: false
+                  });
+                  this.isTransitioning = false;
                   props.afterSlide(0);
                   this.resetAutoplay();
                 }
@@ -627,7 +637,10 @@ export default class Carousel extends React.Component {
               this.setState(
                 { isWrappingAround: false, resetWrapAroundPosition: true },
                 () => {
-                  this.setState({ resetWrapAroundPosition: false });
+                  this.setState({
+                    resetWrapAroundPosition: false
+                  });
+                  this.isTransitioning = false;
                   props.afterSlide(endSlide);
                   this.resetAutoplay();
                 }
@@ -648,6 +661,7 @@ export default class Carousel extends React.Component {
       () =>
         setTimeout(() => {
           this.resetAutoplay();
+          this.isTransitioning = false;
           if (index !== previousSlide) {
             this.props.afterSlide(index);
           }
@@ -851,9 +865,9 @@ export default class Carousel extends React.Component {
     if (typeof props.slideWidth !== 'number') {
       slideWidth = parseInt(props.slideWidth);
     } else if (props.vertical) {
-      slideWidth = slideHeight / slidesToShow * props.slideWidth;
+      slideWidth = (slideHeight / slidesToShow) * props.slideWidth;
     } else {
-      slideWidth = frame.offsetWidth / slidesToShow * props.slideWidth;
+      slideWidth = (frame.offsetWidth / slidesToShow) * props.slideWidth;
     }
 
     if (!props.vertical) {

--- a/test/e2e/carousel.test.js
+++ b/test/e2e/carousel.test.js
@@ -22,6 +22,7 @@ describe('Nuka Carousel', () => {
     it('should show the previous slide when the Previous button is clicked.', async () => {
       await expect(page).toClick('button', { text: 'NEXT' });
       await expect(page).toMatch('Nuka Carousel: Slide 2');
+      await page.waitFor(600); // need to let slide transition complete
       await expect(page).toClick('button', { text: 'PREV' });
       await expect(page).toMatch('Nuka Carousel: Slide 1');
     });
@@ -35,17 +36,22 @@ describe('Nuka Carousel', () => {
 
     it('should navigate to the first slide from the last in wrapAround mode.', async () => {
       await expect(page).toClick('button', { text: 'Toggle Wrap Around' });
+      await page.waitFor(600); // need to let slide transition complete
       await expect(page).toClick('button', { text: '6' });
       await expect(page).toMatch('Nuka Carousel: Slide 6');
+      await page.waitFor(600); // need to let slide transition complete
       await expect(page).toClick('button', { text: 'NEXT' });
       await expect(page).toMatch('Nuka Carousel: Slide 1');
     });
 
     it('should navigate to the first slide from the second in wrapAround mode with only 2 slides.', async () => {
       await expect(page).toClick('button', { text: 'Toggle Wrap Around' });
+      await page.waitFor(600); // need to let slide transition complete
       await expect(page).toClick('button', { text: '2 Slides Only' });
+      await page.waitFor(600); // need to let slide transition complete
       await expect(page).toClick('button', { text: '2' });
       await expect(page).toMatch('Nuka Carousel: Slide 2');
+      await page.waitFor(600); // need to let slide transition complete
       await expect(page).toClick('button', { text: 'NEXT' });
       await expect(page).toMatch('Nuka Carousel: Slide 1');
     });
@@ -153,6 +159,7 @@ describe('Nuka Carousel', () => {
       await page.mouse.move(startX - metrics.width / 3.0, startY);
       await page.mouse.up();
       await expect(page).toMatch('Nuka Carousel: Slide 2');
+      await page.waitFor(600); // need to let slide transition complete
       await page.mouse.move(startX, startY);
       await page.mouse.down();
       await page.mouse.move(startX + metrics.width / 3.0, startY);
@@ -184,6 +191,7 @@ describe('Nuka Carousel', () => {
       await page.mouse.move(startX + metrics.width / 3.0, startY);
       await page.mouse.up();
       await expect(page).toMatch('Nuka Carousel: Slide 6');
+      await page.waitFor(600); // need to let slide transition complete
       await page.mouse.move(startX, startY);
       await page.mouse.down();
       await page.mouse.move(startX - metrics.width / 3.0, startY);
@@ -248,6 +256,7 @@ describe('Nuka Carousel', () => {
       await expect(page).toClick('button', { text: 'Toggle Wrap Around' });
       await expect(page).toClick('button', { text: '6' });
       await expect(page).toMatch('Nuka Carousel: Slide 6');
+      await page.waitFor(600); // need to let slide transition complete
       await expect(page).toClick('button', { text: 'NEXT' });
       await expect(page).toMatch('Nuka Carousel: Slide 1');
       await page.waitFor(600); // need to let slide transition complete
@@ -293,6 +302,7 @@ describe('Nuka Carousel', () => {
       await expect(page).toClick('button', { text: 'Toggle Wrap Around' });
       await expect(page).toClick('button', { text: '6' });
       await expect(page).toMatch('Nuka Carousel: Slide 6');
+      await page.waitFor(600); // need to let slide transition complete
       await expect(page).toClick('button', { text: 'NEXT' });
       await expect(page).toMatch('Nuka Carousel: Slide 1');
       await page.waitFor(600); // need to let slide transition complete

--- a/test/specs/carousel.test.js
+++ b/test/specs/carousel.test.js
@@ -458,7 +458,6 @@ describe('<Carousel />', () => {
       );
 
       wrapper.instance().goToSlide(1);
-      // await new Promise(resolve => setTimeout(resolve, speed));
       jest.advanceTimersByTime(speed);
       expect(beforeSlideSpy).toBeCalledWith(0, 1);
       expect(afterSlideSpy).toBeCalledWith(1);

--- a/test/specs/carousel.test.js
+++ b/test/specs/carousel.test.js
@@ -209,11 +209,13 @@ describe('<Carousel />', () => {
         </Carousel>
       );
       const nextButton = wrapper.find('.slider-control-centerright button');
-      nextButton.simulate('click');
-      nextButton.simulate('click');
-      nextButton.simulate('click');
-      nextButton.simulate('click');
-      nextButton.simulate('click');
+      jest.useFakeTimers();
+
+      for (let i = 0; i < 5; i++) {
+        nextButton.simulate('click');
+        jest.advanceTimersByTime(500);
+      }
+
       expect(wrapper).toHaveState({ currentSlide: 5 });
     });
 
@@ -229,11 +231,13 @@ describe('<Carousel />', () => {
         </Carousel>
       );
       const nextButton = wrapper.find('.slider-control-centerright button');
-      nextButton.simulate('click');
-      nextButton.simulate('click');
-      nextButton.simulate('click');
-      nextButton.simulate('click');
-      nextButton.simulate('click');
+      jest.useFakeTimers();
+
+      for (let i = 0; i < 5; i++) {
+        nextButton.simulate('click');
+        jest.advanceTimersByTime(500);
+      }
+
       expect(wrapper).toHaveState({ currentSlide: 5 });
     });
 
@@ -454,7 +458,8 @@ describe('<Carousel />', () => {
       );
 
       wrapper.instance().goToSlide(1);
-      await new Promise(resolve => setTimeout(resolve, speed));
+      // await new Promise(resolve => setTimeout(resolve, speed));
+      jest.advanceTimersByTime(speed);
       expect(beforeSlideSpy).toBeCalledWith(0, 1);
       expect(afterSlideSpy).toBeCalledWith(1);
     });
@@ -623,8 +628,14 @@ describe('<Carousel />', () => {
           <p>Slide 3</p>
         </Carousel>
       );
-      wrapper.instance().nextSlide();
-      wrapper.instance().nextSlide();
+
+      jest.useFakeTimers();
+
+      for (let i = 0; i < 2; i++) {
+        wrapper.instance().nextSlide();
+        jest.advanceTimersByTime(500);
+      }
+
       expect(wrapper).toHaveState({ currentSlide: 2 });
       wrapper.instance().nextSlide();
       expect(wrapper).toHaveState({ currentSlide: 2 });


### PR DESCRIPTION
### Description

Carousel would go into an infinite loop between two slide. Added a `isTransitioning` check to wait until `afterSlide` is finish.

Fixes #427, #416 (these are the issues I am aware of that are related to this)

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

yarn test && yarn test-e2e (had to add some wait time so that the transition could complete)

### Checklist: (Feel free to delete this section upon completion)

- [x] My code follows the style guidelines of this project (I have run `yarn lint`)
- [x] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
