### PR TITLE
Fix typo in PR #609

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -292,7 +292,7 @@ export default class Carousel extends React.Component {
     };
 
     const unlockTouchScroll = () => {
-      document.addEventListener('touchmove', blockEvent, {
+      document.removeEventListener('touchmove', blockEvent, {
         passive: false
       });
     };


### PR DESCRIPTION
### Description

The unlockTouchScroll method should remove the event listener instead of adding it again.

Fixes #609 

#### Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Ran tests.
