### PR TITLE
Issue 646: Prevent fade and fadeFromSlide from reaching/equalling slideCount to solve opacity issue

### DIFF
--- a/src/transitions/fade-transition.js
+++ b/src/transitions/fade-transition.js
@@ -108,8 +108,8 @@ export default class FadeTransition extends React.Component {
 
   render() {
     const fade =
-      -(this.props.deltaX || this.props.deltaY) / this.props.slideWidth;
-
+      (-(this.props.deltaX || this.props.deltaY) / this.props.slideWidth) %
+      this.props.slideCount;
     if (parseInt(fade) === fade) {
       this.fadeFromSlide = fade;
     }


### PR DESCRIPTION
### Description

When transitionMode = 'fade', autoplay = true, and wrapAround = true, there is a bug where the opacity of the first slide is set to 0 for a brief moment when it is displayed after the first loop.  In fade-transition.js, there is some code that calculates slide opacity which has an issue when the final slide finishes the transition to opacity 0 (the fade variable gets set to max index + 1, which causes issues in the opacity object that is created).  My fix is to add a modulo operation when calculating the fade variable which prevents it from exceeding the maximum index.

Fixes #646 

#### Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I added an autoplay option to the demo and tested the demo, monitoring the opacity of the first slide.  I also directly modified the node_modules code in the project where I encountered the bug and it resolved the issue.
