### PR TITLE
Fix speed slide flicker

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -872,7 +872,7 @@ export default class Carousel extends React.Component {
     } = this.props;
     const duration =
       this.state.dragging ||
-      this.state.resetWrapAroundPosition ||
+      this.state.resetWrapAroundPosition && this.props.wrapAround ||
       disableAnimation ||
       !this.state.hasInteraction
         ? 0

--- a/src/index.js
+++ b/src/index.js
@@ -872,7 +872,7 @@ export default class Carousel extends React.Component {
     } = this.props;
     const duration =
       this.state.dragging ||
-      this.state.resetWrapAroundPosition && this.props.wrapAround ||
+      (this.state.resetWrapAroundPosition && this.props.wrapAround) ||
       disableAnimation ||
       !this.state.hasInteraction
         ? 0

--- a/src/index.js
+++ b/src/index.js
@@ -872,7 +872,9 @@ export default class Carousel extends React.Component {
     } = this.props;
     const duration =
       this.state.dragging ||
-      (this.state.resetWrapAroundPosition && this.props.wrapAround) ||
+      (!this.state.dragging &&
+        this.state.resetWrapAroundPosition &&
+        this.props.wrapAround) ||
       disableAnimation ||
       !this.state.hasInteraction
         ? 0
@@ -947,7 +949,8 @@ export default class Carousel extends React.Component {
                           left: newLeft,
                           top: newTop,
                           isWrappingAround: false,
-                          resetWrapAroundPosition: true
+                          resetWrapAroundPosition: true,
+                          dragging: false
                         },
                         () => {
                           this.setState({


### PR DESCRIPTION
### Description

@lauterry opened the issue #493 and it also happened to me. When we scroll on the carousel sometimes it just pop to the next image very quickly. The issue comes from the fix of PR #458 where the `resetWrapAroundPosition` state is set to true which changes the `duration` variable to 0 instead of taking the speed props. My fix is to get the `resetWrapAroundPosition` state only if the props `wrapAround` is enabled.

Fixes #493 

#### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

