### PR TITLE
Add missing controls to the TypeScript library definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -411,39 +411,13 @@ export interface CarouselState {
   wrapToIndex: boolean;
 }
 
-export interface PagingDotsProps {
-  /**
-   * The total number of slides
-   */
-  slideCount: number;
+export interface PreviousButtonProps extends CarouselSlideRenderControlProps {}
+export class PreviousButton extends React.Component<PreviousButtonProps> {}
 
-  /**
-   * Thte number of slides to scroll
-   */
-  slidesToScroll: number;
+export interface NextButtonProps extends CarouselSlideRenderControlProps {}
+export class NextButton extends React.Component<NextButtonProps> {}
 
-  /**
-   * The number of slides to show
-   */
-  slidesToShow: number;
-
-  /**
-   * The cell alignment
-   */
-  cellAlign: CarouselCellAlignProp;
-
-  /**
-   * The current slide
-   */
-  currentSlide: number;
-
-  /**
-   * Go to a new slide
-   * @param index The slide index to go to
-   */
-  goToSlide: (index: number) => void;
-}
-
+export interface PagingDotsProps extends CarouselSlideRenderControlProps {}
 export class PagingDots extends React.Component<PagingDotsProps> {
   public getButtonStyles(active: boolean): React.CSSProperties;
   public getListStyles(): React.CSSProperties;

--- a/tslint.json
+++ b/tslint.json
@@ -4,6 +4,7 @@
   "rules": {
     "interface-name": false,
     "max-classes-per-file": false,
+    "no-empty-interface": false,
     "quotemark": false,
     "trailing-comma": false
   }


### PR DESCRIPTION
### Description

Add PreviousButton, PreviousButtonProps, NextButton, and NextButtonProps to the TypeScript library definition.

I also updated PagingDotsProps to extend CarouseSlideRenderControlProps rather than duplicating prop types. All controls are passed the same props object and the additional props may be useful when customizing/subclassing PagingDots. I needed to disable the tslint `no-empty-interface` rule in order to eliminate the duplication without removing the existing PagingDotsProps interface, which would be disruptive to TS users.

#### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I tested this in a TypeScript project by implementing a Carousel that renders the default controls using the NextButton and PreviousButton exports from nuka-carousel, and confirmed that the type issues were resolved with this change.

```typescript
import Carousel, { NextButton, PreviousButton, PagingDots } from 'nuka-carousel'
import * as React from 'react'

<Carousel
  renderCenterLeftControls={props => <PreviousButton {...props} />}
  renderCenterRightControls={props => <NextButton {...props} />}
  renderBottomCenterControls={props => <PagingDots {...props} />}
>
  ...
</Carousel>
```