### PR TITLE
Issue 611: Added extra props to allow customization of default controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,11 @@ Or on CodeSandBox at the following url: <a href="https://codesandbox.io/s/curryi
 | autoplayInterval           | `React.PropTypes.number`                                                                                                                                                                                                                                               | Interval for autoplay iteration.                                                                                                                                                                                                                                                            | `3000 milliseconds`                                                                                                |
 | autoplayReverse            | `React.PropTypes.bool`                                                                                                                                                                                                                                                 | Only meaningful when `autoplay` is already true. When `autoplayReverse` is also true, autorotation cycles through slides indexes from high to low.                                                                                                                                          | `false`                                                                                                            |
 | beforeSlide                | `React.PropTypes.func`                                                                                                                                                                                                                                                 | Hook to be called before a slide is changed                                                                                                                                                                                                                                                 |                                                                                                                    |
-| cellAlign                  | `React.PropTypes.oneOf(['left', 'center', 'right'])`                                                                                                                                                                                                                   | When displaying more than one slide, sets which position to anchor the current slide to. **Is overridden to `left` when `transitionMode="fade"`**                                               |                                                                                                                    |
+| cellAlign                  | `React.PropTypes.oneOf(['left', 'center', 'right'])`                                                                                                                                                                                                                   | When displaying more than one slide, sets which position to anchor the current slide to. **Is overridden to `left` when `transitionMode="fade"`**                                                                                                                                           |                                                                                                                    |
 | cellSpacing                | `React.PropTypes.number`                                                                                                                                                                                                                                               | Space between slides, as an integer, but reflected as `px`                                                                                                                                                                                                                                  |                                                                                                                    |
-| enableKeyboardControls     | `React.PropTypes.bool`                                                                                                                                                                                                                                                 | When set to `true` will enable keyboard controls when the carousel has focus.  If the carousel does not have focus, keyboard controls will be ignored.                                                                                                                                                                                                                                           | `false`                                                                                                            |
+| enableKeyboardControls     | `React.PropTypes.bool`                                                                                                                                                                                                                                                 | When set to `true` will enable keyboard controls when the carousel has focus.  If the carousel does not have focus, keyboard controls will be ignored.                                                                                                                                      | `false`                                                                                                            |
 | keyCodeConfig              | `PropTypes.exact({ previousSlide: PropTypes.arrayOf(PropTypes.number), nextSlide: PropTypes.arrayOf(PropTypes.number), firstSlide: PropTypes.arrayOf(PropTypes.number), lastSlide: PropTypes.arrayOf(PropTypes.number), pause: PropTypes.arrayOf(PropTypes.number) })` | If `enableKeyboardControls` prop is true, you can pass configuration for the keyCode so you can override the default keyboard keys configured.                                                                                                                                              | `{ nextSlide: [39, 68, 38, 87], previousSlide: [37, 65, 40, 83], firstSlide: [81], lastSlide: [69], pause: [32] }` |
+| defaultControlsConfig      | `React.PropTypes.shape({ nextButtonClassName: PropTypes.string, nextButtonStyle: Proptypes.object, nextButtonText: PropTypes.string, prevButtonClassName: PropTypes.string, prevButtonStyle: PropTypes.object, prevButtonText: PropTypes.string, pagingDotsContainerClassName: PropTypes.string, pagingDotsClassName: PropTypes.string, pagingDotsStyle: PropTypes.object })`  | This prop lets you apply custom classes and styles to the default `Next`, `Previous`, and `Paging Dots` controls.  More information on how to customize these controls can be found below.  | `{}`                                                                                                 |
 | disableAnimation           | `React.PropTypes.bool`                                                                                                                                                                                                                                                 | When set to `true`, will disable animation.                                                                                                                                                                                                                                                 | `false`                                                                                                            |
 | disableEdgeSwiping         | `React.PropTypes.bool`                                                                                                                                                                                                                                                 | When set to `true`, will disable swiping before first slide and after last slide.                                                                                                                                                                                                           | `false`                                                                                                            |
 | dragging                   | `React.PropTypes.bool`                                                                                                                                                                                                                                                 | Enable mouse swipe/dragging.                                                                                                                                                                                                                                                                | `true`                                                                                                             |
