### PR TITLE
Remove getListItemStyles() from type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -421,7 +421,6 @@ export interface PagingDotsProps extends CarouselSlideRenderControlProps {}
 export class PagingDots extends React.Component<PagingDotsProps> {
   public getButtonStyles(active: boolean): React.CSSProperties;
   public getListStyles(): React.CSSProperties;
-  public getListItemStyles(): React.CSSProperties;
   public getDotIndexes(
     slideCount: number,
     slidesToScroll: number,


### PR DESCRIPTION
### Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #613

#### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist: (Feel free to delete this section upon completion)

- [x] My code follows the style guidelines of this project (I have run `yarn lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] For any breaking API changes, I have updated the type definitions in [`index.d.ts`](../index.d.ts)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
