### PR TITLE
Fix onDragStart to happen only when dragging/swiping

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -246,10 +246,6 @@ export default class Carousel extends React.Component {
         };
         this.handleMouseOver();
 
-        if (this.props.onDragStart) {
-          this.props.onDragStart(e);
-        }
-
         this.setState({
           dragging: true
         });
@@ -278,6 +274,11 @@ export default class Carousel extends React.Component {
                 Math.pow(e.touches[0].pageX - this.touchObject.startX, 2)
               )
             );
+
+        if (length >= 10) {
+          if (this.clickDisabled === false) this.props.onDragStart(e);
+          this.clickDisabled = true;
+        }
 
         this.touchObject = {
           startX: this.touchObject.startX,
@@ -331,10 +332,6 @@ export default class Carousel extends React.Component {
           startY: e.clientY
         };
 
-        if (this.props.onDragStart) {
-          this.props.onDragStart(e);
-        }
-
         this.setState({
           dragging: true
         });
@@ -366,7 +363,10 @@ export default class Carousel extends React.Component {
             );
 
         // prevents disabling click just because mouse moves a fraction of a pixel
-        if (length >= 10) this.clickDisabled = true;
+        if (length >= 10) {
+          if (this.clickDisabled === false) this.props.onDragStart(e);
+          this.clickDisabled = true;
+        }
 
         this.touchObject = {
           startX: this.touchObject.startX,
@@ -1181,6 +1181,7 @@ Carousel.defaultProps = {
   framePadding: '0px',
   height: 'auto',
   heightMode: 'max',
+  onDragStart() {},
   onResize() {},
   pauseOnHover: true,
   renderAnnounceSlideMessage: defaultRenderAnnounceSlideMessage,

--- a/test/specs/carousel.test.js
+++ b/test/specs/carousel.test.js
@@ -129,6 +129,27 @@ describe('<Carousel />', () => {
   });
 
   describe('Props', () => {
+    it('should call onDragStart only when dragging occurs.', () => {
+      const onDragStart = jest.fn();
+      const wrapper = mount(
+        <Carousel onDragStart={onDragStart}>
+          <p>Slide 1</p>
+          <p>Slide 2</p>
+          <p>Slide 3</p>
+        </Carousel>
+      );
+      // setup mouse events
+      const event = { clientX: 10 };
+      wrapper.instance().touchObject.startX = 0;
+      wrapper.setState({ dragging: true });
+
+      wrapper.find('div.slider-frame').simulate('click');
+      expect(onDragStart).toHaveBeenCalledTimes(0);
+
+      wrapper.find('div.slider-frame').simulate('mousemove', event);
+      expect(onDragStart).toHaveBeenCalledTimes(1);
+    });
+
     it('should render with the class `slider` when no props are supplied.', () => {
       const wrapper = mount(
         <Carousel>


### PR DESCRIPTION
### Description

There is this new prop `onDragStart` that happens `onClick` or `onTouch` rather than an actual drag/swipe event. I modified the code slightly to make the behavior more appropriate to the event. It is better to do it this way so the event doesn't give a false impression that it is starting a drag event when only a click occurs.

Fixes https://github.com/FormidableLabs/nuka-carousel/issues/579

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Using the demo and writing a unit test.

#### Desktop
![desktop](https://user-images.githubusercontent.com/6808172/64490017-809aef00-d21e-11e9-9b5e-ebb21a3def53.gif)


#### Mobile
![mobile](https://user-images.githubusercontent.com/6808172/64490020-8690d000-d21e-11e9-911a-32b949376d89.gif)
