### PR TITLE
Adds classnames to pagination for ease of styling

### DIFF
--- a/src/default-controls.js
+++ b/src/default-controls.js
@@ -150,12 +150,10 @@ export class PagingDots extends React.Component {
 
   getButtonStyles(active) {
     return {
-      border: 0,
       cursor: 'pointer',
       opacity: active ? 1 : 0.5,
-      borderRadius: '3px',
       background: 'transparent',
-      padding: '10px'
+      border: 'none'
     };
   }
 
@@ -187,8 +185,8 @@ export class PagingDots extends React.Component {
                 <span
                   className="paging-dot"
                   style={{
-                    display: 'block',
-                    borderRadius: '3px',
+                    display: 'inline-block',
+                    borderRadius: '50%',
                     width: '6px',
                     height: '6px',
                     background: 'black'

--- a/src/default-controls.js
+++ b/src/default-controls.js
@@ -151,12 +151,11 @@ export class PagingDots extends React.Component {
   getButtonStyles(active) {
     return {
       border: 0,
-      background: 'transparent',
-      color: 'black',
       cursor: 'pointer',
-      padding: 10,
-      fontSize: 24,
-      opacity: active ? 1 : 0.5
+      opacity: active ? 1 : 0.5,
+      borderRadius: '3px',
+      background: 'transparent',
+      padding: '10px'
     };
   }
 
@@ -171,13 +170,30 @@ export class PagingDots extends React.Component {
       <ul style={this.getListStyles()}>
         {indexes.map(index => {
           return (
-            <li style={this.getListItemStyles()} key={index}>
+            <li
+              style={this.getListItemStyles()}
+              key={index}
+              className={
+                this.props.currentSlide === index
+                  ? 'paging-item active'
+                  : 'paging-item'
+              }
+            >
               <button
                 style={this.getButtonStyles(this.props.currentSlide === index)}
                 onClick={this.props.goToSlide.bind(null, index)}
                 aria-label={`slide ${index + 1} bullet`}
               >
-                &bull;
+                <span
+                  className="paging-dot"
+                  style={{
+                    display: 'block',
+                    borderRadius: '3px',
+                    width: '6px',
+                    height: '6px',
+                    background: 'black'
+                  }}
+                />
               </button>
             </li>
           );


### PR DESCRIPTION
### Description

Previously, the pagination dots used a hard-coded &bull HTML symbol, which was restrictive in terms of styling and shape. This PR changes that to use CSS for the bullet styles, adds classnames to the bullet list items so you can hook styles in, and adds an active class, again for ease of styling.

In the future, this opens up opportunity to add props for pagination styles etc.

#### Type of Change

- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Tests run as per the Contributing.md

### Checklist: (Feel free to delete this section upon completion)

- [x] My code follows the style guidelines of this project (I have run `yarn lint`)
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [n/a] For any breaking API changes, I have updated the type definitions in [`index.d.ts`](../index.d.ts)
- [x] My changes generate no new warnings
- [n/a] Any dependent changes have been merged and published in downstream modules
