### PR TITLE
Changed the dot styling.

### DIFF
--- a/src/default-controls.js
+++ b/src/default-controls.js
@@ -5,7 +5,8 @@ const defaultButtonStyles = disabled => ({
   background: 'rgba(0,0,0,0.4)',
   color: 'white',
   padding: 10,
-  opacity: disabled ? 0.3 : 1,
+  textTransform: 'uppercase',
+  opacity: disabled && 0.3,
   cursor: disabled ? 'not-allowed' : 'pointer'
 });
 
@@ -30,7 +31,7 @@ export class PreviousButton extends React.Component {
         aria-label="previous"
         type="button"
       >
-        PREV
+        Prev
       </button>
     );
   }
@@ -106,7 +107,7 @@ export class NextButton extends React.Component {
         aria-label="next"
         type="button"
       >
-        NEXT
+        Next
       </button>
     );
   }
@@ -137,16 +138,11 @@ export class PagingDots extends React.Component {
   getListStyles() {
     return {
       position: 'relative',
-      margin: 0,
       top: -10,
-      padding: 0
-    };
-  }
-
-  getListItemStyles() {
-    return {
-      listStyleType: 'none',
-      display: 'inline-block'
+      display: 'flex',
+      margin: 0,
+      padding: 0,
+      listStyleType: 'none'
     };
   }
 
@@ -171,7 +167,6 @@ export class PagingDots extends React.Component {
         {indexes.map(index => {
           return (
             <li
-              style={this.getListItemStyles()}
               key={index}
               className={
                 this.props.currentSlide === index
@@ -185,16 +180,16 @@ export class PagingDots extends React.Component {
                 onClick={this.props.goToSlide.bind(null, index)}
                 aria-label={`slide ${index + 1} bullet`}
               >
-                <span
-                  className="paging-dot"
-                  style={{
-                    display: 'inline-block',
-                    borderRadius: '50%',
-                    width: '6px',
-                    height: '6px',
-                    background: 'black'
-                  }}
-                />
+                <svg className="paging-dot" width="6" height="6">
+                  <circle
+                    cx="3"
+                    cy="3"
+                    r="3"
+                    style={{
+                      fill: 'black'
+                    }}
+                  />
+                </svg>
               </button>
             </li>
           );

--- a/src/index.js
+++ b/src/index.js
@@ -1015,7 +1015,7 @@ export default class Carousel extends React.Component {
 
     return (
       <div
-        className={['slider', this.props.className || ''].join(' ')}
+        className={['slider', this.props.className || ''].join(' ').trim()}
         style={Object.assign(
           {},
           getSliderStyles(this.props.width, this.props.height),

--- a/test/e2e/carousel.test.js
+++ b/test/e2e/carousel.test.js
@@ -15,22 +15,22 @@ describe('Nuka Carousel', () => {
     });
 
     it('should show the next slide when the Next button is clicked.', async () => {
-      await expect(page).toClick('button', { text: 'NEXT' });
+      await expect(page).toClick('button', { text: 'Next' });
       await expect(page).toMatch('Nuka Carousel: Slide 2');
     });
 
     it('should show the previous slide when the Previous button is clicked.', async () => {
-      await expect(page).toClick('button', { text: 'NEXT' });
+      await expect(page).toClick('button', { text: 'Next' });
       await expect(page).toMatch('Nuka Carousel: Slide 2');
       await page.waitFor(600); // need to let slide transition complete
-      await expect(page).toClick('button', { text: 'PREV' });
+      await expect(page).toClick('button', { text: 'Prev' });
       await expect(page).toMatch('Nuka Carousel: Slide 1');
     });
 
     it('should navigate to the last slide from the first in wrapAround mode.', async () => {
       await expect(page).toClick('button', { text: 'Toggle Wrap Around' });
       await expect(page).toMatch('Nuka Carousel: Slide 1');
-      await expect(page).toClick('button', { text: 'PREV' });
+      await expect(page).toClick('button', { text: 'Prev' });
       await expect(page).toMatch('Nuka Carousel: Slide 6');
     });
 
@@ -40,7 +40,7 @@ describe('Nuka Carousel', () => {
       await expect(page).toClick('button', { text: '6' });
       await expect(page).toMatch('Nuka Carousel: Slide 6');
       await page.waitFor(600); // need to let slide transition complete
-      await expect(page).toClick('button', { text: 'NEXT' });
+      await expect(page).toClick('button', { text: 'Next' });
       await expect(page).toMatch('Nuka Carousel: Slide 1');
     });
 
@@ -54,7 +54,7 @@ describe('Nuka Carousel', () => {
       await expect(page).toClick('button', { text: '3' });
       await expect(page).toMatch('Nuka Carousel: Slide 3');
       await page.waitFor(600); // need to let slide transition complete
-      await expect(page).toClick('button', { text: 'NEXT' });
+      await expect(page).toClick('button', { text: 'Next' });
       await expect(page).toMatch('Nuka Carousel: Slide 1');
     });
 
@@ -217,7 +217,7 @@ describe('Nuka Carousel', () => {
       const getWidth = parseInt(firstSlide.width, 10);
       await expect(firstSlide.left).toMatch('0px');
       await expect(lastSlide.left).toMatch(`${getWidth * -1}px`);
-      await expect(page).toClick('button', { text: 'PREV' });
+      await expect(page).toClick('button', { text: 'Prev' });
       await expect(page).toMatch('Nuka Carousel: Slide 6');
       await page.waitFor(600); // need to let slide transition complete
       firstSlide = await page.evaluate(getStyles, `.slider-slide:first-child`, [
@@ -236,7 +236,7 @@ describe('Nuka Carousel', () => {
       const pointX = metrics.x + metrics.width / 2.0;
       const pointY = metrics.y + metrics.height / 2.0;
       await expect(page).toClick('button', { text: 'Toggle Wrap Around' });
-      await expect(page).toClick('button', { text: 'PREV' });
+      await expect(page).toClick('button', { text: 'Prev' });
       await expect(page).toMatch('Nuka Carousel: Slide 6');
       await page.waitFor(600); // need to let slide transition complete
       const getComputedStyleLeft = () => {
@@ -259,7 +259,7 @@ describe('Nuka Carousel', () => {
       await expect(page).toClick('button', { text: '6' });
       await expect(page).toMatch('Nuka Carousel: Slide 6');
       await page.waitFor(600); // need to let slide transition complete
-      await expect(page).toClick('button', { text: 'NEXT' });
+      await expect(page).toClick('button', { text: 'Next' });
       await expect(page).toMatch('Nuka Carousel: Slide 1');
       await page.waitFor(600); // need to let slide transition complete
       const getComputedStyleLeft = () => {
@@ -279,7 +279,7 @@ describe('Nuka Carousel', () => {
       const pointX = metrics.x + metrics.width / 2.0;
       const pointY = metrics.y + metrics.height / 2.0;
       await expect(page).toClick('button', { text: 'Toggle Wrap Around' });
-      await expect(page).toClick('button', { text: 'PREV' });
+      await expect(page).toClick('button', { text: 'Prev' });
       await expect(page).toMatch('Nuka Carousel: Slide 6');
       await page.waitFor(600); // need to let slide transition complete
       const getTextDecoration = () => {
@@ -305,7 +305,7 @@ describe('Nuka Carousel', () => {
       await expect(page).toClick('button', { text: '6' });
       await expect(page).toMatch('Nuka Carousel: Slide 6');
       await page.waitFor(600); // need to let slide transition complete
-      await expect(page).toClick('button', { text: 'NEXT' });
+      await expect(page).toClick('button', { text: 'Next' });
       await expect(page).toMatch('Nuka Carousel: Slide 1');
       await page.waitFor(600); // need to let slide transition complete
       const getTextDecoration = () => {


### PR DESCRIPTION
### Description

I changed the styling of the `ul` and `li`. Each `li` had `list-style-type` and `display`, but I moved that to the parent element. I also replaced the `span` that was the dot with a `svg`.
I spent today researching carousels to replace the existing ones on Redfin and wanted to make some small tweaks.

#### Type of Change

N/A

### How Has This Been Tested?

Tested manually by looking at the slider control on modern browsers.

### Checklist: (Feel free to delete this section upon completion)

- [X] My code follows the style guidelines of this project (I have run `yarn lint`)
- [X] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings