### PR TITLE
Add active class

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ A set of eight render props for rendering controls in different positions around
 
 - The function returns the props for `goToSlide`, `nextSlide` and `previousSlide` functions in addition to `slideCount` and `currentSlide` values. Can also remove all render controls using `withoutControls`.
 
+- NOTE: The className `slide-visible` is added to the currently visible slide.
+
 ### External Control of Carousel State
 
 You can control the state of the carousel from your parent component as shown below:

--- a/src/transitions/fade-transition.js
+++ b/src/transitions/fade-transition.js
@@ -8,10 +8,13 @@ export default class FadeTransition extends React.Component {
   }
 
   formatChildren(children, opacity) {
+    const { currentSlide, slidesToShow } = this.props;
     return React.Children.map(children, (child, index) => {
+      const visible =
+        index >= currentSlide && index < currentSlide + slidesToShow;
       return (
         <li
-          className="slider-slide"
+          className={`slider-slide${visible ? ' slide-visible' : ''}`}
           style={this.getSlideStyles(index, opacity)}
           key={index}
         >

--- a/src/transitions/scroll-transition.js
+++ b/src/transitions/scroll-transition.js
@@ -63,13 +63,13 @@ export default class ScrollTransition extends React.Component {
   }
 
   formatChildren(children) {
-    const positionValue = this.props.vertical
-      ? this.props.top
-      : this.props.left;
+    const { top, left, currentSlide } = this.props;
+    const positionValue = this.props.vertical ? top : left;
     return React.Children.map(children, (child, index) => {
+      const visible = index >= currentSlide && index < currentSlide + 1;
       return (
         <li
-          className="slider-slide"
+          className={`slider-slide${visible ? ' slide-visible' : ''}`}
           style={this.getSlideStyles(index, positionValue)}
           key={index}
         >

--- a/test/specs/carousel.test.js
+++ b/test/specs/carousel.test.js
@@ -73,6 +73,18 @@ describe('<Carousel />', () => {
       expect(children).toHaveLength(1);
     });
 
+    it('should render visible child with the `slide-visible` class.', () => {
+      const wrapper = mount(
+        <Carousel>
+          <p>Slide 1</p>
+          <p>Slide 2</p>
+          <p>Slide 3</p>
+        </Carousel>
+      );
+      const children = wrapper.find('.slide-visible');
+      expect(children).toHaveLength(1);
+    });
+
     it('should render controls by default.', () => {
       const wrapper = mount(
         <Carousel>


### PR DESCRIPTION
### Description
Add `slide-visible` class to currently visible slide

Fixes # (issue)
https://github.com/FormidableLabs/nuka-carousel/issues/112

#### Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update - need to add to readme


