### PR TITLE
fix active class when slidesToShow is more than 1

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -12,7 +12,7 @@ class App extends React.Component {
       length: 6,
       wrapAround: false,
       underlineHeader: false,
-      slidesToShow: 1.0,
+      slidesToShow: 1,
       cellAlign: 'left',
       transitionMode: 'scroll',
       heightMode: 'max',

--- a/src/transitions/scroll-transition.js
+++ b/src/transitions/scroll-transition.js
@@ -63,10 +63,11 @@ export default class ScrollTransition extends React.Component {
   }
 
   formatChildren(children) {
-    const { top, left, currentSlide } = this.props;
+    const { top, left, currentSlide, slidesToShow } = this.props;
     const positionValue = this.props.vertical ? top : left;
     return React.Children.map(children, (child, index) => {
-      const visible = index >= currentSlide && index < currentSlide + 1;
+      const visible =
+        index >= currentSlide && index < currentSlide + slidesToShow;
       return (
         <li
           className={`slider-slide${visible ? ' slide-visible' : ''}`}


### PR DESCRIPTION
This PR fixes an issue that didn't allow for `slide-visible` to be added to multiple slides if `slidesToShow` was more than 1
