### PR TITLE
Issue 556: Height mode 'current' uses tallest visible slide

### DIFF
--- a/src/utilities/bootstrapping-utilities.js
+++ b/src/utilities/bootstrapping-utilities.js
@@ -18,19 +18,95 @@ export const getValidChildren = children => {
   return React.Children.toArray(children);
 };
 
-const findMaxHeightSlide = slides => {
+const getMax = (a, b) => {
+  return a > b ? a : b;
+};
+
+// end - is exclusive
+export const findMaxHeightSlideInRange = (slides, start, end) => {
   let maxHeight = 0;
-  for (let i = 0; i < slides.length; i++) {
-    if (slides[i].offsetHeight > maxHeight) {
-      maxHeight = slides[i].offsetHeight;
-    }
+
+  if (
+    slides.length === 0 ||
+    start < 0 ||
+    end < 0 ||
+    start > slides.length - 1 ||
+    end > slides.length
+  ) {
+    return maxHeight;
   }
+
+  if (start < end) {
+    for (let i = start; i < end; i++) {
+      maxHeight = getMax(slides[i].offsetHeight, maxHeight);
+    }
+  } else if (start > end) {
+    // Finding max in a wrap around
+    for (let i = start; i < slides.length; i++) {
+      maxHeight = getMax(slides[i].offsetHeight, maxHeight);
+    }
+
+    for (let i = 0; i < end; i++) {
+      maxHeight = getMax(slides[i].offsetHeight, maxHeight);
+    }
+  } else {
+    // start === end
+    maxHeight = slides[start].offsetHeight;
+  }
+
   return maxHeight;
 };
 
+export const findCurrentHeightSlide = (
+  currentSlide,
+  slidesToShow,
+  alignment,
+  wrapAround,
+  slides
+) => {
+  if (slidesToShow > 1) {
+    let startIndex = currentSlide;
+    let lastIndex = Math.min(
+      Math.ceil(slidesToShow) + currentSlide,
+      slides.length
+    );
+
+    const offset =
+      alignment === 'center' ? (slidesToShow - 1) / 2 : slidesToShow - 1;
+
+    switch (alignment) {
+      case 'center':
+        startIndex = Math.floor(currentSlide - offset);
+        lastIndex = Math.ceil(currentSlide + offset) + 1;
+        break;
+
+      case 'right':
+        startIndex = Math.floor(currentSlide - offset);
+        lastIndex = currentSlide + 1;
+        break;
+    }
+
+    // inclusive
+    startIndex =
+      wrapAround && startIndex < 0
+        ? slides.length + startIndex
+        : Math.max(startIndex, 0);
+
+    // exclusive
+    lastIndex =
+      wrapAround && lastIndex > slides.length
+        ? lastIndex - slides.length
+        : Math.min(lastIndex, slides.length);
+
+    return findMaxHeightSlideInRange(slides, startIndex, lastIndex);
+  } else {
+    return slides[currentSlide].offsetHeight;
+  }
+};
+
 export const getSlideHeight = (props, state, childNodes = []) => {
-  const { heightMode, vertical, initialSlideHeight } = props;
-  const { slidesToShow, currentSlide } = state;
+  const { heightMode, vertical, initialSlideHeight, wrapAround } = props;
+  const { slidesToShow, currentSlide, cellAlign } = state;
   const firstSlide = childNodes[0];
 
   if (firstSlide && heightMode === 'first') {
@@ -38,11 +114,20 @@ export const getSlideHeight = (props, state, childNodes = []) => {
       ? firstSlide.offsetHeight * slidesToShow
       : firstSlide.offsetHeight;
   }
+
   if (heightMode === 'max') {
-    return findMaxHeightSlide(childNodes);
+    return findMaxHeightSlideInRange(childNodes, 0, childNodes.length);
   }
+
   if (heightMode === 'current') {
-    return childNodes[currentSlide].offsetHeight;
+    return findCurrentHeightSlide(
+      currentSlide,
+      slidesToShow,
+      cellAlign,
+      wrapAround,
+      childNodes
+    );
   }
+
   return initialSlideHeight || 100;
 };

--- a/test/specs/bootstrapping-utilities.test.js
+++ b/test/specs/bootstrapping-utilities.test.js
@@ -1,0 +1,104 @@
+import {
+  findMaxHeightSlideInRange,
+  findCurrentHeightSlide
+} from '../../src/utilities/bootstrapping-utilities';
+
+describe('Bootstrapping Utilties', () => {
+  const slides = [
+    { offsetHeight: 100 }, // 0
+    { offsetHeight: 200 }, // 1
+    { offsetHeight: 800 }, // 2
+    { offsetHeight: 400 }, // 3
+    { offsetHeight: 500 } // 4
+  ];
+
+  describe('#findMaxHeightSlideInRange', () => {
+    it('should find slide with max height', () => {
+      // start < end
+      expect(findMaxHeightSlideInRange(slides, 0, slides.length)).toBe(800);
+      expect(findMaxHeightSlideInRange(slides, 0, 2)).toBe(200);
+
+      // start > end
+      expect(findMaxHeightSlideInRange(slides, 4, 3)).toBe(800);
+      expect(findMaxHeightSlideInRange(slides, 3, 2)).toBe(500);
+
+      // start === end
+      expect(findMaxHeightSlideInRange(slides, 3, 3)).toBe(400);
+      expect(findMaxHeightSlideInRange(slides, 3, 3)).toBe(400);
+    });
+
+    it('should return 0 if start/end are out of bounds', () => {
+      // start out of bounds
+      expect(findMaxHeightSlideInRange(slides, -1, 3)).toBe(0);
+      expect(findMaxHeightSlideInRange(slides, slides.length, 3)).toBe(0);
+
+      // end out of bounds
+      expect(findMaxHeightSlideInRange(slides, 0, slides.length + 1)).toBe(0);
+      expect(findMaxHeightSlideInRange(slides, 0, -3)).toBe(0);
+
+      // both out of bounds
+      expect(findMaxHeightSlideInRange(slides, -1, -1)).toBe(0);
+    });
+  });
+
+  describe('#findCurrentHeightSlide', () => {
+    it('should return height of current slide if slidesToShow less than equal to one', () => {
+      expect(findCurrentHeightSlide(0, 1, 'left', false, slides)).toBe(100);
+      expect(findCurrentHeightSlide(3, 1, 'right', true, slides)).toBe(400);
+      expect(
+        findCurrentHeightSlide(slides.length - 1, 1, 'center', false, slides)
+      ).toBe(500);
+    });
+
+    describe('aligned left', () => {
+      // wrapAround = false
+      const noWrapHeight = findCurrentHeightSlide(
+        1,
+        1.25,
+        'left',
+        false,
+        slides
+      );
+
+      expect(noWrapHeight).toBe(800);
+
+      // wrapAround = true
+      const wrapHeight = findCurrentHeightSlide(4, 1.25, 'left', true, slides);
+      expect(wrapHeight).toBe(500);
+    });
+
+    describe('aligned center', () => {
+      // wrapAround = false
+      const noWrapHeight = findCurrentHeightSlide(
+        3,
+        1.5,
+        'center',
+        false,
+        slides
+      );
+
+      expect(noWrapHeight).toBe(800);
+
+      // wrapAround = true
+      const wrapHeight = findCurrentHeightSlide(0, 1.5, 'center', true, slides);
+      expect(wrapHeight).toBe(500);
+    });
+
+    describe('aligned right', () => {
+      // wrapAround = false
+      const noWrapHeight = findCurrentHeightSlide(
+        3,
+        1.5,
+        'right',
+        false,
+        slides
+      );
+
+      expect(noWrapHeight).toBe(800);
+
+      // wrapAround = true
+      const wrapHeight = findCurrentHeightSlide(0, 1.5, 'right', true, slides);
+      expect(wrapHeight).toBe(500);
+    });
+  });
+});


### PR DESCRIPTION
### Description

This PR adjusts the height calculations done while in `heightMode="current"`.  Before we just took the height of the active slide, now we use the tallest height of the visible slides (meaning if `slidesToShow` is set to greater than 1).

Fixes #556 

#### Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

I added tests in `bootstrapping-utilties.test.js` to verify the logic and below are gifs showing how it works:

Left aligned:
![left-align-height-calc](https://user-images.githubusercontent.com/40646372/70287042-6b345300-1782-11ea-97d3-5f401da92e88.gif)

Right aligned:
![right-align-height-calc](https://user-images.githubusercontent.com/40646372/70287044-6d96ad00-1782-11ea-8ec5-e390f2f8a626.gif)

Center aligned (even a bit of wraparound):
![center-align-height-calc](https://user-images.githubusercontent.com/40646372/70287048-70919d80-1782-11ea-940f-04f7bf1153f3.gif)

