### PR TITLE
Fix changing to vertical mode and backwards, add missed prop to @types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -101,6 +101,12 @@ export interface CarouselProps {
   afterSlide?: (prevSlide: number) => void;
 
   /**
+   * Will generate a style tag to help ensure images are displayed properly
+   * @default true
+   */
+  autoGenerateStyleTag?: boolean;
+
+  /**
    * Autoplay mode active
    * @default false
    */

--- a/src/index.js
+++ b/src/index.js
@@ -155,7 +155,10 @@ export default class Carousel extends React.Component {
   componentDidUpdate(prevProps, prevState) {
     const slideChanged = prevState.currentSlide !== this.state.currentSlide;
     const heightModeChanged = prevProps.heightMode !== this.props.heightMode;
-    if (slideChanged || heightModeChanged) {
+    const axisChanged = prevProps.vertical !== this.props.vertical;
+    if (axisChanged) {
+      this.onResize();
+    } else if (slideChanged || heightModeChanged) {
       this.setSlideHeightAndWidth();
     }
   }


### PR DESCRIPTION
### Description

Add missed prop description from **index.d.ts** file.
Fix the issue with incorrect calculations of slides and carousel dimensions after toggling mode from horizontal to vertical and vice-versa.

Fixes #515 

#### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Created an additional button for toggling vertical/horizontal mode with different slides amount for each mode. Add autoGenerateStyleTag property as false and saw slides overlaping and incorrect calculation of sizes. But after little resize everything works properly.
So I decided to make this PR to help to fix this issue.

### Checklist: (Feel free to delete this section upon completion)

- [ ] My code follows the style guidelines of this project (I have run `yarn lint`)
- [ ] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [ ] I have performed a self-review of my own code
- [ ] For any breaking API changes, I have updated the type definitions in [`index.d.ts`](../index.d.ts)
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
