### PR TITLE
Fixed defintions from Component to FC.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -500,13 +500,13 @@ export interface CarouselState {
 }
 
 export interface PreviousButtonProps extends CarouselSlideRenderControlProps {}
-export class PreviousButton extends React.Component<PreviousButtonProps> {}
+export class PreviousButton extends React.FunctionalComponent<PreviousButtonProps> {}
 
 export interface NextButtonProps extends CarouselSlideRenderControlProps {}
-export class NextButton extends React.Component<NextButtonProps> {}
+export class NextButton extends React.FunctionalComponent<NextButtonProps> {}
 
 export interface PagingDotsProps extends CarouselSlideRenderControlProps {}
-export class PagingDots extends React.Component<PagingDotsProps> {
+export class PagingDots extends React.FunctionalComponent<PagingDotsProps> {
   public getButtonStyles(active: boolean): React.CSSProperties;
   public getListStyles(): React.CSSProperties;
   public getDotIndexes(


### PR DESCRIPTION
### Description

Changed the type definition of `PreviousButton`, `NextButton`, and `PagingDots` from `React.Component` to `React.FuncitonalComponent`. I went with FuncitonalComponent over FC because this is open source and I wanted to make sure people knew what the definition stood for.

Fixes #697 

#### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

`yarn lint` was run with no errors.
