### PR TITLE
Issue 610: Prevent swipe logic from taking over when no swipe was made

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -544,7 +544,9 @@ export default class Carousel extends React.Component {
       slidesToShow = this.state.slidesToScroll;
     }
 
-    if (this.touchObject.length > this.state.slideWidth / slidesToShow / 5) {
+    const touchLength = this.touchObject.length || 0;
+
+    if (touchLength > this.state.slideWidth / slidesToShow / 5) {
       if (this.touchObject.direction === 1) {
         if (
           this.state.currentSlide + 1 >= this.state.slideCount &&
@@ -561,7 +563,7 @@ export default class Carousel extends React.Component {
           this.previousSlide();
         }
       }
-    } else {
+    } else if (touchLength > 0) {
       this.goToSlide(this.state.currentSlide);
     }
 


### PR DESCRIPTION
### Description

This PR prevents swipe logic from running when a swipe of 0 distance (meaning just tapping the screen) has occurred. 

Fixes #610 

#### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Existing tests pass.  Manually tested.

### Screenshots

The little numbered button under each slide is a button _within_ the carousel that changes the `slideIndex` on click, before they didn't work (on emulated mobile), now they do:
![mobile-button](https://user-images.githubusercontent.com/40646372/73005709-3fb30980-3dbe-11ea-9106-4e28e59b3d37.gif)
