### PR TITLE
prevent default on mouse down to fix dragging image bug on safari

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -328,6 +328,10 @@ export default class Carousel extends React.Component {
       onMouseOut: this.handleMouseOut,
 
       onMouseDown: e => {
+        if (e.preventDefault) {
+          e.preventDefault();
+        }
+
         this.touchObject = {
           startX: e.clientX,
           startY: e.clientY


### PR DESCRIPTION
An old bug resurfaced and this fixes it!
