### PR TITLE
Prevent multiple afterSlide calls of which some used undefined variabes, breaking slide-changes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -561,6 +561,7 @@ export default class Carousel extends React.Component {
 
     this.setState({ easing: easing[props.easing] });
     this.isTransitioning = true;
+    const previousSlide = this.state.currentSlide;
 
     if (index >= this.state.slideCount || index < 0) {
       if (!props.wrapAround) {
@@ -569,38 +570,65 @@ export default class Carousel extends React.Component {
       }
       if (index >= this.state.slideCount) {
         props.beforeSlide(this.state.currentSlide, 0);
-        this.setState(prevState => ({
-          left: props.vertical
-            ? 0
-            : this.getTargetLeft(this.state.slideWidth, prevState.currentSlide),
-          top: props.vertical
-            ? this.getTargetLeft(this.state.slideWidth, prevState.currentSlide)
-            : 0,
-          currentSlide: 0,
-          isWrappingAround: true,
-          wrapToIndex: index
-        }));
+        this.setState(
+          prevState => ({
+            left: props.vertical
+              ? 0
+              : this.getTargetLeft(
+                  this.state.slideWidth,
+                  prevState.currentSlide
+                ),
+            top: props.vertical
+              ? this.getTargetLeft(
+                  this.state.slideWidth,
+                  prevState.currentSlide
+                )
+              : 0,
+            currentSlide: 0,
+            isWrappingAround: true,
+            wrapToIndex: index
+          }),
+          () => {
+            setTimeout(() => {
+              this.resetAutoplay();
+              this.isTransitioning = false;
+              if (index !== previousSlide) {
+                this.props.afterSlide(0);
+              }
+            }, props.speed);
+          }
+        );
         return;
       } else {
         const endSlide = this.state.slideCount - this.state.slidesToScroll;
         props.beforeSlide(this.state.currentSlide, endSlide);
-        this.setState(prevState => ({
-          left: props.vertical
-            ? 0
-            : this.getTargetLeft(0, prevState.currentSlide),
-          top: props.vertical
-            ? this.getTargetLeft(0, prevState.currentSlide)
-            : 0,
-          currentSlide: endSlide,
-          isWrappingAround: true,
-          wrapToIndex: index
-        }));
+        this.setState(
+          prevState => ({
+            left: props.vertical
+              ? 0
+              : this.getTargetLeft(0, prevState.currentSlide),
+            top: props.vertical
+              ? this.getTargetLeft(0, prevState.currentSlide)
+              : 0,
+            currentSlide: endSlide,
+            isWrappingAround: true,
+            wrapToIndex: index
+          }),
+          () => {
+            setTimeout(() => {
+              this.resetAutoplay();
+              this.isTransitioning = false;
+              if (index !== previousSlide) {
+                this.props.afterSlide(this.state.slideCount - 1);
+              }
+            }, props.speed);
+          }
+        );
         return;
       }
     }
 
     this.props.beforeSlide(this.state.currentSlide, index);
-    const previousSlide = this.state.currentSlide;
 
     this.setState(
       {
@@ -892,13 +920,6 @@ export default class Carousel extends React.Component {
                         this.setState({
                           resetWrapAroundPosition: false
                         });
-                        this.isTransitioning = false;
-                        if (this.props.currentSlide > this.props.slideCount) {
-                          this.props.afterSlide(0);
-                        } else {
-                          this.props.afterSlide(this.props.slideCount - 1);
-                        }
-                        this.resetAutoplay();
                       }
                     );
                   }


### PR DESCRIPTION
### Description

After upgrading Nuka Carousel to 4.4.4, our `afterSlide` callbacks were being called twice and with `slideIndex === NaN`. After quickly checking, it seemed that the library tries to call `props.slideCount`, but `slideCount` is not a prop of the component. Further investigating, seemed that the before/after callbacks seemed to be best placed in the `goToSlide` function, so that's what this PR also includes (`afterSlide` is not used outside of this function anymore).

#### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Switching slides and adding a console.log to the `afterSlide` prop to see how often it gets called and with what value. Then debugged it down some more to come to the fixes in this PR.

### Checklist: 

- [X] My code follows the style guidelines of this project (I have run `yarn lint`)
- [x] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
