### PR TITLE
Allow isEdgeSwiping to work with vertical slider

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -616,14 +616,23 @@ export default class Carousel extends React.Component {
     }
 
     return {
-      tx: [this.props.vertical ? 0 : offset],
-      ty: [this.props.vertical ? offset : 0]
+      tx: this.props.vertical ? 0 : offset,
+      ty: this.props.vertical ? offset : 0
     };
   }
 
   isEdgeSwiping() {
-    const { slideCount, slideWidth } = this.state;
-    const { tx } = this.getOffsetDeltas();
+    const { slideCount, slideWidth, slideHeight, slidesToShow } = this.state;
+    const { tx, ty } = this.getOffsetDeltas();
+
+    if (this.props.vertical) {
+      const rowHeight = slideHeight / slidesToShow;
+      const slidesLeftToShow = slideCount - slidesToShow;
+      const lastSlideLimit = rowHeight * slidesLeftToShow;
+
+      // returns true if ty offset is outside first or last slide
+      return ty > 0 || -ty > lastSlideLimit;
+    }
 
     // returns true if tx offset is outside first or last slide
     return tx > 0 || -tx > slideWidth * (slideCount - 1);


### PR DESCRIPTION
### Description

The prop `disableEdgeSwiping` was only taking into account horizontal sliders. When combined with the `vertical` prop, the disable edge swiping did not work, because the function `isEdgeSwiping` was only taking into consideration the `tx` offset, and not the `ty` offset when we are on a vertical slider.

Furthermore, i'm not sure if it was on purpose, but the `getOffsetDeltas` function, returned an array of offsets for the `tx` and `ty` keys, but in multiple parts of the code, it was used as if it return a number value. Maybe someone can clarify that to me.

Fixes # (issue)

#### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist: (Feel free to delete this section upon completion)

- [x] My code follows the style guidelines of this project (I have run `yarn lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] For any breaking API changes, I have updated the type definitions in [`index.d.ts`](../index.d.ts)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
