### PR TITLE
Fix dragging

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -954,7 +954,8 @@ export default class Carousel extends React.Component {
                           left: newLeft,
                           top: newTop,
                           isWrappingAround: false,
-                          resetWrapAroundPosition: true
+                          resetWrapAroundPosition: true,
+                          dragging: false
                         },
                         () => {
                           this.setState({
@@ -978,7 +979,9 @@ export default class Carousel extends React.Component {
             )}
           />
         </div>
+
         {this.renderControls()}
+
         {this.props.autoGenerateStyleTag && (
           <style
             type="text/css"

--- a/src/index.js
+++ b/src/index.js
@@ -899,12 +899,7 @@ export default class Carousel extends React.Component {
     const touchEvents = this.getTouchEvents();
     const mouseEvents = this.getMouseEvents();
     const TransitionControl = Transitions[this.props.transitionMode];
-    const validChildren = addAccessibility(
-      getValidChildren(this.props.children),
-      slidesToShow,
-      currentSlide
-    );
-    const transitionProps = getTransitionProps(this.props, this.state);
+    const validChildren = getValidChildren(this.props.children);
 
     return (
       <div
@@ -931,12 +926,10 @@ export default class Carousel extends React.Component {
           <Animate
             show
             start={{ tx: 0, ty: 0 }}
-            update={() => {
-              const { tx, ty } = this.getOffsetDeltas();
-
-              return {
-                tx,
-                ty,
+            update={Object.assign(
+              {},
+              this.getOffsetDeltas(this.touchObject, this.props, this.state),
+              {
                 timing: {
                   duration,
                   ease: this.state.easing
@@ -959,8 +952,7 @@ export default class Carousel extends React.Component {
                           left: newLeft,
                           top: newTop,
                           isWrappingAround: false,
-                          resetWrapAroundPosition: true,
-                          dragging: false
+                          resetWrapAroundPosition: true
                         },
                         () => {
                           this.setState({
@@ -971,18 +963,20 @@ export default class Carousel extends React.Component {
                     }
                   }
                 }
-              };
-            }}
+              }
+            )}
             children={({ tx, ty }) => (
-              <TransitionControl {...transitionProps} deltaX={tx} deltaY={ty}>
-                {validChildren}
+              <TransitionControl
+                {...getTransitionProps(this.props, this.state)}
+                deltaX={tx}
+                deltaY={ty}
+              >
+                {addAccessibility(validChildren, slidesToShow, currentSlide)}
               </TransitionControl>
             )}
           />
         </div>
-
         {this.renderControls()}
-
         {this.props.autoGenerateStyleTag && (
           <style
             type="text/css"

--- a/src/index.js
+++ b/src/index.js
@@ -926,10 +926,12 @@ export default class Carousel extends React.Component {
           <Animate
             show
             start={{ tx: 0, ty: 0 }}
-            update={Object.assign(
-              {},
-              this.getOffsetDeltas(this.touchObject, this.props, this.state),
-              {
+            update={() => {
+              const { tx, ty } = this.getOffsetDeltas();
+
+              return {
+                tx,
+                ty,
                 timing: {
                   duration,
                   ease: this.state.easing
@@ -963,8 +965,8 @@ export default class Carousel extends React.Component {
                     }
                   }
                 }
-              }
-            )}
+              };
+            }}
             children={({ tx, ty }) => (
               <TransitionControl
                 {...getTransitionProps(this.props, this.state)}


### PR DESCRIPTION
### Description

I noticed the dragging feature (set dragging prop to true) is not working on the current release 4.5.1.  My sincere apologies, I think I introduced that in https://github.com/FormidableLabs/nuka-carousel/pull/500.  I am really surprised nobody reported it (?)

1. To see the issue open the [sandbox](https://codesandbox.io/s/04wxloyyp)
2. Dragging works
3. Fork it and upgrade nuka to latest
4. Dragging doesn't work

Fixes # (issue)

Unreported issue where dragging does not work.

#### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I tested it on the demo app on the test suite.