### PR TITLE
Fixed visibility for initial load and added height prop

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -154,6 +154,12 @@ export interface CarouselProps {
   enableKeyboardControls?: boolean;
 
   /**
+   * Disable slides animation
+   * @default false
+   */
+  disableAnimation?: boolean;
+
+  /**
    * Enable mouse swipe/dragging
    */
   dragging?: boolean;
@@ -183,6 +189,13 @@ export interface CarouselProps {
    * @example '500px'
    */
   framePadding?: string;
+
+  /**
+   * Used to hardcode the slider height
+   * @example '80%'
+   * @example '500px'
+   */
+  height?: string;
 
   /**
    * Change the height of the slides based either on the first slide,

--- a/src/index.js
+++ b/src/index.js
@@ -954,7 +954,7 @@ export default class Carousel extends React.Component {
         className={['slider', this.props.className || ''].join(' ')}
         style={Object.assign(
           {},
-          getSliderStyles(this.props.width, this.state.slideWidth),
+          getSliderStyles(this.props.width, this.props.height),
           this.props.style
         )}
       >
@@ -1057,6 +1057,7 @@ Carousel.propTypes = {
   edgeEasing: PropTypes.string,
   frameOverflow: PropTypes.string,
   framePadding: PropTypes.string,
+  height: PropTypes.string,
   heightMode: PropTypes.oneOf(['first', 'current', 'max']),
   initialSlideHeight: PropTypes.number,
   initialSlideWidth: PropTypes.number,
@@ -1108,6 +1109,7 @@ Carousel.defaultProps = {
   edgeEasing: 'easeElasticOut',
   frameOverflow: 'hidden',
   framePadding: '0px',
+  height: 'auto',
   heightMode: 'max',
   onResize() {},
   pauseOnHover: true,

--- a/src/utilities/style-utilities.js
+++ b/src/utilities/style-utilities.js
@@ -93,14 +93,13 @@ export const getDecoratorStyles = position => {
   }
 };
 
-export const getSliderStyles = (propWidth, stateSlideWidth) => {
+export const getSliderStyles = (propWidth, propHeight) => {
   return {
     boxSizing: 'border-box',
     display: 'block',
-    height: 'auto',
+    height: propHeight,
     MozBoxSizing: 'border-box',
     position: 'relative',
-    visibility: stateSlideWidth ? 'inherit' : 'hidden',
     width: propWidth
   };
 };


### PR DESCRIPTION
### Description

- Change to show first image in carrousel when loaded, instead of waiting until all assets are loaded. 
- Added prop to set hardcoded height and typescript definition (with default value ```'auto'``` as before).
- Added disableAnimation typescript definition.

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

I have run `yarn test` and `yarn test-e2e` and tests are ok.
