### PR TITLE
fix: flash after wrap around

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -165,6 +165,10 @@ export default class Carousel extends React.Component {
       }
     }
 
+    if (this.state.isWrappingAround) {
+      this.isWrapped = true;
+    }
+
     const prevSlideCount = getValidChildren(prevProps.children).length;
     const slideCount = getValidChildren(this.props.children).length;
     const slideCountChanged = prevSlideCount !== slideCount;
@@ -972,8 +976,10 @@ export default class Carousel extends React.Component {
 
     if (
       slideHeight !== this.state.slideHeight ||
-      slideWidth !== this.state.slideWidth
+      slideWidth !== this.state.slideWidth ||
+      this.isWrapped
     ) {
+      this.isWrapped = false;
       this.setState({ slideHeight, slideWidth });
     }
   }


### PR DESCRIPTION
### Description

While performing the wrap around, slide jumps to 0px that causes blinking on the screen. This PR applies a hot-fix for that problem. Actually that issue has been fixed before, but after #624 merged, it appeared again. I am also aware of an open [WIP] PR #675 that relevant indirectly with this issue. Since I don't know how long it is gonna take, I am opening that PR to use the latest version of the library which got rid of deprecated UNSAFE_componentWillReceiveProps fn.


**To reproduce:** https://codesandbox.io/s/dark-cdn-9m1tk
> It is also possible to reproduce it on local demo using yarn start. (prerequisite: Toggle wrapAround)



Fixes #494 

#### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist: (Feel free to delete this section upon completion)

- [x] My code follows the style guidelines of this project (I have run `yarn lint`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [x] I have performed a self-review of my own code

- We can consider adding a test case for later as this situation repeats once in a while.