### PR TITLE
Fix issues where `clickDisabled` is set to true too often

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -458,7 +458,7 @@ export default class Carousel extends React.Component {
     // wait for `handleClick` event before resetting clickDisabled
     setTimeout(() => {
       this.clickDisabled = false;
-    }, 200);
+    }, 0);
     this.touchObject = {};
 
     this.setState({

--- a/src/index.js
+++ b/src/index.js
@@ -352,7 +352,9 @@ export default class Carousel extends React.Component {
               Math.sqrt(Math.pow(e.clientX - this.touchObject.startX, 2))
             );
 
-        this.clickDisabled = true;
+        // prevents disabling click just because mouse moves a fraction of a pixel
+        if (length >= 10) this.clickDisabled = true;
+
         this.touchObject = {
           startX: this.touchObject.startX,
           startY: this.touchObject.startY,


### PR DESCRIPTION
### Description

Endusers of my implementation of nuka have been complaining that sometimes their clicks don't register. So I looked into this...

1) I found that 200ms is a bit too high to wait before resetting `clickDisabled` state after swiping. This caused some users' clicks not to register even after the swiping behavior. Clicks should only be disabled for the minimum amount of time necessary while swiping/dragging and not a moment later.
2) Occasionally `onMouseMove` is invoked even at the slightest mouse movement. This is unnoticeable to the user, but noticeable to the code which then disables the click event altogether leaving the enduser confused.

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)