### PR TITLE
add cellAlign to CarouselSlideRenderControlProps

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,6 +19,11 @@ export type CarouselSlideWidthProp = string | number;
 
 export interface CarouselSlideRenderControlProps {
   /**
+   * When displaying more than one slide, sets which position to anchor the current slide to.
+   */
+  cellAlign: CarouselCellAlignProp;
+
+  /**
    * Space between slides, as an integer, but reflected as px
    */
   cellSpacing: number;


### PR DESCRIPTION
### Description

the prop `cellAlign` is missing in the `CarouselSlideRenderControlProps` interface

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

