### PR TITLE
don't wrap handleMouseOut handler in extra function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -170,12 +170,8 @@ export default class Carousel extends React.Component {
   getTouchEvents() {
     if (this.props.swiping === false) {
       return {
-        onTouchStart: () => {
-          this.handleMouseOver();
-        },
-        onTouchEnd: () => {
-          this.handleMouseOut();
-        }
+        onTouchStart: this.handleMouseOver,
+        onTouchEnd: this.handleMouseOut
       };
     }
 
@@ -251,16 +247,16 @@ export default class Carousel extends React.Component {
   getMouseEvents() {
     if (this.props.dragging === false) {
       return {
-        onMouseOver: () => this.handleMouseOver(),
+        onMouseOver: this.handleMouseOver,
 
-        onMouseOut: () => this.handleMouseOut()
+        onMouseOut: this.handleMouseOut
       };
     }
 
     return {
-      onMouseOver: () => this.handleMouseOver(),
+      onMouseOver: this.handleMouseOver,
 
-      onMouseOut: () => this.handleMouseOut(),
+      onMouseOut: this.handleMouseOut,
 
       onMouseDown: e => {
         this.touchObject = {


### PR DESCRIPTION
### Description

Extra anonymous functions around a component's event handler can prevent event's from being deregistered when the component is unmounted resulting in a memory leak.