### PR TITLE
React move 4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "d3-ease": "^1.0.3",
     "exenv": "^1.2.0",
     "prop-types": "^15.6.0",
-    "react-move": "^2.7.0"
+    "react-move": "^4.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.42",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "d3-ease": "^1.0.3",
     "exenv": "^1.2.0",
     "prop-types": "^15.6.0",
-    "react-move": "^4.0.0"
+    "react-move": "^4.0.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.42",
@@ -46,8 +46,8 @@
     "jest-puppeteer-preset": "^2.0.1",
     "prettier": "1.15.3",
     "puppeteer": "^1.1.1",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0",
+    "react": "^16.3.2",
+    "react-dom": "^16.3.3",
     "react-hot-loader": "^1.3.0",
     "react-test-renderer": "^16.2.0",
     "sinon": "^4.4.2",

--- a/package.json
+++ b/package.json
@@ -60,8 +60,8 @@
     "webpack-dev-server": "^3.0.0"
   },
   "peerDependencies": {
-    "react": "^0.14.9 || ^15.3.0 || ^16.0.0",
-    "react-dom": "^0.14.9 || ^15.3.0 || ^16.0.0"
+    "react": "^16.3.0",
+    "react-dom": "^16.3.0"
   },
   "scripts": {
     "build": "builder concurrent --buffer build-lib build-es",

--- a/src/animate.js
+++ b/src/animate.js
@@ -1,0 +1,16 @@
+import { createAnimate } from 'react-move';
+
+const numeric = (beg, end) => {
+  const a = +beg;
+  const b = +end - a;
+
+  return function(t) {
+    return a + b * t;
+  };
+};
+
+const getInterpolator = (begValue, endValue) => {
+  return numeric(begValue, endValue);
+};
+
+export default createAnimate(getInterpolator);

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ExecutionEnvironment from 'exenv';
-import Animate from 'react-move/Animate';
+import Animate from './animate';
 import * as easing from 'd3-ease';
 import { PagingDots, PreviousButton, NextButton } from './default-controls';
 import Transitions from './all-transitions';


### PR DESCRIPTION
### Description

I realize you probably can't merge this.  **This PR would drop the size of this library by ~33% (!).** Locally it looks like a gzipped version would be ~14kb.  React-move 4.0 breaks the dependency on d3-interpolate and allows you to setup just the interpolators that you need.  In this library you are only interpolating numbers and applying ease functions to transitions. This PR sets up the interpolation and creates a local Animate component. 

**This PR also sets the react peer for Nuka to ^16.3 because that's needed for react-move 4.0.**  You would need to cut support for earlier versions of react.  I realize you may not want to do that.  This is more of an FYI.  

Cheers!

Fixes # (issue)
https://github.com/FormidableLabs/nuka-carousel/issues/363

#### Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist: (Feel free to delete this section upon completion)

- [x] My code follows the style guidelines of this project (I have run `yarn lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] For any breaking API changes, I have updated the type definitions in [`index.d.ts`](../index.d.ts)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
