### PR TITLE
change default prop for height, set to inherit

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1179,7 +1179,7 @@ Carousel.defaultProps = {
   edgeEasing: 'easeElasticOut',
   frameOverflow: 'hidden',
   framePadding: '0px',
-  height: 'auto',
+  height: 'inherit',
   heightMode: 'max',
   onResize() {},
   pauseOnHover: true,


### PR DESCRIPTION
Another effort to get to the bottom of this height/resizing issue! Instead of having the user have to pass in a height prop to the Carousel, or set an explicit height style property on the Carousel or its wrapper, setting the default prop to 'inherit' allows the Carousel to take on the height of its contents. Previously, it was set to 'auto' and it was not inheriting the height value of it's children until a resize event was fired or the slide was changed. 

I tested this by providing a {height: inherit} style property to this codesandbox https://codesandbox.io/s/sad-solomon-gwd10 and did not see the resizing issue. When height was set to auto, the issue persisted. 