### PR TITLE
Add onDragStart callback

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -187,6 +187,10 @@ export default class Carousel extends React.Component {
         };
         this.handleMouseOver();
 
+        if (this.props.onDragStart) {
+          this.props.onDragStart();
+        }
+
         this.setState({
           dragging: true
         });
@@ -267,6 +271,10 @@ export default class Carousel extends React.Component {
           startX: e.clientX,
           startY: e.clientY
         };
+
+        if (this.props.onDragStart) {
+          this.props.onDragStart();
+        }
 
         this.setState({
           dragging: true
@@ -1012,6 +1020,7 @@ Carousel.propTypes = {
   heightMode: PropTypes.oneOf(['first', 'current', 'max']),
   initialSlideHeight: PropTypes.number,
   initialSlideWidth: PropTypes.number,
+  onDragStart: PropTypes.func,
   onResize: PropTypes.func,
   pauseOnHover: PropTypes.bool,
   renderAnnounceSlideMessage: PropTypes.func,


### PR DESCRIPTION
### Description

This adds an onDragStart callback. I found this useful when trying to hint that this was a carousel (displayed with no controls), and I wanted to hide the hint as soon as someone interacted with it.

#### Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### How Has This Been Tested?

I ran this locally and verified that my callback function was called when I started dragging the carousel

### Checklist: (Feel free to delete this section upon completion)

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] For any breaking API changes, I have updated the type definitions in [`index.d.ts`](../index.d.ts)
