### PR TITLE
Fixes Issue 521: Initial height calculations will be repeated until successful.

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ In componentDidMount, the initial dimensions are assigned to each slide:
 - Width: `initialSlidewidth` || `slideWidth` || (`slidesToShow` / width of container)
 - Height: `initialSlideHeight`
 
-Once the component has completed mounting with the accurate width, it waits for the readyStateChange event to fire before measuring the desired height of the content (`current`, `first`, `max`). That measurement then replaces `initialSlideHeight` with the measured height in pixels.
+After the component completes mounting with the accurate width, it tries to calculate the desired height of the content (`current`, `first`, `max`). If that calculation fails (perhaps because slide images are still loading), it'll wait a bit and try again. Once successful, that measurement then replaces `initialSlideHeight` with the measured height in pixels.
 
 ### Contributing
 


### PR DESCRIPTION
### Description

It looks like when the carousel is loaded within an iframe the `readyStateChange` event that we're dependent on does _not_ fire.  It's also a race condition in general that `readyStateChange` has to fire _after_ enough DOM data has loaded (i.e mostly images).  So, instead of being dependent on a race condition for an event that may not fire when we expect, I added a simple looping `setTimeout` call within `componentDidMount`.  

With this code, once the app mounts, it'll check if the `slideHeight` has been set, if it has, great, it stops looking.  If the `slideHeight` hasn't been set, then it tries to set it by calling `setDimensions` and waiting a little bit to check the height again.  It'll keep trying to set the height until it finally succeeds, and when it succeeds once, the check ends and doesn't ever start back up during the lifetime of the component.

*Note:* If the entire carousel is loaded within an element that has `display: none;` then the height will _not_ be able to be calculated and the `setTimeout` loop will continue indefinitely (gradually being checked at a slower and slower rate) until the carousel is made visible in the DOM.

Fixes #521 

#### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

### How Has This Been Tested?

I used this codesandbox as a source (it showcase the bug):
https://codesandbox.io/s/xpz69xnx94

I uploaded the fixed carousel code into this codesandbox and the bug no longer happens:
https://codesandbox.io/s/romantic-darwin-oj653
