### PR TITLE
fix: add types for animation props

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -101,6 +101,11 @@ export interface CarouselProps {
   afterSlide?: (prevSlide: number) => void;
 
   /**
+   * Adds a zoom effect on the currently visible slide.
+   */
+  animation?: 'zoom';
+
+  /**
    * Will generate a style tag to help ensure images are displayed properly
    * @default true
    */


### PR DESCRIPTION
### Description

Using typescript, and then the `animation` props isn't declared in `index.d.ts`.

Fixes # (issue)
* add types for `animation` props

#### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

use `create-react-app` to create a ts react project, and then just check it type with the following code

```ts
import React from 'react';
import Carousel from 'nuka-carousel';

export default class extends React.Component {
  render() {
    return (
      <Carousel animation="zoom">
        <img src="https://via.placeholder.com/400/ffffff/c0392b/&text=slide1" />
        <img src="https://via.placeholder.com/400/ffffff/c0392b/&text=slide2" />
        <img src="https://via.placeholder.com/400/ffffff/c0392b/&text=slide3" />
      </Carousel>
    );
  }
}
```

### Checklist: (Feel free to delete this section upon completion)

- [x] My code follows the style guidelines of this project (I have run `yarn lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] For any breaking API changes, I have updated the type definitions in [`index.d.ts`](../index.d.ts)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
