### PR TITLE
Fix dropdown and button bug in slides

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -262,10 +262,6 @@ export default class Carousel extends React.Component {
       onMouseOut: () => this.handleMouseOut(),
 
       onMouseDown: e => {
-        if (e.preventDefault) {
-          e.preventDefault();
-        }
-
         this.touchObject = {
           startX: e.clientX,
           startY: e.clientY
@@ -275,6 +271,7 @@ export default class Carousel extends React.Component {
           dragging: true
         });
       },
+
       onMouseMove: e => {
         if (!this.state.dragging) {
           return;
@@ -325,13 +322,19 @@ export default class Carousel extends React.Component {
             : 0
         });
       },
+
       onMouseUp: e => {
-        if (!this.state.dragging || !this.touchObject.length) {
+        if (
+          this.touchObject.length === 0 ||
+          this.touchObject.length === undefined
+        ) {
+          this.setState({ dragging: false });
           return;
         }
 
         this.handleSwipe(e);
       },
+
       onMouseLeave: e => {
         if (!this.state.dragging) {
           return;


### PR DESCRIPTION
### Description

this PR adjusts the mouseUp handler to account for click buttons or drop downs within the slide.
By checking for a `0` or `undefined` touchObject.length in the `mouseUp` method, we account for clicks on buttons or dropdown menus within the slide and return early before firing the `handleSwipe` method. This is essentially the same as `dragging === false`, but dragging is not set to `false` onClick and we can tell it's not a `dragging` event if the `touchObject.length` is `0 || undefined`. This allows us to remove the `e.preventDefault` statement from the `mouseDown` event because we are handling the event manually.

Fixes #484 

#### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
