### PR TITLE
Rename param of afterSlide callback

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -116,9 +116,9 @@ export interface CSSProperties extends CSS.Properties<string | number> {}
 export interface CarouselProps {
   /**
    * Hook to be called after a slide is changed
-   * @param prevSlide Index of the previous slide
+   * @param index Index of the current slide
    */
-  afterSlide?: (prevSlide: number) => void;
+  afterSlide?: (index: number) => void;
 
   /**
    * Adds a zoom effect on the currently visible slide.


### PR DESCRIPTION
### Description

This param name confused me. so i updated it

Fixes # (issue) no issue

#### Type of Change

Please delete options that are not relevant.

- [x] refactor type only
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist: (Feel free to delete this section upon completion)

- [x] My code follows the style guidelines of this project (I have run `yarn lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] For any breaking API changes, I have updated the type definitions in [`index.d.ts`](../index.d.ts)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
