### PR TITLE
Issue 622: Only fully visible slides are interactable.

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -2,6 +2,7 @@ import React, { useState, useCallback } from 'react';
 import Carousel from '../src/index';
 import ReactDom from 'react-dom';
 
+// eslint-disable-next-line complexity
 export default function App() {
   const colors = [
     '7732bb',
@@ -17,6 +18,7 @@ export default function App() {
   const [animation, setAnimation] = useState(undefined);
   const [autoplay, setAutoplay] = useState(false);
   const [cellAlign, setCellAlign] = useState('left');
+  const [cellSpacing, setCellSpacing] = useState(0);
   const [heightMode, setHeightMode] = useState('max');
   const [length, setLength] = useState(colors.length);
   const [scrollMode, setScrollMode] = useState('remainder');
@@ -67,6 +69,7 @@ export default function App() {
   return (
     <div style={{ width: '50%', margin: 'auto' }}>
       <Carousel
+        cellSpacing={cellSpacing}
         animation={animation}
         autoplay={autoplay}
         cellAlign={cellAlign}
@@ -147,6 +150,13 @@ export default function App() {
             }
           >
             Toggle ScrollMode: {scrollMode}
+          </button>
+          <button
+            onClick={() =>
+              setCellSpacing(prevCellSpacing => (prevCellSpacing > 0 ? 0 : 5))
+            }
+          >
+            Toggle Cellspacing {cellSpacing > 0 ? 'Off' : 'On'}
           </button>
         </div>
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "d3-ease": "^1.0.3",
     "exenv": "^1.2.0",
     "prop-types": "^15.6.0",
-    "react-move": "^6.1.0"
+    "react-move": "^6.1.0",
+    "wicg-inert": "^3.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.5.5",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import 'wicg-inert';
 import PropTypes from 'prop-types';
 import ExecutionEnvironment from 'exenv';
 import Animate from 'react-move/Animate';

--- a/src/transitions/scroll-transition.js
+++ b/src/transitions/scroll-transition.js
@@ -4,7 +4,11 @@ import {
   getSlideHeight,
   getAlignmentOffset
 } from '../utilities/style-utilities';
-import { getSlideDirection, handleSelfFocus } from '../utilities/utilities';
+import {
+  getSlideDirection,
+  handleSelfFocus,
+  isFullyVisible
+} from '../utilities/utilities';
 
 const MIN_ZOOM_SCALE = 0;
 const MAX_ZOOM_SCALE = 1;
@@ -104,6 +108,9 @@ export default class ScrollTransition extends React.Component {
     return React.Children.map(children, (child, index) => {
       const visible =
         index >= currentSlide && index < currentSlide + slidesToShow;
+      const isVisible = isFullyVisible(index, this.props);
+      const inert = isVisible ? {} : { inert: 'true' };
+
       return (
         <li
           className={`slider-slide${visible ? ' slide-visible' : ''}`}
@@ -111,6 +118,7 @@ export default class ScrollTransition extends React.Component {
           key={index}
           onClick={handleSelfFocus}
           tabIndex={-1}
+          {...inert}
         >
           {child}
         </li>

--- a/src/utilities/utilities.js
+++ b/src/utilities/utilities.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { getAlignmentOffset } from './style-utilities';
 
 export const addEvent = function(elem, type, eventHandle) {
   if (elem === null || typeof elem === 'undefined') {
@@ -168,4 +169,50 @@ export const handleSelfFocus = e => {
   if (e && e.currentTarget) {
     e.currentTarget.focus();
   }
+};
+
+export const isFullyVisible = (slideIndex, config) => {
+  const {
+    currentSlide,
+    cellSpacing,
+    slideCount,
+    slideWidth,
+    frameWidth,
+    wrapAround
+  } = config;
+
+  // Slide width can't be 0
+  const fullSlideWidth = slideWidth || 1;
+  // Calculate offset without cellSpacing
+  const offsetWidth =
+    getAlignmentOffset(currentSlide, config) + cellSpacing * currentSlide;
+  const remainingWidth = frameWidth - offsetWidth;
+
+  const fullSlidesBefore = Math.max(
+    Math.floor(offsetWidth / fullSlideWidth),
+    0
+  );
+
+  const fullSlidesAfter = Math.max(
+    Math.floor(remainingWidth / fullSlideWidth) - 1,
+    0
+  );
+
+  const currentSlideIndex = Math.ceil(currentSlide);
+  const fullyVisibleSlides = [];
+
+  for (
+    let i = currentSlideIndex - fullSlidesBefore;
+    i < currentSlideIndex + fullSlidesAfter + 1;
+    i++
+  ) {
+    if (i < 0) {
+      // -1 won't match a slide index
+      fullyVisibleSlides.push(wrapAround ? slideCount + i : -1);
+    } else {
+      fullyVisibleSlides.push(i > slideCount - 1 ? i - slideCount : i);
+    }
+  }
+
+  return fullyVisibleSlides.includes(slideIndex);
 };

--- a/test/e2e/carousel.test.js
+++ b/test/e2e/carousel.test.js
@@ -411,6 +411,47 @@ describe('Nuka Carousel', () => {
       await page.mouse.up();
       await expect(page).toMatch('Nuka Carousel: Slide 4');
     });
+
+    it('should handle click events when cellspacing is greater than 0', async () => {
+      const slide = await page.$('.slider-slide');
+      const metrics = await slide.boundingBox();
+      const pointX = metrics.x + metrics.width / 2.0;
+      const pointY = metrics.y + metrics.height / 2.0;
+
+      await expect(page).toClick('button', { text: 'Toggle Cellspacing On' });
+
+      const getTextDecoration = () => {
+        const e = document.querySelector('.slider-control-topcenter div');
+        return window.getComputedStyle(e).textDecorationLine;
+      };
+
+      await expect(page).toMatch('Nuka Carousel: Slide 1');
+
+      // Make sure link works on first slide
+      let textDecoration = await page.evaluate(getTextDecoration);
+      expect(textDecoration).toMatch('none');
+      await page.mouse.click(pointX, pointY);
+      textDecoration = await page.evaluate(getTextDecoration);
+      expect(textDecoration).toMatch('underline');
+      await page.mouse.click(pointX, pointY);
+      textDecoration = await page.evaluate(getTextDecoration);
+      expect(textDecoration).toMatch('none');
+
+      await expect(page).toClick('button', { text: 'Next' });
+      await page.waitFor(600); // need to let slide transition complete
+
+      await expect(page).toMatch('Nuka Carousel: Slide 2');
+
+      // It should work on this slide too
+      textDecoration = await page.evaluate(getTextDecoration);
+      expect(textDecoration).toMatch('none');
+      await page.mouse.click(pointX, pointY);
+      textDecoration = await page.evaluate(getTextDecoration);
+      expect(textDecoration).toMatch('underline');
+      await page.mouse.click(pointX, pointY);
+      textDecoration = await page.evaluate(getTextDecoration);
+      expect(textDecoration).toMatch('none');
+    });
   });
 
   describe('Neighboring Slide Visibility and Slide Alignment', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9039,6 +9039,11 @@ which@^1.2.12, which@^1.2.9, which@^1.3.0:
   dependencies:
     isexe "^2.0.0"
 
+wicg-inert@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/wicg-inert/-/wicg-inert-3.0.0.tgz#4f5797172fbf7ff01effd3839b52872e35d3cba2"
+  integrity sha512-sZsYZ8pk8y6CgDLkTxivfhLDBvZuDWTWBawU8OuDdO0Id6AOd1Gqjkvt9g9Ni7rgHIS7UbRvbLSv1z7MSJDYCA==
+
 word-wrap@~1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"


### PR DESCRIPTION
**Warning:** This PR adds the package `wicg-inert` which currently has a bug in it that causes issues with server side rendering.  There is  PR out to fix it, but it's not yet been merged (https://github.com/WICG/inert/pull/144).  Once _that_ fix is merged, this PR should update `wicg-inert` to the latest package and then this can be merged!

### Description

This is a second attempt for this PR to fix issue #622.  With the previous version, a user found an issue (#664) that fully visible slides were being marked as `inert` and thus weren't inter-actable.  I believe I fixed the logic in `isFullyVisible` so slides won't be incorrectly tagged as `inert`.

Fixes #622 #664 

#### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

All existing tests pass and a new e2e test was written that failed at first, but now passes with the updated code.

### Screenshots
The below screenshots demonstrate that the anchor inside each slide is clickable when the slide is fully visible (the carousel title text toggles an underline as the anchors are clicked).

Slides remain active with cellspacing and multiple slides to show, left-aligned:
![left_active_anchor](https://user-images.githubusercontent.com/40646372/74693023-c92be080-519e-11ea-86be-de1691612143.gif)

Right-aligned:
![right_active_anchor](https://user-images.githubusercontent.com/40646372/74693026-ccbf6780-519e-11ea-8d0d-df7e650b3b9c.gif)

Center-aligned:
![center_active_anchor](https://user-images.githubusercontent.com/40646372/74693027-cfba5800-519e-11ea-8283-e2a3ed7c3686.gif)

And works with wrap around enabled too:
![wrapAround_active_anchor](https://user-images.githubusercontent.com/40646372/74693029-d21cb200-519e-11ea-8b01-7d930f201c2b.gif)
