### PR TITLE
Fix wrongly calculated height for current slide on slide change

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -164,7 +164,13 @@ export default class Carousel extends React.Component {
     if (axisChanged) {
       this.onResize();
     } else if (slideChanged || heightModeChanged) {
-      this.setSlideHeightAndWidth();
+      const image = this.getCurrentChildNodeImg();
+      if (image) {
+        image.addEventListener('load', this.setSlideHeightAndWidth);
+        image.removeEventListener('load', this.setSlideHeightAndWidth);
+      } else {
+        this.setSlideHeightAndWidth();
+      }
     }
   }
 
@@ -878,6 +884,14 @@ export default class Carousel extends React.Component {
 
   getChildNodes() {
     return this.frame.childNodes[0].childNodes;
+  }
+
+  getCurrentChildNodeImg() {
+    const childNodes = this.getChildNodes();
+    const currentChildNode = childNodes[this.props.slideIndex];
+    return currentChildNode
+      ? currentChildNode.getElementsByTagName('img')[0]
+      : null;
   }
 
   setLeft() {

--- a/test/specs/carousel.test.js
+++ b/test/specs/carousel.test.js
@@ -1076,5 +1076,31 @@ describe('<Carousel />', () => {
       expect(instance.setSlideHeightAndWidth).not.toBeCalled();
       Carousel.prototype.getChildNodes.mockRestore();
     });
+
+    it('should update slide width and height only when current slide image is loaded on slide change', () => {
+      const image = new Image();
+      const wrapper = mount(
+        <Carousel>
+          <p>Slide 1</p>
+          <p>Slide 2</p>
+          <p>
+            <img src="/test.jpg" />
+          </p>
+        </Carousel>
+      );
+      const instance = wrapper.instance();
+      image.addEventListener = jest.fn();
+      image.removeEventListener = jest.fn();
+      instance.getCurrentChildNodeImg = jest.fn(() => image);
+      wrapper.setState({ currentSlide: 1 });
+      expect(image.addEventListener).toBeCalledWith(
+        'load',
+        instance.setSlideHeightAndWidth
+      );
+      expect(image.removeEventListener).toBeCalledWith(
+        'load',
+        instance.setSlideHeightAndWidth
+      );
+    });
   });
 });


### PR DESCRIPTION
### Description

Fix wrongly calculated height for current slide image on slide change
![nuka_height_recalc_bug](https://user-images.githubusercontent.com/46492012/59604901-20604980-9116-11e9-84bb-3772d5442cdc.gif)

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
