### PR TITLE
Issue 618: Fixed max (and first) height mode calculations

### DIFF
--- a/src/transitions/3d-scroll-transition.js
+++ b/src/transitions/3d-scroll-transition.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { getSlideHeight } from '../utilities/style-utilities';
 
 const MIN_ZOOM_SCALE = 0;
 const MAX_ZOOM_SCALE = 1;
@@ -175,11 +176,12 @@ export default class ScrollTransition3D extends React.Component {
   getSlideStyles(index, positionValue) {
     const targetPosition = this.getSlideTargetPosition(index, positionValue);
     const transformScale = this.getTransformScale(index);
+
     return {
       zIndex: this.props.slideCount - this.getDistanceToCurrentSlide(index),
       boxSizing: 'border-box',
       display: this.props.vertical ? 'block' : 'inline-block',
-      height: 'auto',
+      height: getSlideHeight(this.props),
       left: this.props.vertical ? 0 : targetPosition,
       listStyleType: 'none',
       marginBottom: this.props.vertical ? this.props.cellSpacing / 2 : 'auto',
@@ -236,6 +238,7 @@ ScrollTransition3D.propTypes = {
   cellSpacing: PropTypes.number,
   currentSlide: PropTypes.number,
   dragging: PropTypes.bool,
+  heightMode: PropTypes.oneOf(['first', 'current', 'max']),
   isWrappingAround: PropTypes.bool,
   left: PropTypes.number,
   slideCount: PropTypes.number,
@@ -255,6 +258,7 @@ ScrollTransition3D.defaultProps = {
   cellSpacing: 0,
   currentSlide: 0,
   dragging: false,
+  heightMode: 'max',
   isWrappingAround: false,
   left: 0,
   slideCount: 0,

--- a/src/transitions/fade-transition.js
+++ b/src/transitions/fade-transition.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { getSlideHeight } from '../utilities/style-utilities';
 
 export default class FadeTransition extends React.Component {
   constructor(props) {
@@ -67,7 +68,7 @@ export default class FadeTransition extends React.Component {
     return {
       boxSizing: 'border-box',
       display: 'block',
-      height: 'auto',
+      height: getSlideHeight(this.props),
       left: data[index] ? data[index].left : 0,
       listStyleType: 'none',
       marginBottom: 'auto',
@@ -135,6 +136,7 @@ FadeTransition.propTypes = {
   deltaX: PropTypes.number,
   deltaY: PropTypes.number,
   dragging: PropTypes.bool,
+  heightMode: PropTypes.oneOf(['first', 'current', 'max']),
   isWrappingAround: PropTypes.bool,
   left: PropTypes.number,
   slideCount: PropTypes.number,
@@ -152,6 +154,7 @@ FadeTransition.defaultProps = {
   deltaX: 0,
   deltaY: 0,
   dragging: false,
+  heightMode: 'max',
   isWrappingAround: false,
   left: 0,
   slideCount: 0,

--- a/src/transitions/scroll-transition.js
+++ b/src/transitions/scroll-transition.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { getSlideHeight } from '../utilities/style-utilities';
 
 const MIN_ZOOM_SCALE = 0;
 const MAX_ZOOM_SCALE = 1;
@@ -140,16 +141,17 @@ export default class ScrollTransition extends React.Component {
       }
     }
 
-    return targetPosition + offset;
+    return targetPosition + offset || 0;
   }
   /* eslint-enable complexity */
-
   formatChildren(children) {
     const { top, left, currentSlide, slidesToShow } = this.props;
     const positionValue = this.props.vertical ? top : left;
+
     return React.Children.map(children, (child, index) => {
       const visible =
         index >= currentSlide && index < currentSlide + slidesToShow;
+
       return (
         <li
           className={`slider-slide${visible ? ' slide-visible' : ''}`}
@@ -171,10 +173,11 @@ export default class ScrollTransition extends React.Component {
             MIN_ZOOM_SCALE
           )
         : 1.0;
+
     return {
       boxSizing: 'border-box',
       display: this.props.vertical ? 'block' : 'inline-block',
-      height: 'auto',
+      height: getSlideHeight(this.props),
       left: this.props.vertical ? 0 : targetPosition,
       listStyleType: 'none',
       marginBottom: this.props.vertical ? this.props.cellSpacing / 2 : 'auto',
@@ -199,6 +202,7 @@ export default class ScrollTransition extends React.Component {
     const spacingOffset =
       this.props.cellSpacing * React.Children.count(this.props.children);
     const transform = `translate3d(${deltaX}px, ${deltaY}px, 0)`;
+
     return {
       transform,
       WebkitTransform: transform,
@@ -244,6 +248,7 @@ ScrollTransition.propTypes = {
   deltaX: PropTypes.number,
   deltaY: PropTypes.number,
   dragging: PropTypes.bool,
+  heightMode: PropTypes.oneOf(['first', 'current', 'max']),
   isWrappingAround: PropTypes.bool,
   left: PropTypes.number,
   slideCount: PropTypes.number,
@@ -264,6 +269,7 @@ ScrollTransition.defaultProps = {
   deltaX: 0,
   deltaY: 0,
   dragging: false,
+  heightMode: 'max',
   isWrappingAround: false,
   left: 0,
   slideCount: 0,

--- a/src/utilities/bootstrapping-utilities.js
+++ b/src/utilities/bootstrapping-utilities.js
@@ -22,6 +22,24 @@ const getMax = (a, b) => {
   return a > b ? a : b;
 };
 
+const getHeightOfSlide = slide => {
+  if (!slide) {
+    return 0;
+  }
+
+  if (slide.children && slide.children.length > 0) {
+    // Need to convert slide.children from HTMLCollection
+    // to an array
+    const children = [...slide.children];
+    return children.reduce(
+      (totalHeight, child) => totalHeight + child.offsetHeight,
+      0
+    );
+  } else {
+    return slide.offsetHeight;
+  }
+};
+
 // end - is exclusive
 export const findMaxHeightSlideInRange = (slides, start, end) => {
   let maxHeight = 0;
@@ -38,20 +56,20 @@ export const findMaxHeightSlideInRange = (slides, start, end) => {
 
   if (start < end) {
     for (let i = start; i < end; i++) {
-      maxHeight = getMax(slides[i].offsetHeight, maxHeight);
+      maxHeight = getMax(getHeightOfSlide(slides[i]), maxHeight);
     }
   } else if (start > end) {
     // Finding max in a wrap around
     for (let i = start; i < slides.length; i++) {
-      maxHeight = getMax(slides[i].offsetHeight, maxHeight);
+      maxHeight = getMax(getHeightOfSlide(slides[i]), maxHeight);
     }
 
     for (let i = 0; i < end; i++) {
-      maxHeight = getMax(slides[i].offsetHeight, maxHeight);
+      maxHeight = getMax(getHeightOfSlide(slides[i]), maxHeight);
     }
   } else {
     // start === end
-    maxHeight = slides[start].offsetHeight;
+    maxHeight = getHeightOfSlide(slides[start]);
   }
 
   return maxHeight;
@@ -101,9 +119,10 @@ export const findCurrentHeightSlide = (
       wrapAround && lastIndex > slides.length
         ? lastIndex - slides.length
         : Math.min(lastIndex, slides.length);
+
     return findMaxHeightSlideInRange(slides, startIndex, lastIndex);
   } else {
-    return slides[currentSlide].offsetHeight;
+    return getHeightOfSlide(slides[currentSlide]);
   }
 };
 
@@ -114,8 +133,8 @@ export const getSlideHeight = (props, state, childNodes = []) => {
 
   if (firstSlide && heightMode === 'first') {
     return vertical
-      ? firstSlide.offsetHeight * slidesToShow
-      : firstSlide.offsetHeight;
+      ? getHeightOfSlide(firstSlide) * slidesToShow
+      : getHeightOfSlide(firstSlide);
   }
 
   if (heightMode === 'max') {

--- a/src/utilities/style-utilities.js
+++ b/src/utilities/style-utilities.js
@@ -1,6 +1,22 @@
+import React from 'react';
+
 export const getImgTagStyles = () => {
   return `.slider-slide > img { width: 100%; display: block; }
           .slider-slide > img:focus { margin: auto; }`;
+};
+
+export const getSlideHeight = props => {
+  const childCount = React.Children.count(props.children);
+  const listWidth = props.slideWidth * childCount;
+  const spacingOffset = props.cellSpacing * childCount;
+
+  const calculatedHeight = props.vertical
+    ? listWidth + spacingOffset
+    : props.slideHeight;
+
+  return calculatedHeight > 0 && props.heightMode !== 'current'
+    ? calculatedHeight
+    : 'auto';
 };
 
 export const getDecoratorStyles = position => {
@@ -133,6 +149,7 @@ export const getTransitionProps = (props, state) => {
     cellSpacing: props.cellSpacing,
     currentSlide: state.currentSlide,
     dragging: props.dragging,
+    heightMode: props.heightMode,
     isWrappingAround: state.isWrappingAround,
     left: state.left,
     slideCount: state.slideCount,

--- a/test/specs/bootstrapping-utilities.test.js
+++ b/test/specs/bootstrapping-utilities.test.js
@@ -4,44 +4,89 @@ import {
 } from '../../src/utilities/bootstrapping-utilities';
 
 describe('Bootstrapping Utilties', () => {
-  const slides = [
-    { offsetHeight: 100 }, // 0
-    { offsetHeight: 200 }, // 1
-    { offsetHeight: 800 }, // 2
-    { offsetHeight: 400 }, // 3
-    { offsetHeight: 500 } // 4
-  ];
-
   describe('#findMaxHeightSlideInRange', () => {
-    it('should find slide with max height', () => {
-      // start < end
-      expect(findMaxHeightSlideInRange(slides, 0, slides.length)).toBe(800);
-      expect(findMaxHeightSlideInRange(slides, 0, 2)).toBe(200);
+    const sharedFindMaxHeightTests = slides => {
+      it('should find slide with max height', () => {
+        // start < end
+        expect(findMaxHeightSlideInRange(slides, 0, slides.length)).toBe(800);
+        expect(findMaxHeightSlideInRange(slides, 0, 2)).toBe(200);
 
-      // start > end
-      expect(findMaxHeightSlideInRange(slides, 4, 3)).toBe(800);
-      expect(findMaxHeightSlideInRange(slides, 3, 2)).toBe(500);
+        // start > end
+        expect(findMaxHeightSlideInRange(slides, 4, 3)).toBe(800);
+        expect(findMaxHeightSlideInRange(slides, 3, 2)).toBe(500);
 
-      // start === end
-      expect(findMaxHeightSlideInRange(slides, 3, 3)).toBe(400);
-      expect(findMaxHeightSlideInRange(slides, 3, 3)).toBe(400);
+        // start === end
+        expect(findMaxHeightSlideInRange(slides, 3, 3)).toBe(400);
+        expect(findMaxHeightSlideInRange(slides, 3, 3)).toBe(400);
+      });
+
+      it('should return 0 if start/end are out of bounds', () => {
+        // start out of bounds
+        expect(findMaxHeightSlideInRange(slides, -1, 3)).toBe(0);
+        expect(findMaxHeightSlideInRange(slides, slides.length, 3)).toBe(0);
+
+        // end out of bounds
+        expect(findMaxHeightSlideInRange(slides, 0, slides.length + 1)).toBe(0);
+        expect(findMaxHeightSlideInRange(slides, 0, -3)).toBe(0);
+
+        // both out of bounds
+        expect(findMaxHeightSlideInRange(slides, -1, -1)).toBe(0);
+      });
+    };
+
+    describe('when slides do not have children', () => {
+      const noChildrenSlides = [
+        { offsetHeight: 100 }, // 0
+        { offsetHeight: 200 }, // 1
+        { offsetHeight: 800 }, // 2
+        { offsetHeight: 400 }, // 3
+        { offsetHeight: 500 } // 4
+      ];
+
+      sharedFindMaxHeightTests(noChildrenSlides);
     });
 
-    it('should return 0 if start/end are out of bounds', () => {
-      // start out of bounds
-      expect(findMaxHeightSlideInRange(slides, -1, 3)).toBe(0);
-      expect(findMaxHeightSlideInRange(slides, slides.length, 3)).toBe(0);
+    describe('when slides have children', () => {
+      const slidesWithChildren = [
+        {
+          offsetHeight: 0,
+          children: [{ offsetHeight: 100 }]
+        }, // 0
+        {
+          offsetHeight: 0,
+          children: [{ offsetHeight: 200 }]
+        }, // 1
+        {
+          offsetHeight: 0,
+          children: [{ offsetHeight: 400 }, { offsetHeight: 400 }]
+        }, // 2
+        {
+          offsetHeight: 0,
+          children: [{ offsetHeight: 300 }, { offsetHeight: 100 }]
+        }, // 3
+        {
+          offsetHeight: 0,
+          children: [
+            { offsetHeight: 100 },
+            { offsetHeight: 100 },
+            { offsetHeight: 300 }
+          ]
+        } // 4
+      ];
 
-      // end out of bounds
-      expect(findMaxHeightSlideInRange(slides, 0, slides.length + 1)).toBe(0);
-      expect(findMaxHeightSlideInRange(slides, 0, -3)).toBe(0);
-
-      // both out of bounds
-      expect(findMaxHeightSlideInRange(slides, -1, -1)).toBe(0);
+      sharedFindMaxHeightTests(slidesWithChildren);
     });
   });
 
   describe('#findCurrentHeightSlide', () => {
+    const slides = [
+      { offsetHeight: 100 }, // 0
+      { offsetHeight: 200 }, // 1
+      { offsetHeight: 800 }, // 2
+      { offsetHeight: 400 }, // 3
+      { offsetHeight: 500 } // 4
+    ];
+
     it('should return height of current slide if slidesToShow less than equal to one', () => {
       expect(findCurrentHeightSlide(0, 1, 'left', false, slides)).toBe(100);
       expect(findCurrentHeightSlide(3, 1, 'right', true, slides)).toBe(400);


### PR DESCRIPTION
### Description

This PR updates the way we calculate a slide's height in `max` or `first` mode, so we can stamp each slide's containing `li` with a specific height in pixels, instead of using `auto`.

The update has been applied to `scroll-transition`, `fade-transition`, and `3d-scroll-transition`.

Fixes #618 

#### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I've updated our bootstraping-utilities tests to validate the new height calculations based off a slide's children.