### PR TITLE
Issue 622: Slides that are not fully visible cannot receive focus.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "d3-ease": "^1.0.3",
     "exenv": "^1.2.0",
     "prop-types": "^15.6.0",
-    "react-move": "^5.0.0"
+    "react-move": "^5.0.0",
+    "wicg-inert": "^3.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.5.5",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import 'wicg-inert';
 import PropTypes from 'prop-types';
 import ExecutionEnvironment from 'exenv';
 import Animate from 'react-move/Animate';
@@ -27,7 +28,7 @@ import {
 import {
   addAccessibility,
   getValidChildren,
-  getSlideHeight
+  calculateSlideHeight
 } from './utilities/bootstrapping-utilities';
 
 export default class Carousel extends React.Component {
@@ -913,7 +914,7 @@ export default class Carousel extends React.Component {
     // slide height
     props = props || this.props;
     const childNodes = this.getChildNodes();
-    const slideHeight = getSlideHeight(props, this.state, childNodes);
+    const slideHeight = calculateSlideHeight(props, this.state, childNodes);
 
     //slide width
     const { slidesToShow } = getPropsByTransitionMode(props, ['slidesToShow']);
@@ -1045,6 +1046,7 @@ export default class Carousel extends React.Component {
       });
     }
   }
+
   render() {
     const { currentSlide, slideCount, frameWidth } = this.state;
     const {

--- a/src/transitions/scroll-transition.js
+++ b/src/transitions/scroll-transition.js
@@ -4,7 +4,11 @@ import {
   getSlideHeight,
   getAlignmentOffset
 } from '../utilities/style-utilities';
-import { getSlideDirection, handleSelfFocus } from '../utilities/utilities';
+import {
+  getSlideDirection,
+  handleSelfFocus,
+  isFullyVisible
+} from '../utilities/utilities';
 
 const MIN_ZOOM_SCALE = 0;
 const MAX_ZOOM_SCALE = 1;
@@ -104,6 +108,9 @@ export default class ScrollTransition extends React.Component {
     return React.Children.map(children, (child, index) => {
       const visible =
         index >= currentSlide && index < currentSlide + slidesToShow;
+      const isVisible = isFullyVisible(index, positionValue, this.props);
+      const inert = isVisible ? {} : { inert: 'true' };
+
       return (
         <li
           className={`slider-slide${visible ? ' slide-visible' : ''}`}
@@ -111,6 +118,7 @@ export default class ScrollTransition extends React.Component {
           key={index}
           onClick={handleSelfFocus}
           tabIndex={-1}
+          {...inert}
         >
           {child}
         </li>

--- a/src/utilities/bootstrapping-utilities.js
+++ b/src/utilities/bootstrapping-utilities.js
@@ -126,7 +126,7 @@ export const findCurrentHeightSlide = (
   }
 };
 
-export const getSlideHeight = (props, state, childNodes = []) => {
+export const calculateSlideHeight = (props, state, childNodes = []) => {
   const { heightMode, vertical, initialSlideHeight, wrapAround } = props;
   const { slidesToShow, currentSlide, cellAlign } = state;
   const firstSlide = childNodes[0];

--- a/src/utilities/utilities.js
+++ b/src/utilities/utilities.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { getAlignmentOffset } from './style-utilities';
 
 export const addEvent = function(elem, type, eventHandle) {
   if (elem === null || typeof elem === 'undefined') {
@@ -168,4 +169,44 @@ export const handleSelfFocus = e => {
   if (e && e.currentTarget) {
     e.currentTarget.focus();
   }
+};
+
+export const isFullyVisible = (slideIndex, positionValue, config) => {
+  const {
+    currentSlide,
+    cellSpacing,
+    slideCount,
+    slideWidth,
+    frameWidth,
+    wrapAround
+  } = config;
+
+  const fullSlideWidth = slideWidth + cellSpacing;
+
+  const offsetWidth = getAlignmentOffset(currentSlide, config);
+  const remainingWidth = frameWidth - offsetWidth;
+
+  const fullSlidesBefore = Math.floor(offsetWidth / fullSlideWidth);
+  const fullSlidesAfter = Math.max(
+    Math.floor(remainingWidth / fullSlideWidth) - 1,
+    0
+  );
+
+  const currentSlideIndex = Math.ceil(currentSlide);
+  const fullyVisibleSlides = [];
+
+  for (
+    let i = currentSlideIndex - fullSlidesBefore;
+    i < currentSlideIndex + fullSlidesAfter + 1;
+    i++
+  ) {
+    if (i < 0) {
+      // -1 won't match a slide index
+      fullyVisibleSlides.push(wrapAround ? slideCount + i : -1);
+    } else {
+      fullyVisibleSlides.push(i > slideCount - 1 ? i - slideCount : i);
+    }
+  }
+
+  return fullyVisibleSlides.includes(slideIndex);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9135,6 +9135,11 @@ which@^1.2.12, which@^1.2.9, which@^1.3.0:
   dependencies:
     isexe "^2.0.0"
 
+wicg-inert@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/wicg-inert/-/wicg-inert-3.0.0.tgz#4f5797172fbf7ff01effd3839b52872e35d3cba2"
+  integrity sha512-sZsYZ8pk8y6CgDLkTxivfhLDBvZuDWTWBawU8OuDdO0Id6AOd1Gqjkvt9g9Ni7rgHIS7UbRvbLSv1z7MSJDYCA==
+
 wide-align@^1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457"


### PR DESCRIPTION
### Description

This PR adds a package called `wicg-inert`(https://www.npmjs.com/package/wicg-inert), which implements a polyfill for the html attribute `inert`.  Using the polyfill, when an html element is tagged as `inert`, the element (and its children) is removed from the tab index.  This PR tags every non-fully visible slide as `insert`, so when tabbing through a page with a nuka carousel you will _not_ tab into hidden slides.

Fixes #622 

#### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

It's been manually tested with a few configurations, and all existing tests pass.

### Screenshots

The below screenshots show a subtle blue outline on elements as they receive tab focus, notice that when the input box within a slide receives focus, the next element to receive focus is either the input box in another _fully_ visible slide or it jumps to the prev/next buttons.  It no longer jumps focus to slides that are _not_ visible.

Normal slides tab focus:
![standard-tabfocus](https://user-images.githubusercontent.com/40646372/72760833-ee710300-3b8e-11ea-9a17-57bb5135b6c8.gif)

Partial slides tab focus (with alignment):
![partial-tabfocus](https://user-images.githubusercontent.com/40646372/72760834-f03ac680-3b8e-11ea-8f84-33f788aaa086.gif)

Extreme slides tab focus (focus moves to both visible slides, even on wrap around):
![extreme-tabfocus](https://user-images.githubusercontent.com/40646372/72760841-f29d2080-3b8e-11ea-8310-a6247771dba7.gif)
