### PR TITLE
Issue 552: Fixed edge swipe bug

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -708,19 +708,32 @@ export default class Carousel extends React.Component {
   }
 
   isEdgeSwiping() {
-    const { slideCount, slideWidth, slideHeight, slidesToShow } = this.state;
+    const {
+      currentSlide,
+      slideCount,
+      slideWidth,
+      slideHeight,
+      slidesToShow
+    } = this.state;
     const { tx, ty } = this.getOffsetDeltas();
+    const offset = getAlignmentOffset(currentSlide, {
+      ...this.props,
+      ...this.state
+    });
+
     if (this.props.vertical) {
       const rowHeight = slideHeight / slidesToShow;
       const slidesLeftToShow = slideCount - slidesToShow;
       const lastSlideLimit = rowHeight * slidesLeftToShow;
 
+      const offsetTy = ty[0] - offset;
       // returns true if ty offset is outside first or last slide
-      return ty > 0 || -ty > lastSlideLimit;
+      return offsetTy > 0 || -offsetTy > lastSlideLimit;
     }
 
+    const offsetTx = tx[0] - offset;
     // returns true if tx offset is outside first or last slide
-    return tx > 0 || -tx > slideWidth * (slideCount - 1);
+    return offsetTx > 0 || -offsetTx > slideWidth * (slideCount - 1);
   }
 
   // Action Methods


### PR DESCRIPTION
### Description

This PR fixes a bug where you couldn't get back to the first slide if edge swiping was disabled (with no wrap around).  We weren't taking into account the alignment offset, but now were are 😎 

Fixes #552 

#### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Lots of manual testing and all existing tests pass.

### Screenshots

This is how it works (or doesn't) in master 😱 :
![broken-edge-swipe](https://user-images.githubusercontent.com/40646372/74886493-2fdf0480-532d-11ea-89c7-403f7250baf1.gif)

Here's it working right-aligned with this PR:
![right-aligned-working](https://user-images.githubusercontent.com/40646372/74886509-366d7c00-532d-11ea-9dca-9bb0f2110b24.gif)

Center-aligned and working:
![center-aligned-working](https://user-images.githubusercontent.com/40646372/74886521-3cfbf380-532d-11ea-8f59-1a96e9052ccb.gif)

Still working left-aligned:
![left-aligned-working](https://user-images.githubusercontent.com/40646372/74886531-44230180-532d-11ea-8a86-30ade788ed15.gif)

And works with no partial slides:
![regular-working](https://user-images.githubusercontent.com/40646372/74886595-687ede00-532d-11ea-964a-63a11dbafc94.gif)

And and edge swiping enabled still works too 😎 
![edge-swipe-enabled](https://user-images.githubusercontent.com/40646372/74886607-6fa5ec00-532d-11ea-81d9-24167c7f3953.gif)
