### PR TITLE
Next and Previous buttons should not implicitly be submit buttons 

### DIFF
--- a/src/default-controls.js
+++ b/src/default-controls.js
@@ -28,6 +28,7 @@ export class PreviousButton extends React.Component {
         disabled={disabled}
         onClick={this.handleClick}
         aria-label="previous"
+        type="button"
       >
         PREV
       </button>
@@ -103,6 +104,7 @@ export class NextButton extends React.Component {
         disabled={disabled}
         onClick={this.handleClick}
         aria-label="next"
+        type="button"
       >
         NEXT
       </button>


### PR DESCRIPTION
### Description

This PR removes the implicit `type="submit"` on the next and previous `button` elements and replaces them with `type="button"`.  

Fixes #554

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

To reproduce: wrap the carousel in `<form>` element, and add a sibling `<select>` element with two options. Focus the `<select>`, and press the enter key. The slides in the carousel toggle between previous/next. 

The implicit `type="submit"` on the previous and next buttons means they are trying to submit the `form` on enter. Removing the implicit `type` and replacing it with an explicit `type="button"` resolves the issue. 

### Checklist: 

I need some guidance on the best approach for testing this fix.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
