### PR TITLE
Added checks to allow clicks when a modifier key is pressed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -353,6 +353,9 @@ export default class Carousel extends React.Component {
 
   handleClick(event) {
     if (this.clickDisabled === true) {
+      if (event.metaKey || event.shiftKey || event.altKey || event.ctrlKey) {
+        return;
+      }
       event.preventDefault();
       event.stopPropagation();
 


### PR DESCRIPTION
### Description

In most use-cases the goal of the slider is to add links to content within the Web Application. In our project we are unable to CMD + Click whenever any link is wrapped by a carousel because of the preventDefault and stopPropagation.


#### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)

### Checklist: (Feel free to delete this section upon completion)

- [ ] My code follows the style guidelines of this project (I have run `yarn lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
