### PR TITLE
Make `pauseOnHover` work even when swiping/dragging is disabled

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -196,7 +196,14 @@ export default class Carousel extends React.Component {
 
   getTouchEvents() {
     if (this.props.swiping === false) {
-      return null;
+      return {
+        onTouchStart: () => {
+          this.handleMouseOver();
+        },
+        onTouchEnd: () => {
+          this.handleMouseOut();
+        }
+      };
     }
 
     return {
@@ -266,7 +273,11 @@ export default class Carousel extends React.Component {
 
   getMouseEvents() {
     if (this.props.dragging === false) {
-      return null;
+      return {
+        onMouseOver: () => this.handleMouseOver(),
+
+        onMouseOut: () => this.handleMouseOut()
+      };
     }
 
     return {


### PR DESCRIPTION
### Description

Right now `pauseOnHover` doesn't work when dragging or swiping is disabled with props. This commit fixes it.

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Tested manually. (I didn't add tests because there are no tests atm for `pauseOnHover` at all.)

### Checklist: (Feel free to delete this section upon completion)

- [x] My code follows the style guidelines of this project (I have run `yarn lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
