### PR TITLE
Issue 649: Apply pinch-zoom and pan-x/pan-y touchAction styles to fade mode as well

### DIFF
--- a/src/transitions/fade-transition.js
+++ b/src/transitions/fade-transition.js
@@ -101,7 +101,7 @@ export default class FadeTransition extends React.Component {
         : `0px ${(this.props.cellSpacing / 2) * -1}px`,
       MozBoxSizing: 'border-box',
       padding: 0,
-      touchAction: 'none',
+      touchAction: `pinch-zoom ${this.props.vertical ? 'pan-x' : 'pan-y'}`,
       width
     };
   }


### PR DESCRIPTION
### Description

touchAction style is set to 'none' for fade-transition, which prevents window scrolling on touch.  Set it to the same as the scroll-transition: `pinch-zoom ${this.props.vertical ? 'pan-x' : 'pan-y'}` 

Fixes #649 

#### Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Ran tests and also tested on demo.
