### PR TITLE
Export NextButton, PreviousButton, and PagingDots from `main` entrypoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,0 @@
-module.exports = require('./lib').default;
-module.exports.default = module.exports;

--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+module.exports = require('./lib').default;
+module.exports.default = module.exports;
+module.exports.NextButton = require('./lib').NextButton;
+module.exports.PreviousButton = require('./lib').PreviousButton;
+module.exports.PagingDots = require('./lib').PagingDots;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nuka-carousel",
   "version": "4.5.9",
   "description": "Pure React Carousel",
-  "main": "lib/index.js",
+  "main": "index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nuka-carousel",
   "version": "4.5.9",
   "description": "Pure React Carousel",
-  "main": "index.js",
+  "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
This ensures that all exports from src/index.js are exported via the 'main' field.

### Description

This updates the package.json `main` field to point to lib/index.js. Prior to this change, only the default export (Carousel) from src/index.js was available via the `main` entry point, omitting NextButton, PreviousButton, and PagingDots, which are available via the `module` field.

My use case is I want to server-side-render a page containing nuka-carousel, with a reference to PagingDots in order to customize styles.

#### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I tested this by making the change in my project where I am using SSR, and this makes it possible to use PagingDots.

In the course of testing this change, I noticed that PreviousButton and NextButton are not in the TypeScript library definition file (index.d.ts). I will submit a separate PR to add those.