### PR TITLE
Add `innerRef` to type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -259,6 +259,11 @@ export interface CarouselProps {
   height?: string;
 
   /**
+   * Ref to pass to carousel element
+   */
+  innerRef?: React.RefObject<HTMLInputElement>;
+
+  /**
    * Change the height of the slides based either on the first slide,
    * the current slide, or the maximum height of all slides.
    */


### PR DESCRIPTION
See https://github.com/FormidableLabs/nuka-carousel/pull/671#issuecomment-594202664