### PR TITLE
Fix a11y issue using aria-hidden attribute (iOS only)

### DIFF
--- a/src/utilities/bootstrapping-utilities.js
+++ b/src/utilities/bootstrapping-utilities.js
@@ -1,33 +1,14 @@
 import React from 'react';
 
-export const addAccessibility = (children, slidesToShow, currentSlide) => {
-  let needsTabIndex;
+export const addAccessibility = (children, slidesToShow) => {
   if (slidesToShow > 1) {
-    return React.Children.map(children, (child, index) => {
-      // create a range from first visible slide to last visible slide
-      const firstVisibleSlide = index >= currentSlide;
-      const lastVisibleSlide = index < slidesToShow + currentSlide;
-      needsTabIndex = firstVisibleSlide && lastVisibleSlide;
-      // if the index of the slide is in range add ariaProps to the slide
-      const ariaProps = needsTabIndex
-        ? { 'aria-hidden': 'false', tabIndex: 0 }
-        : { 'aria-hidden': 'true' };
-      return React.cloneElement(child, {
-        ...child.props,
-        ...ariaProps
-      });
+    return React.Children.map(children, child => {
+      return React.cloneElement(child, child.props);
     });
   } else {
     // when slidesToshow is 1
-    return React.Children.map(children, (child, index) => {
-      needsTabIndex = index !== currentSlide;
-      const ariaProps = needsTabIndex
-        ? { 'aria-hidden': 'true' }
-        : { 'aria-hidden': 'false', tabIndex: 0 };
-      return React.cloneElement(child, {
-        ...child.props,
-        ...ariaProps
-      });
+    return React.Children.map(children, child => {
+      return React.cloneElement(child, child.props);
     });
   }
 };

--- a/test/specs/carousel.test.js
+++ b/test/specs/carousel.test.js
@@ -805,39 +805,6 @@ describe('<Carousel />', () => {
       nextButton.simulate('click');
       expect(wrapper).toHaveState({ currentSlide: 0 });
     });
-
-    it('should give children correct aria-hidden props', () => {
-      const wrapper = mount(
-        <Carousel>
-          <p>Slide 1</p>
-          <p>Slide 2</p>
-          <p>Slide 3</p>
-        </Carousel>
-      );
-      const firstChild = wrapper.find('p').first();
-      const thirdChild = wrapper.find('p').last();
-      expect(firstChild.props().tabIndex).toBe(0);
-      expect(firstChild.props()['aria-hidden']).toBe('false');
-      expect(thirdChild.props().tabIndex).toBe(undefined);
-      expect(thirdChild.props()['aria-hidden']).toBe('true');
-    });
-
-    it('should give children correct aria-hidden props when currentSlide is 1', () => {
-      const wrapper = mount(
-        <Carousel>
-          <p>Slide 1</p>
-          <p>Slide 2</p>
-          <p>Slide 3</p>
-        </Carousel>
-      );
-      wrapper.setState({ currentSlide: 2 });
-      const firstChild = wrapper.find('p').first();
-      const thirdChild = wrapper.find('p').last();
-      expect(firstChild.props().tabIndex).toBe(undefined);
-      expect(firstChild.props()['aria-hidden']).toBe('true');
-      expect(thirdChild.props().tabIndex).toBe(0);
-      expect(thirdChild.props()['aria-hidden']).toBe('false');
-    });
   });
 
   describe('Controls', () => {


### PR DESCRIPTION
### Description

In 4.4.2 there were some useful a11y changes to make Nuka more accessible. This was good until after I updated to 4.4.2 and noticed that all our home page carousels on iPhones were NOT accessible anymore.

![IMG_1020 TRIM](https://user-images.githubusercontent.com/6808172/64204597-c1c88300-ce5b-11e9-8d22-f6c9b55386d1.gif)


**Fixes #**

https://github.com/FormidableLabs/nuka-carousel/pull/425/files#r225346008

### How Has This Been Tested?

I made sure there were no regressions in the demo (seems to still be accessible across devices) and our website now behaves as expected on an iOS device with VoiceOver.
