### PR TITLE
Impossible to select last images when swiping

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -462,7 +462,7 @@ export default class Carousel extends React.Component {
     if (this.touchObject.length > this.state.slideWidth / slidesToShow / 5) {
       if (this.touchObject.direction === 1) {
         if (
-          this.state.currentSlide >= this.state.slideCount - slidesToShow &&
+          this.state.currentSlide + 1 >= this.state.slideCount &&
           !this.props.wrapAround
         ) {
           this.setState({ easing: easing[this.props.edgeEasing] });


### PR DESCRIPTION
### Description

When more than one slides are displayed, swiping is enabled and `cellAlign` is defined, then last images are not accessible swiping 

Fixes #587

#### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Using different combinations of slidesToShow, dragging, cellAlign, among other options

### Checklist: (Feel free to delete this section upon completion)

- [x] My code follows the style guidelines of this project (I have run `yarn lint`)
- [ ] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
