### PR TITLE
Fix multi-slide wraparound

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -706,7 +706,10 @@ export default class Carousel extends React.Component {
         );
         return;
       } else {
-        const endSlide = this.state.slideCount - this.state.slidesToScroll;
+        const endSlide =
+          index < 0
+            ? this.state.slideCount + index
+            : this.state.slideCount - this.state.slidesToScroll;
         props.beforeSlide(this.state.currentSlide, endSlide);
         this.setState(
           prevState => ({

--- a/src/index.js
+++ b/src/index.js
@@ -690,7 +690,7 @@ export default class Carousel extends React.Component {
               : 0,
             currentSlide: 0,
             isWrappingAround: true,
-            wrapToIndex: index
+            wrapToIndex: this.state.slideCount
           }),
           () => {
             this.timers.push(


### PR DESCRIPTION
### Description

There are 2 current issues with wraparound behavior that can occur when scrolling multiple slides at once:

* When advancing the carousel forwards past the start slide, the animation advances `slidesToScroll` slides and continues past the first slide but the carousel then resets its position to the start slide.
* When advancing the carousel backwards, the animation advances backwards `slidesToScroll` slides but the carousel then sometimes will reset to a different slide.

(See "Testing" section for demo of these issues)

This PR fixes the first issue by changing the animation to advance to the start slide and not past it. The second issue is fixed by fixing the `endSlide` calculation when the new slide index is negative, which makes the animation and final position line up.

Fixes https://github.com/FormidableLabs/nuka-carousel/issues/563

#### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Modified the standard demo to change `length` to 5, `slidesToScroll` to 2, and `wrapAround` to true: https://codesandbox.io/s/frosty-resonance-noivg

In the above sandbox demo you can see the first issue by repeatedly clicking "Next"; you will see it animate sliding from Slide 5 to Slide 2 but then the position resets to Slide 1.

Clicking "Prev" repeatedly triggers the second issue; it will animate going back from Slide 2 to Slide 5 but then the position resets to Slide 4.

I tested the above demo with my changes, and the carousel behaves with no animation/final position mismatches.

### Checklist: (Feel free to delete this section upon completion)

- [x] My code follows the style guidelines of this project (I have run `yarn lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] For any breaking API changes, I have updated the type definitions in [`index.d.ts`](../index.d.ts)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
