### PR TITLE
Add Carousel.opacityScale to the type definitions, fixes #726

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -290,6 +290,12 @@ export interface CarouselProps {
   onResize?: () => void;
 
   /**
+   * Adds a number value to set the scale of the opacity for the 'scroll3d' transition mode.
+   * @default 0.65
+   */
+  opacityScale?: number;
+
+  /**
    * Pause autoPlay when mouse is over carousel
    * @default true
    */


### PR DESCRIPTION
### Description

This adds `opacityScale` to the TypeScript definitions.

Fixes #726 

#### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

N/A since this is an additive, non-breaking type definition change.