### PR TITLE
Add TS definition for renderAnnounceSlideMessage

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -286,6 +286,11 @@ export interface CarouselProps {
   renderBottomRightControls?: CarouselRenderControl | null;
 
   /**
+   * Function for rendering aria-live announcement messages
+   */
+  renderAnnounceSlideMessage?: ({ currentSlide, slideCount }) => string;
+
+  /**
    * Manually set the index of the slide to be shown
    */
   slideIndex?: number;


### PR DESCRIPTION
### Description

The type definition is currently missing for `renderAnnounceSlideMessage`. I'd like to add one in so I can use this library in my project.

#### Type of Change

This PR adds a TS definition for `renderAnnounceSlideMessage` so that property can be used in `.tsx` files.

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I ran the test suites and they are all passing except the one that is currently failing in master. I also tried out the type definition in my project and it made the compiler work.
