### PR TITLE
Add typing to support changes introduced in #644

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,8 @@ A set of eight render props for rendering controls in different positions around
 
 `React.PropTypes.func`
 
-`getControlsContainerStyles` is a function props that will be call with key argument being one of the following: `TopLeft` | `TopCenter` | `TopRight` | `CenterLeft` | `CenterCenter` | `CenterRight` | `BottomLeft` | `BottomCenter` | `BottomRight`. the function expect to return CSS Properties Ex:
+`getControlsContainerStyles` is a function prop that will be called with a key argument being one of the following: `TopLeft` | `TopCenter` | `TopRight` | `CenterLeft` | `CenterCenter` | `CenterRight` | `BottomLeft` | `BottomCenter` | `BottomRight`. 
+The function will then return CSS Properties.
 
 ```jsx
 <Carousel

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ Or on CodeSandBox at the following url: <a href="https://codesandbox.io/s/curryi
 | cellSpacing                | `React.PropTypes.number`                                                                                                                                                                                                                                               | Space between slides, as an integer, but reflected as `px`                                                                                                                                                                                                                                  |                                                                                                                    |
 | enableKeyboardControls     | `React.PropTypes.bool`                                                                                                                                                                                                                                                 | When set to `true` will enable keyboard controls when the carousel has focus.  If the carousel does not have focus, keyboard controls will be ignored.                                                                                                                                      | `false`                                                                                                            |
 | keyCodeConfig              | `PropTypes.exact({ previousSlide: PropTypes.arrayOf(PropTypes.number), nextSlide: PropTypes.arrayOf(PropTypes.number), firstSlide: PropTypes.arrayOf(PropTypes.number), lastSlide: PropTypes.arrayOf(PropTypes.number), pause: PropTypes.arrayOf(PropTypes.number) })` | If `enableKeyboardControls` prop is true, you can pass configuration for the keyCode so you can override the default keyboard keys configured.                                                                                                                                              | `{ nextSlide: [39, 68, 38, 87], previousSlide: [37, 65, 40, 83], firstSlide: [81], lastSlide: [69], pause: [32] }` |
-| defaultControlsConfig      | `React.PropTypes.shape({ nextButtonClassName: PropTypes.string, nextButtonStyle: Proptypes.object, nextButtonText: PropTypes.string, prevButtonClassName: PropTypes.string, prevButtonStyle: PropTypes.object, prevButtonText: PropTypes.string, pagingDotsContainerClassName: PropTypes.string, pagingDotsClassName: PropTypes.string, pagingDotsStyle: PropTypes.object })`  | This prop lets you apply custom classes and styles to the default `Next`, `Previous`, and `Paging Dots` controls.  More information on how to customize these controls can be found below.  | `{}`                                                                                                 |
+| getControlsContainerStyles | `React.PropTypes.func` | callback function to provide style to controls containers | |
+| defaultControlsConfig      | `React.PropTypes.shape({ containerClassName: PropTypes.string, nextButtonClassName: PropTypes.string, nextButtonStyle: Proptypes.object, nextButtonText: PropTypes.string, prevButtonClassName: PropTypes.string, prevButtonStyle: PropTypes.object, prevButtonText: PropTypes.string, pagingDotsContainerClassName: PropTypes.string, pagingDotsClassName: PropTypes.string, pagingDotsStyle: PropTypes.object })`  | This prop lets you apply custom classes and styles to the default `Container`. `Next`, `Previous`, and `Paging Dots` controls.  More information on how to customize these controls can be found below.  | `{}`                                                                                                 |
 | disableAnimation           | `React.PropTypes.bool`                                                                                                                                                                                                                                                 | When set to `true`, will disable animation.                                                                                                                                                                                                                                                 | `false`                                                                                                            |
 | disableEdgeSwiping         | `React.PropTypes.bool`                                                                                                                                                                                                                                                 | When set to `true`, will disable swiping before first slide and after last slide.                                                                                                                                                                                                           | `false`                                                                                                            |
 | dragging                   | `React.PropTypes.bool`                                                                                                                                                                                                                                                 | Enable mouse swipe/dragging.                                                                                                                                                                                                                                                                | `true`                                                                                                             |
@@ -150,6 +151,32 @@ A set of eight render props for rendering controls in different positions around
   renderAnnounceSlideMessage={({ currentSlide, slideCount }) =>
     `Slide ${currentSlide + 1} of ${slideCount}`
   }
+>
+  {/* Carousel Content */}
+</Carousel>
+```
+
+#### getControlsContainerStyles
+
+`React.PropTypes.func`
+
+`getControlsContainerStyles` is a function props that will be call with key argument being one of the following: `TopLeft` | `TopCenter` | `TopRight` | `CenterLeft` | `CenterCenter` | `CenterRight` | `BottomLeft` | `BottomCenter` | `BottomRight`. the function expect to return CSS Properties Ex:
+
+```jsx
+<Carousel
+  getControlsContainerStyles={(key) => {
+     switch (key) {
+        case 'TopLeft':
+          return {
+            backgroundColor: "red",
+          };
+        default:
+          // will apply all other keys
+          return {
+            backgroundColor: "blue",
+          };
+      }
+  }} />
 >
   {/* Carousel Content */}
 </Carousel>

--- a/index.d.ts
+++ b/index.d.ts
@@ -173,6 +173,21 @@ export interface CarouselProps {
   };
 
   /**
+   * This prop lets you apply custom classes and styles to the default Next, Previous, and Paging Dots controls
+   */
+  defaultControlsConfig?: {
+    nextButtonClassName?: string;
+    nextButtonStyle?: CSSProperties;
+    nextButtonText?: string;
+    prevButtonClassName?: string;
+    prevButtonStyle?: CSSProperties;
+    prevButtonText?: string;
+    pagingDotsContainerClassName: string;
+    pagingDotsClassName?: string;
+    pagingDotsStyle?: CSSProperties;
+  };
+
+  /**
    * Disable slides animation
    * @default false
    */

--- a/index.d.ts
+++ b/index.d.ts
@@ -27,6 +27,17 @@ export type CarouselSlideActions =
   | 'lastSlide'
   | 'pause';
 
+export type CarouselControlContainerProp =
+  | 'TopLeft'
+  | 'TopCenter'
+  | 'TopRight'
+  | 'CenterLeft'
+  | 'CenterCenter'
+  | 'CenterRight'
+  | 'BottomLeft'
+  | 'BottomCenter'
+  | 'BottomRight';
+
 export interface CarouselSlideRenderControlProps {
   /**
    * When displaying more than one slide, sets which position to anchor the current slide to.
@@ -173,16 +184,24 @@ export interface CarouselProps {
   };
 
   /**
+   * Optional callback to apply styles to the container of a control.
+   */
+  getControlContainerStyle?: (
+    key: CarouselControlContainerProp
+  ) => CSSProperties;
+
+  /**
    * This prop lets you apply custom classes and styles to the default Next, Previous, and Paging Dots controls
    */
   defaultControlsConfig?: {
+    containerClassName?: string;
     nextButtonClassName?: string;
     nextButtonStyle?: CSSProperties;
     nextButtonText?: string;
     prevButtonClassName?: string;
     prevButtonStyle?: CSSProperties;
     prevButtonText?: string;
-    pagingDotsContainerClassName: string;
+    pagingDotsContainerClassName?: string;
     pagingDotsClassName?: string;
     pagingDotsStyle?: CSSProperties;
   };
@@ -317,7 +336,10 @@ export interface CarouselProps {
   /**
    * Function for rendering aria-live announcement messages
    */
-  renderAnnounceSlideMessage?: ({ currentSlide, slideCount }: CarouselSlideRenderControlProps) => string;
+  renderAnnounceSlideMessage?: ({
+    currentSlide,
+    slideCount
+  }: CarouselSlideRenderControlProps) => string;
 
   /**
    * Manually set the index of the slide to be shown

--- a/src/index.js
+++ b/src/index.js
@@ -1042,9 +1042,17 @@ export default class Carousel extends React.Component {
         return (
           controlChildren && (
             <div
-              className={`slider-control-${key.toLowerCase()}`}
-              style={getDecoratorStyles(key)}
               key={key}
+              className={[
+                `slider-control-${key.toLowerCase()}`,
+                this.props.defaultControlsConfig.containerClassName || ''
+              ]
+                .join(' ')
+                .trim()}
+              style={{
+                ...getDecoratorStyles(key),
+                ...this.props.getControlsContainerStyles(key)
+              }}
             >
               {controlChildren}
             </div>
@@ -1197,7 +1205,9 @@ Carousel.propTypes = {
   beforeSlide: PropTypes.func,
   cellAlign: PropTypes.oneOf(['left', 'center', 'right']),
   cellSpacing: PropTypes.number,
+  getControlsContainerStyles: PropTypes.func,
   defaultControlsConfig: PropTypes.shape({
+    containerClassName: PropTypes.string,
     nextButtonClassName: PropTypes.string,
     nextButtonStyle: PropTypes.object,
     nextButtonText: PropTypes.string,
@@ -1268,6 +1278,7 @@ Carousel.defaultProps = {
   beforeSlide() {},
   cellAlign: 'left',
   cellSpacing: 0,
+  getControlsContainerStyles() {},
   defaultControlsConfig: {},
   disableAnimation: false,
   disableEdgeSwiping: false,

--- a/test/specs/carousel.test.js
+++ b/test/specs/carousel.test.js
@@ -216,6 +216,18 @@ describe('<Carousel />', () => {
       expect(slider).toHaveLength(1);
     });
 
+    it('should render with the className `test` append to slider-control-bottomcenter', () => {
+      const wrapper = mount(
+        <Carousel defaultControlsConfig={{ containerClassName: 'test' }}>
+          <p>Slide 1</p>
+          <p>Slide 2</p>
+          <p>Slide 3</p>
+        </Carousel>
+      );
+      const slider = wrapper.find('div.slider-control-bottomcenter');
+      expect(slider).toHaveClassName('test');
+    });
+
     it('should merge provided styles with default styles.', () => {
       const wrapper = mount(
         <Carousel style={{ backgroundColor: 'black' }}>
@@ -227,6 +239,33 @@ describe('<Carousel />', () => {
       const slider = wrapper.find('div.slider');
       expect(slider).toHaveStyle('backgroundColor', 'black');
       expect(slider).toHaveStyle('display', 'block');
+    });
+
+    it('should merge provided defaultControlsConfig.containerStyle with default styles.', () => {
+      const wrapper = mount(
+        <Carousel
+          getControlsContainerStyles={key => {
+            switch (key) {
+              case 'BottomCenter':
+                return {
+                  bottom: '50%',
+                  top: '0'
+                };
+
+              default:
+                return {};
+            }
+          }}
+        >
+          <p>Slide 1</p>
+          <p>Slide 2</p>
+          <p>Slide 3</p>
+        </Carousel>
+      );
+      const slider = wrapper.find('div.slider-control-bottomcenter');
+      expect(slider).toHaveStyle('position', 'absolute');
+      expect(slider).toHaveStyle('top', '0');
+      expect(slider).toHaveStyle('bottom', '50%');
     });
 
     it('should align to 0 when `cellAlign` is `left`.', () => {


### PR DESCRIPTION
### Description

https://github.com/FormidableLabs/nuka-carousel/pull/644 Introduced new props but didn't add typing to support those.

This PR also add `getControlsContainerStyles` & `defaultControlsConfig .containerClassName` to target the container wrapping controls