### PR TITLE
Disabled animation for initial slide on page load

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -22,14 +22,14 @@ class App extends React.Component {
     };
 
     this.handleImageClick = this.handleImageClick.bind(this);
-    this.handleZoomChangeChange = this.handleZoomChangeChange.bind(this);
+    this.handleZoomScaleChange = this.handleZoomScaleChange.bind(this);
   }
 
   handleImageClick() {
     this.setState({ underlineHeader: !this.state.underlineHeader });
   }
 
-  handleZoomChangeChange(event) {
+  handleZoomScaleChange(event) {
     this.setState({
       zoomScale: event.target.value
     });
@@ -176,7 +176,7 @@ class App extends React.Component {
                 <input
                   type="number"
                   value={this.state.zoomScale}
-                  onChange={this.handleZoomChangeChange}
+                  onChange={this.handleZoomScaleChange}
                 />
               )}
               <button

--- a/demo/app.js
+++ b/demo/app.js
@@ -22,14 +22,14 @@ class App extends React.Component {
     };
 
     this.handleImageClick = this.handleImageClick.bind(this);
-    this.handleZoomScaleChange = this.handleZoomScaleChange.bind(this);
+    this.handleZoomChangeChange = this.handleZoomChangeChange.bind(this);
   }
 
   handleImageClick() {
     this.setState({ underlineHeader: !this.state.underlineHeader });
   }
 
-  handleZoomScaleChange(event) {
+  handleZoomChangeChange(event) {
     this.setState({
       zoomScale: event.target.value
     });
@@ -176,7 +176,7 @@ class App extends React.Component {
                 <input
                   type="number"
                   value={this.state.zoomScale}
-                  onChange={this.handleZoomScaleChange}
+                  onChange={this.handleZoomChangeChange}
                 />
               )}
               <button

--- a/src/index.js
+++ b/src/index.js
@@ -53,6 +53,7 @@ export default class Carousel extends React.Component {
       currentSlide: this.props.slideIndex,
       dragging: false,
       easing: easing.easeCircleOut,
+      hasInteraction: false, // to remove animation from the initial slide on the page load when non-default slideIndex is used
       isWrappingAround: false,
       left: 0,
       resetWrapAroundPosition: false,
@@ -567,7 +568,7 @@ export default class Carousel extends React.Component {
       return;
     }
 
-    this.setState({ easing: easing[props.easing] });
+    this.setState({ hasInteraction: true, easing: easing[props.easing] });
     this.isTransitioning = true;
     const previousSlide = this.state.currentSlide;
 
@@ -868,7 +869,9 @@ export default class Carousel extends React.Component {
       renderAnnounceSlideMessage
     } = this.props;
     const duration =
-      this.state.dragging || this.state.resetWrapAroundPosition
+      this.state.dragging ||
+      this.state.resetWrapAroundPosition ||
+      !this.state.hasInteraction
         ? 0
         : this.props.speed;
 


### PR DESCRIPTION
### Description

Disabled animation for an initial slide when non-default slideIndex prop is passed. 

Fixes #426

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)


### Checklist: (Feel free to delete this section upon completion)

- [x] My code follows the style guidelines of this project (I have run `yarn lint`)
- [x] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

