### PR TITLE
Fix issue with webpack builds by updating import

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ExecutionEnvironment from 'exenv';
-import Animate from 'react-move/Animate';
+import { Animate } from 'react-move';
 import * as easing from 'd3-ease';
 import { PagingDots, PreviousButton, NextButton } from './default-controls';
 import Transitions from './all-transitions';


### PR DESCRIPTION
### Description

This fixes a weird issue with the webpack `concatenateModules` optimization config. When this is turned on, the dependency tree is not loaded correctly. I found that using a named import rather than importing Animate by file path corrects this problem. This is the way recommended in the react-move documentation anyway, and modern bundlers (like webpack) can optimize this via tree shaking so there wont be an increase in bundle size.

#### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)