### PR TITLE
Clear all timeouts when component unmounts

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,7 @@ export default class Carousel extends React.Component {
     this.displayName = 'Carousel';
     this.clickDisabled = false;
     this.isTransitioning = false;
+    this.timers = [];
     this.touchObject = {};
     this.controlsMap = [
       { funcName: 'renderTopLeftControls', key: 'TopLeft' },
@@ -189,7 +190,9 @@ export default class Carousel extends React.Component {
     this.stopAutoplay();
     // see https://github.com/facebook/react/issues/3417#issuecomment-121649937
     this.mounted = false;
-    this.goToSlide();
+    for (let i = 0; i < this.timers.length; i++) {
+      clearTimeout(this.timers[i]);
+    }
   }
 
   establishChildNodesMutationObserver() {
@@ -478,9 +481,11 @@ export default class Carousel extends React.Component {
     }
 
     // wait for `handleClick` event before resetting clickDisabled
-    setTimeout(() => {
-      this.clickDisabled = false;
-    }, 0);
+    this.timers.push(
+      setTimeout(() => {
+        this.clickDisabled = false;
+      }, 0)
+    );
     this.touchObject = {};
 
     this.setState({
@@ -689,13 +694,15 @@ export default class Carousel extends React.Component {
             wrapToIndex: index
           }),
           () => {
-            setTimeout(() => {
-              this.resetAutoplay();
-              this.isTransitioning = false;
-              if (index !== previousSlide) {
-                this.props.afterSlide(0);
-              }
-            }, props.speed);
+            this.timers.push(
+              setTimeout(() => {
+                this.resetAutoplay();
+                this.isTransitioning = false;
+                if (index !== previousSlide) {
+                  this.props.afterSlide(0);
+                }
+              }, props.speed)
+            );
           }
         );
         return;
@@ -715,13 +722,15 @@ export default class Carousel extends React.Component {
             wrapToIndex: index
           }),
           () => {
-            setTimeout(() => {
-              this.resetAutoplay();
-              this.isTransitioning = false;
-              if (index !== previousSlide) {
-                this.props.afterSlide(this.state.slideCount - 1);
-              }
-            }, props.speed);
+            this.timers.push(
+              setTimeout(() => {
+                this.resetAutoplay();
+                this.isTransitioning = false;
+                if (index !== previousSlide) {
+                  this.props.afterSlide(this.state.slideCount - 1);
+                }
+              }, props.speed)
+            );
           }
         );
         return;
@@ -735,13 +744,15 @@ export default class Carousel extends React.Component {
         currentSlide: index
       },
       () =>
-        setTimeout(() => {
-          this.resetAutoplay();
-          this.isTransitioning = false;
-          if (index !== previousSlide) {
-            this.props.afterSlide(index);
-          }
-        }, props.speed)
+        this.timers.push(
+          setTimeout(() => {
+            this.resetAutoplay();
+            this.isTransitioning = false;
+            if (index !== previousSlide) {
+              this.props.afterSlide(index);
+            }
+          }, props.speed)
+        )
     );
   }
 


### PR DESCRIPTION
@namuwikilover I believe the issue you are experiencing is due to the timeouts not being cleared when the component unmounts. While calling `goToSlide` may have fixed your error, I don't believe that it got to the root of the issue. I have made these changes on your branch so you can test it out to see if it also solves your error. If so, I believe this is a better fix as it clears all the timeouts and not just those related to the goToSlide method.