### PR TITLE
Added type="button" to paging dots

### DIFF
--- a/src/default-controls.js
+++ b/src/default-controls.js
@@ -178,6 +178,7 @@ export class PagingDots extends React.Component {
               }
             >
               <button
+                type="button"
                 style={this.getButtonStyles(this.props.currentSlide === index)}
                 onClick={this.props.goToSlide.bind(null, index)}
                 aria-label={`slide ${index + 1} bullet`}


### PR DESCRIPTION
The existing buttons default to type="submit", causing enclosing forms to be submitted on click