### PR TITLE
Fix getControlsContainerStyle prop name typo in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -186,7 +186,7 @@ export interface CarouselProps {
   /**
    * Optional callback to apply styles to the container of a control.
    */
-  getControlContainerStyle?: (
+  getControlsContainerStyle?: (
     key: CarouselControlContainerProp
   ) => CSSProperties;
 


### PR DESCRIPTION
### Description

Fixes a typo in the `getControlsContainerStyle` prop name in index.d.ts that was preventing its use in TypeScript code.

#### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Tested in a TypeScript codebase by using the `getControlsContainerStyles` prop.

### Workaround

Until this is merged and released, it can be worked around by including this snippet somewhere in your project:

```typescript
declare module 'nuka-carousel' {
  interface CarouselProps {
    /**
     * Optional callback to apply styles to the container of a control.
     */
    getControlsContainerStyles?: (
      key: CarouselControlContainerProp,
    ) => CSSProperties
  }
}
```