### PR TITLE
 Changed componentWillRecieveProps to UNSAFE_componentWillReceiveProps to avoid future compatibility issues with new React versions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -110,7 +110,8 @@ export default class Carousel extends React.Component {
 
   // @TODO Remove deprecated componentWillReceiveProps with getDerivedStateFromProps
   // eslint-disable-next-line react/no-deprecated
-  componentWillReceiveProps(nextProps) {
+  // eslint-disable-next-line camelcase
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const slideCount = getValidChildren(nextProps.children).length;
     const slideCountChanged = slideCount !== this.state.slideCount;
     this.setState(prevState => ({


### PR DESCRIPTION
### Description

Changed `componentWillRecieveProps` to `UNSAFE_componentWillReceiveProps` to avoid future compatibility issues with new React versions as described in this issue  #591 

This is a middle step meanwhile the `componentWillRecieveProps` is changed to `getDerivedStateFromProps` as described here [https://github.com/FormidableLabs/nuka-carousel/blob/master/src/index.js#L111](https://github.com/FormidableLabs/nuka-carousel/blob/master/src/index.js#L111)

https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops

Fixes #591 

#### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist: (Feel free to delete this section upon completion)

- [x] My code follows the style guidelines of this project (I have run `yarn lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] For any breaking API changes, I have updated the type definitions in [`index.d.ts`](../index.d.ts)
- [] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
