### PR TITLE
Fix click event handler on button within slide element

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -326,7 +326,7 @@ export default class Carousel extends React.Component {
         });
       },
       onMouseUp: e => {
-        if (!this.state.dragging) {
+        if (!this.state.dragging || !this.touchObject.length) {
           return;
         }
 
@@ -381,6 +381,7 @@ export default class Carousel extends React.Component {
       }
     }
   }
+
   handleSwipe() {
     let slidesToShow = this.state.slidesToShow;
     if (this.props.slidesToScroll === 'auto') {


### PR DESCRIPTION
### Description

This PR fixes the click event handler for buttons that are within the slide elements. Clicking a button was firing the `handleSwipe` method, when it should only fire it's own onClick handler. By checking onMouseUp if there is a direction on the click event, we can avoid unnecessary swipe method calls.

Fixes https://github.com/FormidableLabs/nuka-carousel/issues/462

#### Type of Change

- [x ] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Add a button to the slides with an onClick handler that changes the slideIndex

### Checklist: (Feel free to delete this section upon completion)

- [x ] My code follows the style guidelines of this project (I have run `yarn lint`)
- [ x] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [ x] I have performed a self-review of my own code
- [ x] My changes generate no new warnings