### PR TITLE
Add touch-action style only when swiping is true

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -934,7 +934,8 @@ export default class Carousel extends React.Component {
       framePadding,
       slidesToShow,
       renderAnnounceSlideMessage,
-      disableAnimation
+      disableAnimation,
+      swiping
     } = this.props;
     const duration =
       this.state.dragging ||
@@ -950,6 +951,7 @@ export default class Carousel extends React.Component {
       frameOverflow,
       vertical,
       framePadding,
+      swiping,
       frameWidth
     );
     const touchEvents = this.getTouchEvents();

--- a/src/transitions/scroll-transition.js
+++ b/src/transitions/scroll-transition.js
@@ -156,7 +156,9 @@ export default class ScrollTransition extends React.Component {
       cursor: this.props.dragging === true ? 'pointer' : 'inherit',
       boxSizing: 'border-box',
       MozBoxSizing: 'border-box',
-      touchAction: `pinch-zoom ${this.props.vertical ? 'pan-x' : 'pan-y'}`
+      touchAction: this.props.swiping
+        ? `pinch-zoom ${this.props.vertical ? 'pan-x' : 'pan-y'}`
+        : 'auto'
     };
   }
 

--- a/src/utilities/style-utilities.js
+++ b/src/utilities/style-utilities.js
@@ -108,6 +108,7 @@ export const getFrameStyles = (
   propFrameOverFlow,
   propVertical,
   propFramePadding,
+  propSwiping,
   stateFrameWidth
 ) => {
   return {
@@ -120,7 +121,9 @@ export const getFrameStyles = (
     overflow: propFrameOverFlow,
     padding: 0,
     position: 'relative',
-    touchAction: `pinch-zoom ${propVertical ? 'pan-x' : 'pan-y'}`,
+    touchAction: propSwiping
+      ? `pinch-zoom ${propVertical ? 'pan-x' : 'pan-y'}`
+      : 'auto',
     transform: 'translate3d(0, 0, 0)',
     WebkitTransform: 'translate3d(0, 0, 0)'
   };


### PR DESCRIPTION
### Description

We don't need `touch-action` on frame when `swiping` is false.
That will prevent scroll when touch upon `Carousel` element.

You can test at [https://codesandbox.io/s/o93438q32y](https://codesandbox.io/s/o93438q32y) with mobile device mode.

- [x] My code follows the style guidelines of this project (I have run `yarn lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
