### PR TITLE
[WIP] add initialCellAlign component property

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -18,7 +18,8 @@ class App extends React.Component {
       cellAlign: 'left',
       transitionMode: 'scroll',
       heightMode: 'max',
-      withoutControls: false
+      withoutControls: false,
+      initialCellAlign: null
     };
 
     this.handleImageClick = this.handleImageClick.bind(this);
@@ -49,6 +50,7 @@ class App extends React.Component {
           wrapAround={this.state.wrapAround}
           slideIndex={this.state.slideIndex}
           heightMode={this.state.heightMode}
+          initialCellAlign={this.state.initialCellAlign}
           renderTopCenterControls={({ currentSlide }) => (
             <div
               style={{
@@ -140,6 +142,33 @@ class App extends React.Component {
                   <button onClick={() => this.setState({ cellAlign: 'right' })}>
                     Right
                   </button>
+                  {this.state.cellAlign === 'center' && (
+                    <>
+                      <br />
+                      <button
+                        onClick={() =>
+                          this.setState({
+                            initialCellAlign: this.state.initialCellAlign
+                              ? null
+                              : 'left'
+                          })
+                        }
+                      >
+                        Toggle initial cellAlign Left
+                      </button>
+                      <button
+                        onClick={() =>
+                          this.setState({
+                            initialCellAlign: this.state.initialCellAlign
+                              ? null
+                              : 'right'
+                          })
+                        }
+                      >
+                        Toggle initial cellAlign Right
+                      </button>
+                    </>
+                  )}
                 </div>
               )}
               <div style={{ marginLeft: 'auto' }}>


### PR DESCRIPTION
### Description

This PR aims to extend the component providing the possibility to pass an initialCellAlign property with possible values `left` or `right`. Especially on mobile devices that can be a UX requirement. This makes sense i.e. if you want the carousel to center partially shown elements but not have the elements centered (i.e. left-aligned) once the component is mounted and thus presented to the user. So in that case, it would be a combination of left-aligned (when the carousel is mounted) and center-aligned (when the carousel is used). 

Fixes # (issue)
#512 

#### Type of Change
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### How Has This Been Tested?
tba

### Checklist: (Feel free to delete this section upon completion)

- [ ] My code follows the style guidelines of this project (I have run `yarn lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] For any breaking API changes, I have updated the type definitions in [`index.d.ts`](../index.d.ts)
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
