### PR TITLE
add logic to toggle btw 2 and 6 slides

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ yarn start
 
 You can access the application on your localhost at the following url: <a href="http://localhost:8080/demo" target="_blank">Local Demo</a>
 
-Or on CodeSandeBox at the following url: <a href="https://codesandbox.io/s/mjxwl64p2y" target="_blank">CodeSandBox Demo</a>
+Or on CodeSandeBox at the following url: <a href="https://codesandbox.io/s/04wxloyyp" target="_blank">CodeSandBox Demo</a>
 
 ### Controls
 

--- a/demo/app.js
+++ b/demo/app.js
@@ -85,7 +85,7 @@ class App extends React.Component {
                 })
               }
             >
-              Toggle 2 Slides
+              Toggle Show 2 Slides Only
             </button>
             <button
               onClick={() =>

--- a/demo/app.js
+++ b/demo/app.js
@@ -77,12 +77,15 @@ class App extends React.Component {
           <div>
             <button
               onClick={() =>
-                this.setState({
-                  length: 2
+                this.setState(prevState => {
+                  const length = prevState.length === 6 ? 2 : 6;
+                  return {
+                    length
+                  };
                 })
               }
             >
-              2 Slides Only
+              Toggle 2 Slides Only
             </button>
             <button
               onClick={() =>

--- a/demo/app.js
+++ b/demo/app.js
@@ -85,7 +85,7 @@ class App extends React.Component {
                 })
               }
             >
-              Toggle 2 Slides Only
+              Toggle 2 Slides
             </button>
             <button
               onClick={() =>

--- a/test/e2e/carousel.test.js
+++ b/test/e2e/carousel.test.js
@@ -47,7 +47,7 @@ describe('Nuka Carousel', () => {
     it('should navigate to the first slide from the second in wrapAround mode with only 2 slides.', async () => {
       await expect(page).toClick('button', { text: 'Toggle Wrap Around' });
       await page.waitFor(600); // need to let slide transition complete
-      await expect(page).toClick('button', { text: 'Toggle 2 Slides Only' });
+      await expect(page).toClick('button', { text: 'Toggle 2 Slides' });
       await page.waitFor(600); // need to let slide transition complete
       await expect(page).toClick('button', { text: '2' });
       await expect(page).toMatch('Nuka Carousel: Slide 2');

--- a/test/e2e/carousel.test.js
+++ b/test/e2e/carousel.test.js
@@ -47,7 +47,9 @@ describe('Nuka Carousel', () => {
     it('should navigate to the first slide from the second in wrapAround mode with only 2 slides.', async () => {
       await expect(page).toClick('button', { text: 'Toggle Wrap Around' });
       await page.waitFor(600); // need to let slide transition complete
-      await expect(page).toClick('button', { text: 'Toggle 2 Slides' });
+      await expect(page).toClick('button', {
+        text: 'Toggle Show 2 Slides Only'
+      });
       await page.waitFor(600); // need to let slide transition complete
       await expect(page).toClick('button', { text: '2' });
       await expect(page).toMatch('Nuka Carousel: Slide 2');

--- a/test/e2e/carousel.test.js
+++ b/test/e2e/carousel.test.js
@@ -47,7 +47,7 @@ describe('Nuka Carousel', () => {
     it('should navigate to the first slide from the second in wrapAround mode with only 2 slides.', async () => {
       await expect(page).toClick('button', { text: 'Toggle Wrap Around' });
       await page.waitFor(600); // need to let slide transition complete
-      await expect(page).toClick('button', { text: '2 Slides Only' });
+      await expect(page).toClick('button', { text: 'Toggle 2 Slides Only' });
       await page.waitFor(600); // need to let slide transition complete
       await expect(page).toClick('button', { text: '2' });
       await expect(page).toMatch('Nuka Carousel: Slide 2');


### PR DESCRIPTION
### Description

Small fix. Notice you couldn't switch from only 2 slides back to 6 slides without refreshing the page.

#### Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### How Has This Been Tested?

yarn test && yarn test-e2e

### Checklist: (Feel free to delete this section upon completion)

- [x] My code follows the style guidelines of this project (I have run `yarn lint`)
- [x] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
