### PR TITLE
Fix Issue 709: Carousel Collapses with wrapAround=true, slidesToShow=2, heightMode=current

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -137,7 +137,7 @@ export default function App() {
           <button
             onClick={() => setWrapAround(prevWrapAround => !prevWrapAround)}
           >
-            Toggle Wrap Around
+            Toggle Wrap Around: {wrapAround.toString()}
           </button>
           <button onClick={() => setAutoplay(prevAutoPlay => !prevAutoPlay)}>
             Toggle Autoplay {autoplay === true ? 'Off' : 'On'}
@@ -189,7 +189,7 @@ export default function App() {
                     )
                   }
                 >
-                  Toggle Height Mode Current
+                  Toggle Height Mode: {heightMode}
                 </button>
                 <button
                   onClick={() =>
@@ -229,6 +229,15 @@ export default function App() {
                 }}
               >
                 Toggle SlidesToScroll {slidesToScroll === 1 ? 2 : 1}
+              </button>
+              <button
+                onClick={() => {
+                  setSlidesToShow(prevSlidesToShow =>
+                    prevSlidesToShow >= 3.0 ? 1.0 : prevSlidesToShow + 0.25
+                  );
+                }}
+              >
+                Increase Slides to Show: {slidesToShow}
               </button>
             </div>
           </>

--- a/index.d.ts
+++ b/index.d.ts
@@ -358,13 +358,13 @@ export interface CarouselProps {
    * Manually set the index of the slide to be shown
    */
   slideIndex?: number;
-  
-  /** 
-   * While using prop animation = "zoom", you can 
+
+  /**
+   * While using prop animation = "zoom", you can
    * configure space around current slide with slideOffset.
    */
-  slideOffset?: number; 
-  
+  slideOffset?: number;
+
   /**
    * Slides to scroll at once. Set to "auto"
    * to always scroll the current number of visible slides
@@ -426,10 +426,10 @@ export interface CarouselProps {
    * @default false
    */
   withoutControls?: boolean;
-  
+
   /**
-   * Adds a number value to set the scale of zoom when animation === "zoom". 
-   * The number value should be set in a range of (0,1). 
+   * Adds a number value to set the scale of zoom when animation === "zoom".
+   * The number value should be set in a range of (0,1).
    * @default 0.85
    */
   zoomScale?: number;

--- a/src/utilities/bootstrapping-utilities.js
+++ b/src/utilities/bootstrapping-utilities.js
@@ -60,6 +60,17 @@ export const findMaxHeightSlideInRange = (slides, start, end) => {
   return maxHeight;
 };
 
+const ensureIndexInBounds = (index, slideCount) => {
+  let newIndex = index;
+  while (newIndex < 0) {
+    newIndex += slideCount;
+  }
+  while (newIndex > slideCount) {
+    newIndex -= slideCount;
+  }
+  return newIndex;
+};
+
 export const findCurrentHeightSlide = (
   currentSlide,
   slidesToShow,
@@ -88,22 +99,20 @@ export const findCurrentHeightSlide = (
         lastIndex = currentSlide + 1;
         break;
       case 'left':
-        startIndex = Math.floor(currentSlide + offset);
+        startIndex = currentSlide;
         lastIndex = Math.ceil(currentSlide + offset) + 1;
         break;
     }
 
     // inclusive
-    startIndex =
-      wrapAround && startIndex < 0
-        ? slides.length + startIndex
-        : Math.max(startIndex, 0);
+    startIndex = wrapAround
+      ? ensureIndexInBounds(startIndex, slides.length)
+      : Math.max(startIndex, 0);
 
     // exclusive
-    lastIndex =
-      wrapAround && lastIndex > slides.length
-        ? lastIndex - slides.length
-        : Math.min(lastIndex, slides.length);
+    lastIndex = wrapAround
+      ? ensureIndexInBounds(lastIndex, slides.length)
+      : Math.min(lastIndex, slides.length);
 
     return findMaxHeightSlideInRange(slides, startIndex, lastIndex);
   } else {

--- a/test/specs/bootstrapping-utilities.test.js
+++ b/test/specs/bootstrapping-utilities.test.js
@@ -110,6 +110,9 @@ describe('Bootstrapping Utilties', () => {
       // wrapAround = true
       const wrapHeight = findCurrentHeightSlide(4, 1.25, 'left', true, slides);
       expect(wrapHeight).toBe(500);
+
+      const wrapHeight2 = findCurrentHeightSlide(4, 4, 'left', true, slides);
+      expect(wrapHeight2).toBe(800);
     });
 
     describe('aligned center', () => {


### PR DESCRIPTION
### Description

* Add test and fix for https://github.com/FormidableLabs/nuka-carousel/issues/709. Carousel Collapses with wrapAround=true, slidesToShow=2, heightMode=current
* Fix linting whitespace issues in typescript files.
* Update demo to allow showing the problem by setting slidesToShow. Add current values for heightMode and wrapAround in the demo buttons to make it clearer what is currently selected.

For context, my motiviation for this fix is that we have a 2.5 slide carousel that may contain images inserted by a third party. I chose the `current` heightMode since I don't think I can rely on them always giving correct dimensioned images, but the carousel collapsed to zero height. As a workaround, we're currently using `max` until this is resolved.

Fixes #709

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Reproduction Steps:
```
slidesToShow={2}
wrapAround={true}
heightMode="current"
```
Click the left arrow to show (length - 1 and 0 indexed slides). The carousel disappears.

* I've included a unit test that shows the problem. Before the changes, it shows that the height is calculated as zero. After the changes, the correct slide height is returned.
* I tested the fix in the demo application. After adding the ability to modify slidesToShow, I verified the issue existed before my change and didn't exist after my change.

I would appreciate any suggestions for other test cases if these are not deemed sufficient. Thanks!