### PR TITLE
Autopause after user controls the carousel manually

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,13 +83,13 @@
     "lint-dts": "tslint index.d.ts --format verbose",
     "lint-fix": "npm run lint-js -- --fix && npm run lint-dts -- --fix",
     "lint-js": "eslint .",
+    "prepare": "npm run build",
     "prettier": "prettier \"**/*.{js,json,ts,css,md}\"",
     "preversion": "npm run check",
     "start": "webpack-dev-server --mode development",
     "test": "jest test --config jest.unit.config.js",
     "test-e2e": "jest test --config jest.e2e.config.js",
-    "version": "npm run build",
-    "prepare": "npm run build"
+    "version": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
     "start": "webpack-dev-server --mode development",
     "test": "jest test --config jest.unit.config.js",
     "test-e2e": "jest test --config jest.e2e.config.js",
-    "version": "npm run build"
+    "version": "npm run build",
+    "prepare": "npm run build-dist"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "test": "jest test --config jest.unit.config.js",
     "test-e2e": "jest test --config jest.e2e.config.js",
     "version": "npm run build",
-    "prepare": "npm run build-dist"
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -553,12 +553,14 @@ export default class Carousel extends React.Component {
         ) {
           this.setState({ easing: easing[this.props.edgeEasing] });
         } else {
+          this.pauseAutoplay();
           this.nextSlide();
         }
       } else if (this.touchObject.direction === -1) {
         if (this.state.currentSlide <= 0 && !this.props.wrapAround) {
           this.setState({ easing: easing[this.props.edgeEasing] });
         } else {
+          this.pauseAutoplay();
           this.previousSlide();
         }
       }
@@ -584,15 +586,19 @@ export default class Carousel extends React.Component {
       const actionName = this.keyCodeMap[e.keyCode];
       switch (actionName) {
         case 'nextSlide':
+          this.pauseAutoplay();
           this.nextSlide();
           break;
         case 'previousSlide':
+          this.pauseAutoplay();
           this.previousSlide();
           break;
         case 'firstSlide':
+          this.pauseAutoplay();
           this.goToSlide(0, this.props);
           break;
         case 'lastSlide':
+          this.pauseAutoplay();
           this.goToSlide(this.state.slideCount - 1, this.props);
           break;
         case 'pause':
@@ -1063,10 +1069,19 @@ export default class Carousel extends React.Component {
             currentSlide: this.state.currentSlide,
             defaultControlsConfig: this.props.defaultControlsConfig,
             frameWidth: this.state.frameWidth,
-            goToSlide: index => this.goToSlide(index),
+            goToSlide: index => {
+              this.pauseAutoplay();
+              this.goToSlide(index);
+            },
             left: this.state.left,
-            nextSlide: () => this.nextSlide(),
-            previousSlide: () => this.previousSlide(),
+            nextSlide: () => {
+              this.pauseAutoplay();
+              this.nextSlide();
+            },
+            previousSlide: () => {
+              this.pauseAutoplay();
+              this.previousSlide();
+            },
             scrollMode: this.props.scrollMode,
             slideCount: this.state.slideCount,
             slidesToScroll: this.state.slidesToScroll,


### PR DESCRIPTION
### Description

currently after I click a control to manually go to a specific slide in the carousel, autoplay kicks in and takes me to the next slide. this changes that behavior so that autoplay is paused after controlling the slide manually.

additionally, this adds a `prepare` script, so that `npm build` is run when people `npm install` the package from a git fork. this makes it easier to use git forks.

Fixes #499

#### Type of Change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist: (Feel free to delete this section upon completion)

- [x] My code follows the style guidelines of this project (I have run `yarn lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] For any breaking API changes, I have updated the type definitions in [`index.d.ts`](../index.d.ts)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
