### PR TITLE
Update onDragStart type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -282,7 +282,7 @@ export interface CarouselProps {
   /**
    * optional callback function
    */
-  onDragStart?: () => void;
+  onDragStart?: (e?: Event) => void;
 
   /**
    * Window onResize callback


### PR DESCRIPTION

### Description

onDragStart is treated as an [event handler](https://github.com/FormidableLabs/nuka-carousel/blob/333237c0cb852b25b23375400af2751de9e95d10/src/index.js#L353), but its type did not reflect that.

#### Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I have an event handler being coerced to any to pass type validation.
```
  onDragStart={handleDrag as any}
```
When the `as any` is removed, this throws a type error:
```
No overload matches this call.
  Overload 1 of 2, '(props: Readonly<CarouselProps>): Carousel', gave the following error.
    Type '(event: MouseEvent | TouchEvent) => void' is not assignable to type '() => void'.
  Overload 2 of 2, '(props: CarouselProps, context?: any): Carousel', gave the following error.
    Type '(event: MouseEvent | TouchEvent) => void' is not assignable to type '() => void'.ts(2769)
```
Updating the index.d.ts with this change removes that error.

### Checklist: (Feel free to delete this section upon completion)

- [ ] My code follows the style guidelines of this project (I have run `yarn lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] For any breaking API changes, I have updated the type definitions in [`index.d.ts`](../index.d.ts)
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
