### PR TITLE
Update incorrect prop 'getControlsContainerStyle'

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -188,7 +188,7 @@ export interface CarouselProps {
   /**
    * Optional callback to apply styles to the container of a control.
    */
-  getControlsContainerStyle?: (
+  getControlsContainerStyles?: (
     key: CarouselControlContainerProp
   ) => CSSProperties;
 


### PR DESCRIPTION
Update incorrect prop definition 'getControlsContainerStyle' to 'getControlsContainerStyles'

### Description

I am using nuka-carousel with typescript. When I am using 'getControlsContainerStyles' it causes next error "Property 'getControlsContainerStyles' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Carousel> & Readonly<CarouselProps> & Readonly<...>'". I fixed type definitions.

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist: (Feel free to delete this section upon completion)

- [x] For any breaking API changes, I have updated the type definitions in [`index.d.ts`](../index.d.ts)
