### PR TITLE
fix(inert polyfill): lazy load the inert polyfill to fix issues when SSR

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import 'wicg-inert';
 import PropTypes from 'prop-types';
 import ExecutionEnvironment from 'exenv';
 import Animate from 'react-move/Animate';
@@ -110,6 +109,9 @@ export default class Carousel extends React.Component {
   componentDidMount() {
     // see https://github.com/facebook/react/issues/3417#issuecomment-121649937
     this.mounted = true;
+
+    // Polyfills are dynamically loaded in componentDidMount to fix issues when SSR
+    this.loadPolyfills();
     this.setLeft();
     this.setDimensions();
     this.bindEvents();
@@ -234,6 +236,12 @@ export default class Carousel extends React.Component {
       clearTimeout(this.timers[i]);
     }
     this.getlockScrollEvents().unlockTouchScroll();
+  }
+
+  loadPolyfills() {
+    if (typeof Element !== 'undefined') {
+      import('wicg-inert');
+    }
   }
 
   establishChildNodesMutationObserver() {


### PR DESCRIPTION
### Description

When using nuka-carousel in an environment which uses server side rendering (SSR). The loading of the wicg-inert polyfill causes the build to fail due to Element not being present when SSR.

Fixes #658 

#### Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- Tested both SSR and non SSR to ensure working as expected.
- Confirmed the polyfill was being loaded when the app was being hydrated on the client side.

### Checklist: (Feel free to delete this section upon completion)

- [X] My code follows the style guidelines of this project (I have run `yarn lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] For any breaking API changes, I have updated the type definitions in [`index.d.ts`](../index.d.ts)
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
