### PR TITLE
check values of slideHeight and slideWidth if not the same in state b…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -917,7 +917,10 @@ export default class Carousel extends React.Component {
   setSlideHeightAndWidth() {
     const { slideHeight, slideWidth } = this.calcSlideHeightAndWidth();
 
-    if (slideHeight !== this.state.slideHeight || slideWidth !== this.state.slideWidth) {
+    if (
+      slideHeight !== this.state.slideHeight ||
+      slideWidth !== this.state.slideWidth
+    ) {
       this.setState({ slideHeight, slideWidth });
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -915,7 +915,11 @@ export default class Carousel extends React.Component {
   }
 
   setSlideHeightAndWidth() {
-    this.setState(this.calcSlideHeightAndWidth());
+    const { slideHeight, slideWidth } = this.calcSlideHeightAndWidth();
+
+    if (slideHeight !== this.state.slideHeight || slideWidth !== this.state.slideWidth) {
+      this.setState({ slideHeight, slideWidth });
+    }
   }
 
   setDimensions(props, stateCb = () => {}) {


### PR DESCRIPTION
### Description

I noticed that setSlideHeightAndWidth changes state without checking if the state contains the same value as produced.
It also by changing state runs componentDidUpdate what also runs setSlideHeightAndWidth. It has a performance impact on slower devices

#### Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I run a library with over 60 cards with that change and without. 
With this change, everything flying

ps. It is my first PR to open source project ever :)

### Checklist: (Feel free to delete this section upon completion)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] For any breaking API changes, I have updated the type definitions in [`index.d.ts`](../index.d.ts)
