### PR TITLE
add slide-current class to currentSlide, cleanup some utility functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ A set of eight render props for rendering controls in different positions around
 
 - The function returns the props for `goToSlide`, `nextSlide` and `previousSlide` functions in addition to `slideCount` and `currentSlide` values. Can also remove all render controls using `withoutControls`.
 
-- NOTE: The className `slide-visible` is added to the currently visible slide.
+- NOTE: The className `slide-visible` is added to the currently visible slide or slides (when slidesToShow > 1). The className `slide-current` is added to the currently "active" slide.
 
 #### renderAnnounceSlideMessage
 

--- a/src/default-controls.js
+++ b/src/default-controls.js
@@ -43,49 +43,46 @@ export const PreviousButton = props => {
   );
 };
 
+export const nextButtonDisabled = ({
+  cellAlign,
+  cellSpacing,
+  currentSlide,
+  frameWidth,
+  positionValue,
+  slideCount,
+  slidesToShow,
+  slideWidth,
+  wrapAround
+}) => {
+  let buttonDisabled = false;
+
+  if (!wrapAround) {
+    const alignmentOffset = getAlignmentOffset(currentSlide, {
+      cellAlign,
+      cellSpacing,
+      frameWidth,
+      slideWidth
+    });
+
+    const relativePosition = positionValue - alignmentOffset;
+
+    const width = slideWidth + cellSpacing;
+    const endOffset =
+      cellAlign === 'center' ? 2 * alignmentOffset : alignmentOffset;
+    const endPosition = -width * slideCount + width * slidesToShow - endOffset;
+
+    buttonDisabled =
+      relativePosition < endPosition ||
+      Math.abs(relativePosition - endPosition) < 0.01;
+  }
+
+  return buttonDisabled;
+};
+
 export const NextButton = props => {
   const handleClick = event => {
     event.preventDefault();
     props.nextSlide();
-  };
-
-  const nextButtonDisabled = params => {
-    const {
-      cellAlign,
-      cellSpacing,
-      currentSlide,
-      frameWidth,
-      positionValue,
-      slideCount,
-      slidesToShow,
-      slideWidth,
-      wrapAround
-    } = params;
-
-    let buttonDisabled = false;
-
-    if (!wrapAround) {
-      const alignmentOffset = getAlignmentOffset(currentSlide, {
-        cellAlign,
-        cellSpacing,
-        frameWidth,
-        slideWidth
-      });
-
-      const relativePosition = positionValue - alignmentOffset;
-
-      const width = slideWidth + cellSpacing;
-      const endOffset =
-        cellAlign === 'center' ? 2 * alignmentOffset : alignmentOffset;
-      const endPosition =
-        -width * slideCount + width * slidesToShow - endOffset;
-
-      buttonDisabled =
-        relativePosition < endPosition ||
-        Math.abs(relativePosition - endPosition) < 0.01;
-    }
-
-    return buttonDisabled;
   };
 
   const {
@@ -138,42 +135,42 @@ export const NextButton = props => {
   );
 };
 
+export const getDotIndexes = (
+  slideCount,
+  slidesToScroll,
+  slidesToShow,
+  cellAlign,
+  scrollMode
+) => {
+  const dotIndexes = [];
+  let lastDotIndex = slideCount - slidesToShow;
+
+  switch (cellAlign) {
+    case 'center':
+    case 'right':
+      lastDotIndex += slidesToShow - 1;
+      break;
+  }
+
+  if (lastDotIndex < 0) {
+    return [0];
+  }
+
+  for (let i = 0; i < lastDotIndex; i += slidesToScroll) {
+    dotIndexes.push(i);
+  }
+
+  if (cellAlign === 'left' && scrollMode === 'page') {
+    lastDotIndex = Math.floor(
+      slideCount - (slideCount % slidesToShow || slidesToShow)
+    );
+  }
+
+  dotIndexes.push(lastDotIndex);
+  return dotIndexes;
+};
+
 export const PagingDots = props => {
-  const getDotIndexes = (
-    slideCount,
-    slidesToScroll,
-    slidesToShow,
-    cellAlign,
-    scrollMode
-  ) => {
-    const dotIndexes = [];
-    let lastDotIndex = slideCount - slidesToShow;
-
-    switch (cellAlign) {
-      case 'center':
-      case 'right':
-        lastDotIndex += slidesToShow - 1;
-        break;
-    }
-
-    if (lastDotIndex < 0) {
-      return [0];
-    }
-
-    for (let i = 0; i < lastDotIndex; i += slidesToScroll) {
-      dotIndexes.push(i);
-    }
-
-    if (cellAlign === 'left' && scrollMode === 'page') {
-      lastDotIndex = Math.floor(
-        slideCount - (slideCount % slidesToShow || slidesToShow)
-      );
-    }
-
-    dotIndexes.push(lastDotIndex);
-    return dotIndexes;
-  };
-
   const getListStyles = () => ({
     position: 'relative',
     top: -10,

--- a/src/default-controls.js
+++ b/src/default-controls.js
@@ -11,59 +11,45 @@ const defaultButtonStyles = disabled => ({
   cursor: disabled ? 'not-allowed' : 'pointer'
 });
 
-export class PreviousButton extends React.Component {
-  constructor() {
-    super(...arguments);
-    this.handleClick = this.handleClick.bind(this);
-  }
-
-  handleClick(event) {
+export const PreviousButton = props => {
+  const handleClick = event => {
     event.preventDefault();
-    this.props.previousSlide();
-  }
+    props.previousSlide();
+  };
 
-  render() {
-    const {
-      prevButtonClassName,
-      prevButtonStyle = {},
-      prevButtonText
-    } = this.props.defaultControlsConfig;
+  const {
+    prevButtonClassName,
+    prevButtonStyle = {},
+    prevButtonText
+  } = props.defaultControlsConfig;
 
-    const disabled =
-      (this.props.currentSlide === 0 && !this.props.wrapAround) ||
-      this.props.slideCount === 0;
+  const disabled =
+    (props.currentSlide === 0 && !props.wrapAround) || props.slideCount === 0;
 
-    return (
-      <button
-        className={prevButtonClassName}
-        style={{
-          ...defaultButtonStyles(disabled),
-          ...prevButtonStyle
-        }}
-        disabled={disabled}
-        onClick={this.handleClick}
-        aria-label="previous"
-        type="button"
-      >
-        {prevButtonText || 'Prev'}
-      </button>
-    );
-  }
-}
+  return (
+    <button
+      className={prevButtonClassName}
+      style={{
+        ...defaultButtonStyles(disabled),
+        ...prevButtonStyle
+      }}
+      disabled={disabled}
+      onClick={handleClick}
+      aria-label="previous"
+      type="button"
+    >
+      {prevButtonText || 'Prev'}
+    </button>
+  );
+};
 
-export class NextButton extends React.Component {
-  constructor() {
-    super(...arguments);
-    this.handleClick = this.handleClick.bind(this);
-    this.nextButtonDisable = this.nextButtonDisabled.bind(this);
-  }
-
-  handleClick(event) {
+export const NextButton = props => {
+  const handleClick = event => {
     event.preventDefault();
-    this.props.nextSlide();
-  }
+    props.nextSlide();
+  };
 
-  nextButtonDisabled(params) {
+  const nextButtonDisabled = params => {
     const {
       cellAlign,
       cellSpacing,
@@ -100,67 +86,66 @@ export class NextButton extends React.Component {
     }
 
     return buttonDisabled;
-  }
+  };
 
-  render() {
-    const {
-      cellAlign,
-      cellSpacing,
-      currentSlide,
-      frameWidth,
-      left,
-      slideCount,
-      slidesToShow,
-      slideWidth,
-      top,
-      vertical,
-      wrapAround
-    } = this.props;
+  const {
+    cellAlign,
+    cellSpacing,
+    currentSlide,
+    defaultControlsConfig,
+    frameWidth,
+    left,
+    slideCount,
+    slidesToShow,
+    slideWidth,
+    top,
+    vertical,
+    wrapAround
+  } = props;
 
-    const {
-      nextButtonClassName,
-      nextButtonStyle = {},
-      nextButtonText
-    } = this.props.defaultControlsConfig;
+  const {
+    nextButtonClassName,
+    nextButtonStyle = {},
+    nextButtonText
+  } = defaultControlsConfig;
 
-    const disabled = this.nextButtonDisabled({
-      cellAlign,
-      cellSpacing,
-      currentSlide,
-      frameWidth,
-      positionValue: vertical ? top : left,
-      slideCount,
-      slidesToShow,
-      slideWidth,
-      wrapAround
-    });
+  const disabled = nextButtonDisabled({
+    cellAlign,
+    cellSpacing,
+    currentSlide,
+    frameWidth,
+    positionValue: vertical ? top : left,
+    slideCount,
+    slidesToShow,
+    slideWidth,
+    wrapAround
+  });
 
-    return (
-      <button
-        className={nextButtonClassName}
-        style={{
-          ...defaultButtonStyles(disabled),
-          ...nextButtonStyle
-        }}
-        disabled={disabled}
-        onClick={this.handleClick}
-        aria-label="next"
-        type="button"
-      >
-        {nextButtonText || 'Next'}
-      </button>
-    );
-  }
-}
+  return (
+    <button
+      className={nextButtonClassName}
+      style={{
+        ...defaultButtonStyles(disabled),
+        ...nextButtonStyle
+      }}
+      disabled={disabled}
+      onClick={handleClick}
+      aria-label="next"
+      type="button"
+    >
+      {nextButtonText || 'Next'}
+    </button>
+  );
+};
 
-export class PagingDots extends React.Component {
-  getDotIndexes(
+export const PagingDots = props => {
+  const getDotIndexes = (
     slideCount,
     slidesToScroll,
     slidesToShow,
     cellAlign,
     scrollMode
-  ) {
+  ) => {
     const dotIndexes = [];
     let lastDotIndex = slideCount - slidesToShow;
 
@@ -187,72 +172,66 @@ export class PagingDots extends React.Component {
 
     dotIndexes.push(lastDotIndex);
     return dotIndexes;
-  }
+  };
 
-  getListStyles() {
-    return {
-      position: 'relative',
-      top: -10,
-      display: 'flex',
-      margin: 0,
-      padding: 0,
-      listStyleType: 'none'
-    };
-  }
+  const getListStyles = () => ({
+    position: 'relative',
+    top: -10,
+    display: 'flex',
+    margin: 0,
+    padding: 0,
+    listStyleType: 'none'
+  });
 
-  getButtonStyles(active) {
-    return {
-      cursor: 'pointer',
-      opacity: active ? 1 : 0.5,
-      background: 'transparent',
-      border: 'none',
-      fill: 'black'
-    };
-  }
+  const getButtonStyles = active => ({
+    cursor: 'pointer',
+    opacity: active ? 1 : 0.5,
+    background: 'transparent',
+    border: 'none',
+    fill: 'black'
+  });
 
-  render() {
-    const indexes = this.getDotIndexes(
-      this.props.slideCount,
-      this.props.slidesToScroll,
-      this.props.slidesToShow,
-      this.props.cellAlign,
-      this.props.scrollMode
-    );
+  const indexes = getDotIndexes(
+    props.slideCount,
+    props.slidesToScroll,
+    props.slidesToShow,
+    props.cellAlign,
+    props.scrollMode
+  );
 
-    const {
-      pagingDotsContainerClassName,
-      pagingDotsClassName,
-      pagingDotsStyle = {}
-    } = this.props.defaultControlsConfig;
+  const {
+    pagingDotsContainerClassName,
+    pagingDotsClassName,
+    pagingDotsStyle = {}
+  } = props.defaultControlsConfig;
 
-    return (
-      <ul className={pagingDotsContainerClassName} style={this.getListStyles()}>
-        {indexes.map(index => {
-          const isActive = this.props.currentSlide === index;
+  return (
+    <ul className={pagingDotsContainerClassName} style={getListStyles()}>
+      {indexes.map(index => {
+        const isActive = props.currentSlide === index;
 
-          return (
-            <li
-              key={index}
-              className={isActive ? 'paging-item active' : 'paging-item'}
+        return (
+          <li
+            key={index}
+            className={isActive ? 'paging-item active' : 'paging-item'}
+          >
+            <button
+              className={pagingDotsClassName}
+              type="button"
+              style={{
+                ...getButtonStyles(isActive),
+                ...pagingDotsStyle
+              }}
+              onClick={props.goToSlide.bind(null, index)}
+              aria-label={`slide ${index + 1} bullet`}
             >
-              <button
-                className={pagingDotsClassName}
-                type="button"
-                style={{
-                  ...this.getButtonStyles(isActive),
-                  ...pagingDotsStyle
-                }}
-                onClick={this.props.goToSlide.bind(null, index)}
-                aria-label={`slide ${index + 1} bullet`}
-              >
-                <svg className="paging-dot" width="6" height="6">
-                  <circle cx="3" cy="3" r="3" />
-                </svg>
-              </button>
-            </li>
-          );
-        })}
-      </ul>
-    );
-  }
-}
+              <svg className="paging-dot" width="6" height="6">
+                <circle cx="3" cy="3" r="3" />
+              </svg>
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+};

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ import AnnounceSlide, {
   defaultRenderAnnounceSlideMessage
 } from './announce-slide';
 import {
+  addAccessibility,
   addEvent,
   removeEvent,
   getPropsByTransitionMode,
@@ -25,7 +26,6 @@ import {
   getTransitionProps
 } from './utilities/style-utilities';
 import {
-  addAccessibility,
   getValidChildren,
   calculateSlideHeight
 } from './utilities/bootstrapping-utilities';
@@ -122,7 +122,7 @@ export default class Carousel extends React.Component {
       this.props.keyCodeConfig
     );
     this.keyCodeMap = this.getKeyCodeMap(keyCodeConfig);
-    this.getlockScrollEvents().lockTouchScroll();
+    this.getLockScrollEvents().lockTouchScroll();
 
     const heightCheckDelay = 200;
     const initializeHeight = delay => {
@@ -233,7 +233,7 @@ export default class Carousel extends React.Component {
     for (let i = 0; i < this.timers.length; i++) {
       clearTimeout(this.timers[i]);
     }
-    this.getlockScrollEvents().unlockTouchScroll();
+    this.getLockScrollEvents().unlockTouchScroll();
   }
 
   establishChildNodesMutationObserver() {
@@ -269,7 +269,7 @@ export default class Carousel extends React.Component {
     }
   }
 
-  getlockScrollEvents() {
+  getLockScrollEvents() {
     const blockEvent = e => {
       if (this.state.dragging) {
         const direction = swipeDirection(
@@ -542,7 +542,8 @@ export default class Carousel extends React.Component {
     }
 
     const touchLength = this.touchObject.length || 0;
-
+    // touchLength must be longer than 1/5 the slideWidth / slidesToShow
+    // for swiping to be initiated
     if (touchLength > this.state.slideWidth / slidesToShow / 5) {
       if (this.touchObject.direction === 1) {
         if (

--- a/src/transitions/3d-scroll-transition.js
+++ b/src/transitions/3d-scroll-transition.js
@@ -45,8 +45,8 @@ export default class ScrollTransition3D extends React.Component {
     }
     return targetPosition + offset;
   }
-  /* eslint-enable complexity */
 
+  /* eslint-enable complexity */
   formatChildren(children) {
     const { top, left, currentSlide, slidesToShow, vertical } = this.props;
     const positionValue = vertical ? top : left;

--- a/src/transitions/fade-transition.js
+++ b/src/transitions/fade-transition.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { getSlideHeight } from '../utilities/style-utilities';
-import { handleSelfFocus } from '../utilities/utilities';
+import { handleSelfFocus, getSlideClassName } from '../utilities/utilities';
 
 export default class FadeTransition extends React.Component {
   constructor(props) {
@@ -11,21 +11,21 @@ export default class FadeTransition extends React.Component {
 
   formatChildren(children, opacity) {
     const { currentSlide, slidesToShow } = this.props;
-    return React.Children.map(children, (child, index) => {
-      const visible =
-        index >= currentSlide && index < currentSlide + slidesToShow;
-      return (
-        <li
-          className={`slider-slide${visible ? ' slide-visible' : ''}`}
-          style={this.getSlideStyles(index, opacity)}
-          key={index}
-          onClick={handleSelfFocus}
-          tabIndex={-1}
-        >
-          {child}
-        </li>
-      );
-    });
+    return React.Children.map(children, (child, index) => (
+      <li
+        className={`slider-slide${getSlideClassName(
+          index,
+          currentSlide,
+          slidesToShow
+        )}`}
+        style={this.getSlideStyles(index, opacity)}
+        key={index}
+        onClick={handleSelfFocus}
+        tabIndex={-1}
+      >
+        {child}
+      </li>
+    ));
   }
 
   getSlideOpacityAndLeftMap(fadeFrom, fadeTo, fade) {

--- a/src/transitions/scroll-transition.js
+++ b/src/transitions/scroll-transition.js
@@ -4,7 +4,11 @@ import {
   getSlideHeight,
   getAlignmentOffset
 } from '../utilities/style-utilities';
-import { getSlideDirection, handleSelfFocus } from '../utilities/utilities';
+import {
+  getSlideDirection,
+  handleSelfFocus,
+  getSlideClassName
+} from '../utilities/utilities';
 
 const MIN_ZOOM_SCALE = 0;
 const MAX_ZOOM_SCALE = 1;
@@ -101,21 +105,21 @@ export default class ScrollTransition extends React.Component {
     const { top, left, currentSlide, slidesToShow, vertical } = this.props;
     const positionValue = vertical ? top : left;
 
-    return React.Children.map(children, (child, index) => {
-      const visible =
-        index >= currentSlide && index < currentSlide + slidesToShow;
-      return (
-        <li
-          className={`slider-slide${visible ? ' slide-visible' : ''}`}
-          style={this.getSlideStyles(index, positionValue)}
-          key={index}
-          onClick={handleSelfFocus}
-          tabIndex={-1}
-        >
-          {child}
-        </li>
-      );
-    });
+    return React.Children.map(children, (child, index) => (
+      <li
+        className={`slider-slide${getSlideClassName(
+          index,
+          currentSlide,
+          slidesToShow
+        )}`}
+        style={this.getSlideStyles(index, positionValue)}
+        key={index}
+        onClick={handleSelfFocus}
+        tabIndex={-1}
+      >
+        {child}
+      </li>
+    ));
   }
 
   getSlideStyles(index, positionValue) {

--- a/src/utilities/bootstrapping-utilities.js
+++ b/src/utilities/bootstrapping-utilities.js
@@ -1,18 +1,5 @@
 import React from 'react';
 
-export const addAccessibility = (children, slidesToShow) => {
-  if (slidesToShow > 1) {
-    return React.Children.map(children, child => {
-      return React.cloneElement(child, child.props);
-    });
-  } else {
-    // when slidesToshow is 1
-    return React.Children.map(children, child => {
-      return React.cloneElement(child, child.props);
-    });
-  }
-};
-
 export const getValidChildren = children => {
   // .toArray automatically removes invalid React children
   return React.Children.toArray(children);

--- a/src/utilities/utilities.js
+++ b/src/utilities/utilities.js
@@ -55,6 +55,20 @@ export const addAccessibility = (children, slidesToShow, currentSlide) => {
   }
 };
 
+export const getSlideClassName = (index, currentSlide, slidesToShow) => {
+  let className = '';
+  const visible = index >= currentSlide && index < currentSlide + slidesToShow;
+  const current = index === currentSlide;
+
+  if (visible) {
+    className = ' slide-visible';
+    if (current) {
+      className = className.concat(' slide-current');
+    }
+  }
+  return className;
+};
+
 export const getPropsByTransitionMode = (props, keys) => {
   const { slidesToShow, transitionMode } = props;
   const updatedDefaults = {};

--- a/test/specs/default-controls.test.js
+++ b/test/specs/default-controls.test.js
@@ -1,168 +1,111 @@
-import { PagingDots, NextButton } from '../../src/default-controls';
+import { getDotIndexes, nextButtonDisabled } from '../../src/default-controls';
 
-describe('<PagingDots />', () => {
-  describe('#getDotIndexes', () => {
-    let instance;
+describe('getDotIndexes', () => {
+  it('should return valid array of paging dot indexes when cellAlign = `left`', () => {
+    // testing smaller number of pages
+    expect(getDotIndexes(6, 1, 1, 'left')).toEqual([0, 1, 2, 3, 4, 5]);
+    expect(getDotIndexes(6, 2, 1, 'left')).toEqual([0, 2, 4, 5]);
+    expect(getDotIndexes(6, 2, 2, 'left')).toEqual([0, 2, 4]);
+    expect(getDotIndexes(6, 3, 5, 'left')).toEqual([0, 1]);
+    expect(getDotIndexes(6, 1, 3, 'left')).toEqual([0, 1, 2, 3]);
 
-    beforeEach(async () => {
-      const wrapper = mount(
-        <PagingDots defaultControlsConfig={{}} goToSlide={() => null} />
-      );
-      instance = wrapper.instance();
-    });
+    // testing extreme scenarios on number of pages
+    expect(getDotIndexes(11, 5, 3, 'left')).toEqual([0, 5, 8]);
+    expect(getDotIndexes(11, 2, 7, 'left')).toEqual([0, 2, 4]);
 
-    it('should return valid array of paging dot indexes when cellAlign = `left`', () => {
-      // testing smaller number of pages
-      expect(instance.getDotIndexes(6, 1, 1, 'left')).toEqual([
-        0,
-        1,
-        2,
-        3,
-        4,
-        5
-      ]);
-      expect(instance.getDotIndexes(6, 2, 1, 'left')).toEqual([0, 2, 4, 5]);
-      expect(instance.getDotIndexes(6, 2, 2, 'left')).toEqual([0, 2, 4]);
-      expect(instance.getDotIndexes(6, 3, 5, 'left')).toEqual([0, 1]);
-      expect(instance.getDotIndexes(6, 1, 3, 'left')).toEqual([0, 1, 2, 3]);
+    // testing edge case scenarios
+    expect(getDotIndexes(5, 2, 6, 'left')).toEqual([0]);
+    expect(getDotIndexes(5, 6, 2, 'left')).toEqual([0, 3]);
+    expect(getDotIndexes(5, 5, 5, 'left')).toEqual([0]);
+  });
 
-      // testing extreme scenarios on number of pages
-      expect(instance.getDotIndexes(11, 5, 3, 'left')).toEqual([0, 5, 8]);
-      expect(instance.getDotIndexes(11, 2, 7, 'left')).toEqual([0, 2, 4]);
+  it('should return valid array of paging dot indexes when cellAlign = `center` || `right`', () => {
+    // testing smaller number of pages when cellAlign = `center`
+    expect(getDotIndexes(6, 2, 2, 'center')).toEqual([0, 2, 4, 5]);
+    expect(getDotIndexes(6, 3, 5, 'center')).toEqual([0, 3, 5]);
+    expect(getDotIndexes(6, 1, 3, 'center')).toEqual([0, 1, 2, 3, 4, 5]);
 
-      // testing edge case scenarios
-      expect(instance.getDotIndexes(5, 2, 6, 'left')).toEqual([0]);
-      expect(instance.getDotIndexes(5, 6, 2, 'left')).toEqual([0, 3]);
-      expect(instance.getDotIndexes(5, 5, 5, 'left')).toEqual([0]);
-    });
+    // testing smaller number of pages cellAlign = `right`
+    expect(getDotIndexes(6, 2, 2, 'right')).toEqual([0, 2, 4, 5]);
+    expect(getDotIndexes(6, 3, 5, 'right')).toEqual([0, 3, 5]);
+    expect(getDotIndexes(6, 1, 3, 'right')).toEqual([0, 1, 2, 3, 4, 5]);
 
-    it('should return valid array of paging dot indexes when cellAlign = `center` || `right`', () => {
-      // testing smaller number of pages when cellAlign = `center`
-      expect(instance.getDotIndexes(6, 2, 2, 'center')).toEqual([0, 2, 4, 5]);
-      expect(instance.getDotIndexes(6, 3, 5, 'center')).toEqual([0, 3, 5]);
-      expect(instance.getDotIndexes(6, 1, 3, 'center')).toEqual([
-        0,
-        1,
-        2,
-        3,
-        4,
-        5
-      ]);
+    // testing extreme scenarios on number of pages when cellAlign = `center`
+    expect(getDotIndexes(11, 5, 3, 'center')).toEqual([0, 5, 10]);
+    expect(getDotIndexes(11, 2, 7, 'center')).toEqual([0, 2, 4, 6, 8, 10]);
 
-      // testing smaller number of pages cellAlign = `right`
-      expect(instance.getDotIndexes(6, 2, 2, 'right')).toEqual([0, 2, 4, 5]);
-      expect(instance.getDotIndexes(6, 3, 5, 'right')).toEqual([0, 3, 5]);
-      expect(instance.getDotIndexes(6, 1, 3, 'right')).toEqual([
-        0,
-        1,
-        2,
-        3,
-        4,
-        5
-      ]);
+    // testing extreme scenarios on number of pages when cellAlign = `right`
+    expect(getDotIndexes(11, 5, 3, 'right')).toEqual([0, 5, 10]);
+    expect(getDotIndexes(11, 2, 7, 'right')).toEqual([0, 2, 4, 6, 8, 10]);
 
-      // testing extreme scenarios on number of pages when cellAlign = `center`
-      expect(instance.getDotIndexes(11, 5, 3, 'center')).toEqual([0, 5, 10]);
-      expect(instance.getDotIndexes(11, 2, 7, 'center')).toEqual([
-        0,
-        2,
-        4,
-        6,
-        8,
-        10
-      ]);
+    // testing edge case scenarios when cellAlign = `center`
+    expect(getDotIndexes(5, 2, 6, 'center')).toEqual([0, 2, 4]);
+    expect(getDotIndexes(5, 6, 2, 'center')).toEqual([0, 4]);
+    expect(getDotIndexes(5, 5, 5, 'center')).toEqual([0, 4]);
 
-      // testing extreme scenarios on number of pages when cellAlign = `right`
-      expect(instance.getDotIndexes(11, 5, 3, 'right')).toEqual([0, 5, 10]);
-      expect(instance.getDotIndexes(11, 2, 7, 'right')).toEqual([
-        0,
-        2,
-        4,
-        6,
-        8,
-        10
-      ]);
+    // testing edge case scenarios when cellAlign = `right`
+    expect(getDotIndexes(5, 2, 6, 'right')).toEqual([0, 2, 4]);
+    expect(getDotIndexes(5, 6, 2, 'right')).toEqual([0, 4]);
+    expect(getDotIndexes(5, 5, 5, 'right')).toEqual([0, 4]);
 
-      // testing edge case scenarios when cellAlign = `center`
-      expect(instance.getDotIndexes(5, 2, 6, 'center')).toEqual([0, 2, 4]);
-      expect(instance.getDotIndexes(5, 6, 2, 'center')).toEqual([0, 4]);
-      expect(instance.getDotIndexes(5, 5, 5, 'center')).toEqual([0, 4]);
-
-      // testing edge case scenarios when cellAlign = `right`
-      expect(instance.getDotIndexes(5, 2, 6, 'right')).toEqual([0, 2, 4]);
-      expect(instance.getDotIndexes(5, 6, 2, 'right')).toEqual([0, 4]);
-      expect(instance.getDotIndexes(5, 5, 5, 'right')).toEqual([0, 4]);
-
-      // testing if `center` and `right` cellAlign is disabled when slidesToScroll === 1
-      expect(instance.getDotIndexes(6, 2, 1, 'center')).toEqual([0, 2, 4, 5]);
-      expect(instance.getDotIndexes(6, 2, 1, 'right')).toEqual([0, 2, 4, 5]);
-    });
+    // testing if `center` and `right` cellAlign is disabled when slidesToScroll === 1
+    expect(getDotIndexes(6, 2, 1, 'center')).toEqual([0, 2, 4, 5]);
+    expect(getDotIndexes(6, 2, 1, 'right')).toEqual([0, 2, 4, 5]);
   });
 });
 
-describe('<NextButton />', () => {
-  describe('nextButtonDisabled', () => {
-    const defaultParams = {
-      wrapAround: false,
-      cellAlign: 'left',
-      cellSpacing: 0,
-      currentSlide: 0,
-      frameWidth: 100,
-      slideCount: 6,
-      slidesToShow: 1,
-      slideWidth: 100,
-      positionValue: 0
+describe('nextButtonDisabled', () => {
+  const defaultParams = {
+    wrapAround: false,
+    cellAlign: 'left',
+    cellSpacing: 0,
+    currentSlide: 0,
+    frameWidth: 100,
+    slideCount: 6,
+    slidesToShow: 1,
+    slideWidth: 100,
+    positionValue: 0
+  };
+
+  it('should return false when wrapAround is true', () => {
+    const disabled = nextButtonDisabled({
+      ...defaultParams,
+      wrapAround: true
+    });
+
+    expect(disabled).toBe(false);
+  });
+
+  it('should return false on first slide of 2 or more slides', () => {
+    const params = {
+      ...defaultParams
     };
 
-    let instance;
+    const disabled = nextButtonDisabled(params);
+    expect(disabled).toBe(false);
+  });
 
-    beforeEach(async () => {
-      const wrapper = mount(
-        <NextButton defaultControlsConfig={{}} buttonDisable={() => null} />
-      );
-      instance = wrapper.instance();
-    });
+  it('should return false on second to last slide', () => {
+    const slideIndex = 4;
+    const params = {
+      ...defaultParams,
+      currentSlide: slideIndex,
+      positionValue: -defaultParams.slideWidth * slideIndex
+    };
 
-    it('should return false when wrapAround is true', () => {
-      const disabled = instance.nextButtonDisabled({
-        ...defaultParams,
-        wrapAround: true
-      });
+    const disabled = nextButtonDisabled(params);
+    expect(disabled).toBe(false);
+  });
 
-      expect(disabled).toBe(false);
-    });
+  it('should return true on last slide', () => {
+    const slideIndex = 5;
+    const params = {
+      ...defaultParams,
+      currentSlide: slideIndex,
+      positionValue: -defaultParams.slideWidth * slideIndex
+    };
 
-    it('should return false on first slide of 2 or more slides', () => {
-      const params = {
-        ...defaultParams
-      };
-
-      const disabled = instance.nextButtonDisabled(params);
-      expect(disabled).toBe(false);
-    });
-
-    it('should return false on second to last slide', () => {
-      const slideIndex = 4;
-      const params = {
-        ...defaultParams,
-        currentSlide: slideIndex,
-        positionValue: -defaultParams.slideWidth * slideIndex
-      };
-
-      const disabled = instance.nextButtonDisabled(params);
-      expect(disabled).toBe(false);
-    });
-
-    it('should return true on last slide', () => {
-      const slideIndex = 5;
-      const params = {
-        ...defaultParams,
-        currentSlide: slideIndex,
-        positionValue: -defaultParams.slideWidth * slideIndex
-      };
-
-      const disabled = instance.nextButtonDisabled(params);
-      expect(disabled).toBe(true);
-    });
+    const disabled = nextButtonDisabled(params);
+    expect(disabled).toBe(true);
   });
 });


### PR DESCRIPTION
### Description

This PR adds a `slide-current` class to the currentSlide based on the child slide index. 

Fixes #691 

#### Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### How Has This Been Tested?

All existing tests pass

### Checklist: (Feel free to delete this section upon completion)

- [x] My code follows the style guidelines of this project (I have run `yarn lint`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
