### PR TITLE
Fix issue about update props on beforeSlide

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -103,12 +103,12 @@ export default class Carousel extends React.Component {
   componentWillReceiveProps(nextProps) {
     const slideCount = getValidChildren(nextProps.children).length;
     const slideCountChanged = slideCount !== this.state.slideCount;
-    this.setState({
+    this.setState(prevState => ({
       slideCount,
       currentSlide: slideCountChanged
         ? nextProps.slideIndex
-        : this.state.currentSlide
-    });
+        : prevState.currentSlide
+    }));
 
     if (slideCount <= this.state.currentSlide) {
       this.goToSlide(Math.max(slideCount - 1, 0), nextProps);


### PR DESCRIPTION
### Description

Slide will not change when update props on `beforeSlide` .

we should use `arrow function` when update state with previous state.

Fixes #452 

#### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


### Checklist: (Feel free to delete this section upon completion)

- [x] My code follows the style guidelines of this project (I have run `yarn lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
