### PR TITLE
Avoid redundant dimension calculations after a DOM mutation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -201,10 +201,8 @@ export default class Carousel extends React.Component {
   establishChildNodesMutationObserver() {
     const childNodes = this.getChildNodes();
     if (childNodes.length && 'MutationObserver' in window) {
-      this.childNodesMutationObs = new MutationObserver(mutations => {
-        mutations.forEach(() => {
-          this.setSlideHeightAndWidth();
-        });
+      this.childNodesMutationObs = new MutationObserver(() => {
+        this.setSlideHeightAndWidth();
       });
 
       const observeChildNodeMutation = node => {


### PR DESCRIPTION
### Description

Changed the callback logic of a MutationObserver to avoid repeatedly calling a function that needs to be called once. Helps a lot with performance issues reported in #617.

Fixes #617 

#### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I stress tested this change in a proprietary codebase where I use nuka-carousel. I am not able to share that code at the moment. To test the change, one should fill a carousel with complex object architectures where re-renders and image loads are likely to occur.

### Checklist: (Feel free to delete this section upon completion)

- [ ] I have added tests that prove my fix is effective or that my feature works
