### PR TITLE
Add resize height issue details

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,22 @@ export default class extends React.Component {
 
 TypeScript type definitions are now shipped with nuka-carousel. You can use them directly from the library.
 
+### Resizing Height Issue
+
+When using dynamic content in a slide such as text, you may see an issue with resizing the height of the component when loading in an iframe, or forcing the component to load synchronously after another component such as a loading screen, or interstitial.
+
+#### How resizing works
+
+In componentDidMount, the initial dimensions are assigned to each slide:
+
+- Width: `initialSlidewidth` || `slideWidth` || (`slidesToShow` / width of container)
+- Height: `initialSlideHeight`
+
+Once the component has completed mounting with the accurate width, it waits for the readyStateChange event to fire before measuring the desired height of the content (`current`, `first`, `max`). That measurement then replaces `initialSlideHeight` with the measured height in pixels.
+
+If the readyStateChange event fires before the component completes mounting, the height of the component is not measured until a resize event or a change in slide is triggered.
+
+
 ### Contributing
 
 See the [Contribution Docs](CONTRIBUTING.md).


### PR DESCRIPTION
Adding info about how the height is initially determined, and why resizing or scrolling through slides fixes it.

### Description

I was able to reproduce issues #457, #521, and #522 by adding a timeout of 1 second before allowing the slider to load. Though no fix has been implemented yet, this PR adds info into the README.

#### Type of Change

Documentation update.