@@ -152,6 +153,40 @@ A set of eight render props for rendering controls in different positions around
 >
   {/* Carousel Content */}
 </Carousel>
+```
+
+#### defaultControlsConfig
+
+```
+React.PropTypes.shape({
+  nextButtonClassName: PropTypes.string,
+  nextButtonStyle: PropTypes.object,
+  nextButtonText: PropTypes.string,
+  prevButtonClassName: PropTypes.string,
+  prevButtonStyle: PropTypes.object,
+  prevButtonText: PropTypes.string,
+  pagingDotsContainerClassName: PropTypes.string,
+  pagingDotsClassName: PropTypes.string,
+  pagingDotsStyle: PropTypes.object
+})
+```
+
+The default controls used by Nuka are the `Previous` button, `Next` button, and `PagingDots` control.  The visual look and text of these controls can be modified with props as described below:
+
+- The props ending with `ClassName` let you apply a custom css class to its respective control.
+- The props ending with `Style` let you apply inline styles to its respective control.
+- The text label for the `Previous` button and `Next` button can be customized using `prevButtonText` and `nextButtonText`, respectively.
+
+Example, you can change the text of the `Previous` and `Next` buttons, and change the paging dots to red by passing in the following configuration:
+
+```
+defaultControlsConfig={{
+  nextButtonText: 'Custom Next',
+  prevButtonText: 'Customn Prev',
+  pagingDotsStyle: {
+    fill: 'red'
+  }
+}}
 ```
 
 ### External Control of Carousel State

--- a/src/default-controls.js
+++ b/src/default-controls.js
@@ -16,23 +16,36 @@ export class PreviousButton extends React.Component {
     super(...arguments);
     this.handleClick = this.handleClick.bind(this);
   }
+
   handleClick(event) {
     event.preventDefault();
     this.props.previousSlide();
   }
+
   render() {
+    const {
+      prevButtonClassName,
+      prevButtonStyle = {},
+      prevButtonText
+    } = this.props.defaultControlsConfig;
+
     const disabled =
       (this.props.currentSlide === 0 && !this.props.wrapAround) ||
       this.props.slideCount === 0;
+
     return (
       <button
-        style={defaultButtonStyles(disabled)}
+        className={prevButtonClassName}
+        style={{
+          ...defaultButtonStyles(disabled),
+          ...prevButtonStyle
+        }}
         disabled={disabled}
         onClick={this.handleClick}
         aria-label="previous"
         type="button"
       >
-        Prev
+        {prevButtonText || 'Prev'}
       </button>
     );
   }
@@ -104,6 +117,12 @@ export class NextButton extends React.Component {
       vertical
     } = this.props;
 
+    const {
+      nextButtonClassName,
+      nextButtonStyle = {},
+      nextButtonText
+    } = this.props.defaultControlsConfig;
+
     const disabled = this.nextButtonDisabled({
       wrapAround,
       slidesToShow,
@@ -118,13 +137,17 @@ export class NextButton extends React.Component {
 
     return (
       <button
-        style={defaultButtonStyles(disabled)}
+        className={nextButtonClassName}
+        style={{
+          ...defaultButtonStyles(disabled),
+          ...nextButtonStyle
+        }}
         disabled={disabled}
         onClick={this.handleClick}
         aria-label="next"
         type="button"
       >
-        Next
+        {nextButtonText || 'Next'}
       </button>
     );
   }
@@ -170,7 +193,8 @@ export class PagingDots extends React.Component {
       cursor: 'pointer',
       opacity: active ? 1 : 0.5,
       background: 'transparent',
-      border: 'none'
+      border: 'none',
+      fill: 'black'
     };
   }
 
@@ -181,33 +205,35 @@ export class PagingDots extends React.Component {
       this.props.slidesToShow,
       this.props.cellAlign
     );
+
+    const {
+      pagingDotsContainerClassName,
+      pagingDotsClassName,
+      pagingDotsStyle = {}
+    } = this.props.defaultControlsConfig;
+
     return (
-      <ul style={this.getListStyles()}>
+      <ul className={pagingDotsContainerClassName} style={this.getListStyles()}>
         {indexes.map(index => {
+          const isActive = this.props.currentSlide === index;
+
           return (
             <li
               key={index}
-              className={
-                this.props.currentSlide === index
-                  ? 'paging-item active'
-                  : 'paging-item'
-              }
+              className={isActive ? 'paging-item active' : 'paging-item'}
             >
               <button
+                className={pagingDotsClassName}
                 type="button"
-                style={this.getButtonStyles(this.props.currentSlide === index)}
+                style={{
+                  ...this.getButtonStyles(isActive),
+                  ...pagingDotsStyle
+                }}
                 onClick={this.props.goToSlide.bind(null, index)}
                 aria-label={`slide ${index + 1} bullet`}
               >
                 <svg className="paging-dot" width="6" height="6">
-                  <circle
-                    cx="3"
-                    cy="3"
-                    r="3"
-                    style={{
-                      fill: 'black'
-                    }}
-                  />
+                  <circle cx="3" cy="3" r="3" />
                 </svg>
               </button>
             </li>

--- a/src/index.js
+++ b/src/index.js
@@ -1015,6 +1015,7 @@ export default class Carousel extends React.Component {
           func &&
           typeof func === 'function' &&
           func({
+            defaultControlsConfig: this.props.defaultControlsConfig,
             top: this.state.top,
             left: this.state.left,
             cellAlign: this.props.cellAlign,
@@ -1190,6 +1191,17 @@ Carousel.propTypes = {
   beforeSlide: PropTypes.func,
   cellAlign: PropTypes.oneOf(['left', 'center', 'right']),
   cellSpacing: PropTypes.number,
+  defaultControlsConfig: PropTypes.shape({
+    nextButtonClassName: PropTypes.string,
+    nextButtonStyle: PropTypes.object,
+    nextButtonText: PropTypes.string,
+    prevButtonClassName: PropTypes.string,
+    prevButtonStyle: PropTypes.object,
+    prevButtonText: PropTypes.string,
+    pagingDotsContainerClassName: PropTypes.string,
+    pagingDotsClassName: PropTypes.string,
+    pagingDotsStyle: PropTypes.object
+  }),
   disableAnimation: PropTypes.bool,
   disableEdgeSwiping: PropTypes.bool,
   dragging: PropTypes.bool,
@@ -1250,6 +1262,7 @@ Carousel.defaultProps = {
   beforeSlide() {},
   cellAlign: 'left',
   cellSpacing: 0,
+  defaultControlsConfig: {},
   disableAnimation: false,
   disableEdgeSwiping: false,
   dragging: true,

--- a/test/specs/default-controls.test.js
+++ b/test/specs/default-controls.test.js
@@ -5,7 +5,9 @@ describe('<PagingDots />', () => {
     let instance;
 
     beforeEach(async () => {
-      const wrapper = mount(<PagingDots goToSlide={() => null} />);
+      const wrapper = mount(
+        <PagingDots defaultControlsConfig={{}} goToSlide={() => null} />
+      );
       instance = wrapper.instance();
     });
 
@@ -115,7 +117,9 @@ describe('<NextButton />', () => {
     let instance;
 
     beforeEach(async () => {
-      const wrapper = mount(<NextButton buttonDisable={() => null} />);
+      const wrapper = mount(
+        <NextButton defaultControlsConfig={{}} buttonDisable={() => null} />
+      );
       instance = wrapper.instance();
     });
 


### PR DESCRIPTION
### Description

This PR adds extra props to let users customize Nuka's default controls.

**NOTE:**  I did _not_ implement the ability to swap out the text of the Next/Prev button for icons or components.  A custom icon would also need to support hover effects, enable/disable, and maybe other functionality that, I felt, could introduce too many edge cases.  If a user wants totally special Next/Prev buttons, then, I feel, it's best to simply pass in their own custom component and handle all the logic themselves.

Fixes #611 

#### Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### How Has This Been Tested?

Manually tested, and current tests pass.

### Screenshots

Normal demo app, without any changes (meaning things keep working by default):
![normal-custom](https://user-images.githubusercontent.com/40646372/72857345-387ee500-3c72-11ea-959d-f11f411a97ed.gif)

Shnazzy demo app with custom text for Prev/Next buttons and red paging dots:
![custom-custom](https://user-images.githubusercontent.com/40646372/72857377-4c2a4b80-3c72-11ea-9861-91b8b7fba5be.gif)

