### PR TITLE
Issue 494: Updated scroll transition logic to fix wrapAround flash

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -15,6 +15,7 @@ class App extends React.Component {
       underlineHeader: false,
       zoomScale: 0.5,
       slidesToShow: 1,
+      slidesToScroll: 1,
       cellAlign: 'left',
       transitionMode: 'scroll',
       heightMode: 'max',

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ import {
   calcSomeInitialState
 } from './utilities/utilities';
 import {
+  getAlignmentOffset,
   getImgTagStyles,
   getDecoratorStyles,
   getSliderStyles,
@@ -653,26 +654,9 @@ export default class Carousel extends React.Component {
   // Animation Method
 
   getTargetLeft(touchOffset, slide) {
-    let offset;
     const target = slide || this.state.currentSlide;
-    switch (this.state.cellAlign) {
-      case 'left': {
-        offset = 0;
-        offset -= this.props.cellSpacing * target;
-        break;
-      }
-      case 'center': {
-        offset = (this.state.frameWidth - this.state.slideWidth) / 2;
-        offset -= this.props.cellSpacing * target;
-        break;
-      }
-      case 'right': {
-        offset = this.state.frameWidth - this.state.slideWidth;
-        offset -= this.props.cellSpacing * target;
-        break;
-      }
-    }
 
+    let offset = getAlignmentOffset(target, { ...this.props, ...this.state });
     let left = this.state.slideWidth * target;
 
     const lastSlide =
@@ -974,13 +958,10 @@ export default class Carousel extends React.Component {
         slidesToScroll,
         slidesToShow,
         slideWidth,
-        cellAlign,
-        left: props.vertical ? 0 : this.getTargetLeft(),
-        top: props.vertical ? this.getTargetLeft() : 0
+        cellAlign
       },
       () => {
         stateCb();
-        this.setLeft();
       }
     );
   }

--- a/src/utilities/style-utilities.js
+++ b/src/utilities/style-utilities.js
@@ -19,6 +19,30 @@ export const getSlideHeight = props => {
     : 'auto';
 };
 
+export const getAlignmentOffset = (slideIndex, config) => {
+  let offset = 0;
+
+  switch (config.cellAlign) {
+    case 'left': {
+      offset = 0;
+      offset -= config.cellSpacing * slideIndex;
+      break;
+    }
+    case 'center': {
+      offset = (config.frameWidth - config.slideWidth) / 2;
+      offset -= config.cellSpacing * slideIndex;
+      break;
+    }
+    case 'right': {
+      offset = config.frameWidth - config.slideWidth;
+      offset -= config.cellSpacing * slideIndex;
+      break;
+    }
+  }
+
+  return offset;
+};
+
 export const getDecoratorStyles = position => {
   switch (position) {
     case 'TopLeft': {
@@ -149,6 +173,7 @@ export const getTransitionProps = (props, state) => {
     cellSpacing: props.cellSpacing,
     currentSlide: state.currentSlide,
     dragging: props.dragging,
+    frameWidth: parseInt(state.frameWidth),
     heightMode: props.heightMode,
     isWrappingAround: state.isWrappingAround,
     left: state.left,

--- a/test/e2e/carousel.test.js
+++ b/test/e2e/carousel.test.js
@@ -215,9 +215,13 @@ describe('Nuka Carousel', () => {
         ['left']
       );
       const getWidth = parseInt(firstSlide.width, 10);
-      const slideCount = (await page.$$('.slider-slide')).length;
+
+      // first slide in first position
       await expect(firstSlide.left).toMatch('0px');
-      await expect(lastSlide.left).toMatch(`${getWidth * (slideCount - 1)}px`);
+
+      // last slide, positioned right behind first slide
+      await expect(lastSlide.left).toMatch(`-${getWidth}px`);
+
       await expect(page).toClick('button', { text: 'Prev' });
       await expect(page).toMatch('Nuka Carousel: Slide 6');
       await page.waitFor(600); // need to let slide transition complete


### PR DESCRIPTION
### Description

This PR updates the `scroll-transition` logic to remove the wrapAround flash.  It divides up the available slides to be in-front and in-back of the carousel (taking into account, alignment _and_ slides to show) so flipping through slides shouldn't flash (as much...).

Fixes #494 

#### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Passes all written tests, and lots of manual testing.

### Screenshots

Normal wrap around: 
![normal-wraparound](https://user-images.githubusercontent.com/40646372/72091498-29d51d00-32c5-11ea-8b54-184efb8a215f.gif)

Partial wrap around:
![partial-wraparound](https://user-images.githubusercontent.com/40646372/72091503-2d68a400-32c5-11ea-9464-f57b5ea47544.gif)

Height Mode "current" wrap around:
![current-wraparound](https://user-images.githubusercontent.com/40646372/72091508-2fcafe00-32c5-11ea-8cf3-199c514fd3bb.gif)

Extreme wrap around.  Slides to show is 6, slides to scroll is 2, and there are _only_ 6 slides in total :scream: (still manages to "work" as best it can):
![extreme-wraparound](https://user-images.githubusercontent.com/40646372/72091512-3194c180-32c5-11ea-8254-a693b70ec6fd.gif)
