### PR TITLE
Avoid the empty div wrapper for 'null' custom controls

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -912,28 +912,32 @@ export default class Carousel extends React.Component {
     } else {
       return this.controlsMap.map(({ funcName, key }) => {
         const func = this.props[funcName];
-        return (
+        const controlChildren =
           func &&
-          typeof func === 'function' && (
+          typeof func === 'function' &&
+          func({
+            cellAlign: this.props.cellAlign,
+            cellSpacing: this.props.cellSpacing,
+            currentSlide: this.state.currentSlide,
+            frameWidth: this.state.frameWidth,
+            goToSlide: index => this.goToSlide(index),
+            nextSlide: () => this.nextSlide(),
+            previousSlide: () => this.previousSlide(),
+            slideCount: this.state.slideCount,
+            slidesToScroll: this.state.slidesToScroll,
+            slidesToShow: this.state.slidesToShow,
+            slideWidth: this.state.slideWidth,
+            wrapAround: this.props.wrapAround
+          });
+
+        return (
+          controlChildren && (
             <div
               className={`slider-control-${key.toLowerCase()}`}
               style={getDecoratorStyles(key)}
               key={key}
             >
-              {func({
-                cellAlign: this.props.cellAlign,
-                cellSpacing: this.props.cellSpacing,
-                currentSlide: this.state.currentSlide,
-                frameWidth: this.state.frameWidth,
-                goToSlide: index => this.goToSlide(index),
-                nextSlide: () => this.nextSlide(),
-                previousSlide: () => this.previousSlide(),
-                slideCount: this.state.slideCount,
-                slidesToScroll: this.state.slidesToScroll,
-                slidesToShow: this.state.slidesToShow,
-                slideWidth: this.state.slideWidth,
-                wrapAround: this.props.wrapAround
-              })}
+              {controlChildren}
             </div>
           )
         );


### PR DESCRIPTION
### The situation
None element is rendered when a `render*Controls` prop in `null`  but when it is a `function that returns null` the control div wrapper is rendered empty:

![image](https://user-images.githubusercontent.com/24297787/61868196-2eee0d80-aed9-11e9-827b-223bd9669f25.png)

**Use case**: Removing the previous/next controls when they are not needed returning null depending on `currentSlide` and `slideCount` renders the empty div wrapper causing pointer-events problems.

### The proposal
This PR renders the div wrapper and the element (returned by the `render*Controls` prop) only when the `render*Controls` prop is a function and that function is not returning null/false.