### PR TITLE
fix: add missing type annotation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -302,7 +302,7 @@ export interface CarouselProps {
   /**
    * Function for rendering aria-live announcement messages
    */
-  renderAnnounceSlideMessage?: ({ currentSlide, slideCount }) => string;
+  renderAnnounceSlideMessage?: ({ currentSlide, slideCount }: CarouselSlideRenderControlProps) => string;
 
   /**
    * Manually set the index of the slide to be shown


### PR DESCRIPTION

### Description

renderAnnounceSlideMessage's function parameters is implicitly 'any' which breaks anyone's build using `noImplicitAny: true`

Fixes # (issue)

#### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist: (Feel free to delete this section upon completion)

- [ ] My code follows the style guidelines of this project (I have run `yarn lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] For any breaking API changes, I have updated the type definitions in [`index.d.ts`](../index.d.ts)
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
