### PR TITLE
fix edge 42.17134.1.0 issue

### DIFF
--- a/src/utilities/bootstrapping-utilities.js
+++ b/src/utilities/bootstrapping-utilities.js
@@ -28,13 +28,11 @@ const getHeightOfSlide = slide => {
   }
 
   if (slide.children && slide.children.length > 0) {
-    // Need to convert slide.children from HTMLCollection
-    // to an array
-    const children = [...slide.children];
-    return children.reduce(
-      (totalHeight, child) => totalHeight + child.offsetHeight,
-      0
-    );
+    let totalHeight = 0;
+    for (let i = 0; i < slide.children.length; ++i) {
+      totalHeight += slide.children[i].offsetHeight;
+    }
+    return totalHeight;
   } else {
     return slide.offsetHeight;
   }


### PR DESCRIPTION
### Description

`const children = [...slide.children];` - doesn't work for me on edge 42.17134.1.0.
test application (yarn; yarn build; yarn start) doesn't work too.

`Invalid attempt to spread non-iterable instance", stack: "TypeError: Invalid attempt to spread non-iterable instance at _nonIterableSpread (eval code:11:33) at _toConsumableArray (eval code:9:36) at getHeightOfSlide (eval code:47:5) at findCurrentHeightSlide (eval code:114:5)`

Fixes # (issue)

#### Type of Change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

tested manually on my edge (2018 version)

### Checklist: (Feel free to delete this section upon completion)

- [ x] I have run `yarn lint`
- [ -] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [x ] I have performed a self-review of my own code
- [ -] I have commented my code, particularly in hard-to-understand areas
- [ -] I have made corresponding changes to the documentation
- [ -] For any breaking API changes, I have updated the type definitions in [`index.d.ts`](../index.d.ts)
- [ x] My changes generate no new warnings
- [ -] Any dependent changes have been merged and published in downstream modules
