### PR TITLE
Adding missing Type For keyCodeConfig prop

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -159,6 +159,17 @@ export interface CarouselProps {
   enableKeyboardControls?: boolean;
 
   /**
+   * When enableKeyboardControls is enabled, Configure keyCodes for corresponding slide actions as array of keyCodes
+   */
+  keyCodeConfig?: {
+    nextSlide: number[];
+    previousSlide: number[];
+    firstSlide: number[];
+    lastSlide: number[];
+    pause: number[];
+  };
+
+  /**
    * Disable slides animation
    * @default false
    */

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,6 +20,13 @@ export type CarouselSlidesToScrollProp = number | 'auto';
 
 export type CarouselSlideWidthProp = string | number;
 
+export type CarouselSlideActions =
+  | 'nextSlide'
+  | 'previousSlide'
+  | 'firstSlide'
+  | 'lastSlide'
+  | 'pause';
+
 export interface CarouselSlideRenderControlProps {
   /**
    * When displaying more than one slide, sets which position to anchor the current slide to.
@@ -162,11 +169,7 @@ export interface CarouselProps {
    * When enableKeyboardControls is enabled, Configure keyCodes for corresponding slide actions as array of keyCodes
    */
   keyCodeConfig?: {
-    nextSlide: number[];
-    previousSlide: number[];
-    firstSlide: number[];
-    lastSlide: number[];
-    pause: number[];
+    [slideAction in CarouselSlideActions]?: number[];
   };
 
   /**


### PR DESCRIPTION
### Description

Adding type definition in index.d.ts for the newly added prop `keyCodeConfig`

Fixes https://github.com/FormidableLabs/nuka-carousel/issues/627

#### Type of Change


- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist: (Feel free to delete this section upon completion)

- [x] My code follows the style guidelines of this project (I have run `yarn lint`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

<img width="537" alt="type-defs" src="https://user-images.githubusercontent.com/317306/70522631-811d8b80-1b67-11ea-9767-4bceb0286d12.png">


