### PR TITLE
Bugfix/720 showpartial breaks the navigation dots

### DIFF
--- a/src/default-controls.js
+++ b/src/default-controls.js
@@ -144,6 +144,7 @@ export const getDotIndexes = (
 ) => {
   const dotIndexes = [];
   let lastDotIndex = slideCount - slidesToShow;
+  const slidesToShowIsDecimal = slidesToShow % 1 !== 0;
 
   switch (cellAlign) {
     case 'center':
@@ -152,7 +153,7 @@ export const getDotIndexes = (
       break;
   }
   // the below condition includes the last index if slidesToShow is decimal
-  if (cellAlign === 'left' && slidesToShow % 1 !== 0) {
+  if (cellAlign === 'left' && slidesToShowIsDecimal) {
     lastDotIndex += slidesToShow - 1;
   }
 
@@ -165,7 +166,7 @@ export const getDotIndexes = (
   }
 
   // the below condition includes the last index if slidesToShow is not decimal and cellAlign = left and mode = page
-  if (cellAlign === 'left' && scrollMode === 'page' && slidesToShow % 1 === 0) {
+  if (cellAlign === 'left' && scrollMode === 'page' && !slidesToShowIsDecimal) {
     lastDotIndex = slideCount - (slideCount % slidesToShow || slidesToShow);
   }
 

--- a/src/default-controls.js
+++ b/src/default-controls.js
@@ -163,8 +163,8 @@ export const getDotIndexes = (
     dotIndexes.push(i);
   }
 
-  if (cellAlign === 'left' && scrollMode === 'page') {
-    lastDotIndex = slideCount - (slideCount % Math.round(slidesToShow) || Math.round(slidesToShow))
+  if (cellAlign === 'left' && scrollMode === 'page' && slidesToShow % 1 == 0) {
+    lastDotIndex = slideCount - (slideCount % slidesToShow || slidesToShow)
   }
 
   dotIndexes.push(lastDotIndex);
@@ -196,7 +196,6 @@ export const PagingDots = (props) => {
     props.cellAlign,
     props.scrollMode
   );
-
   const {
     pagingDotsContainerClassName,
     pagingDotsClassName,

--- a/src/default-controls.js
+++ b/src/default-controls.js
@@ -151,6 +151,9 @@ export const getDotIndexes = (
       lastDotIndex += slidesToShow - 1;
       break;
   }
+  if(cellAlign == 'left' && slidesToShow % 1 !== 0 ){
+    lastDotIndex += slidesToShow - 1;
+  }
 
   if (lastDotIndex < 0) {
     return [0];
@@ -161,9 +164,7 @@ export const getDotIndexes = (
   }
 
   if (cellAlign === 'left' && scrollMode === 'page') {
-    lastDotIndex = Math.floor(
-      slideCount - (slideCount % slidesToShow || slidesToShow)
-    );
+    lastDotIndex = slideCount - (slideCount % Math.round(slidesToShow) || Math.round(slidesToShow))
   }
 
   dotIndexes.push(lastDotIndex);
@@ -201,12 +202,13 @@ export const PagingDots = (props) => {
     pagingDotsClassName,
     pagingDotsStyle = {}
   } = props.defaultControlsConfig;
-
   return (
     <ul className={pagingDotsContainerClassName} style={getListStyles()}>
-      {indexes.map((index) => {
-        const isActive = props.currentSlide === index;
-
+      {indexes.map((index , i) => {
+        let isActive = props.currentSlide === index
+        if(props.currentSlide < index && props.currentSlide > indexes[i-1]){
+          isActive = true
+        }
         return (
           <li
             key={index}

--- a/src/default-controls.js
+++ b/src/default-controls.js
@@ -151,6 +151,7 @@ export const getDotIndexes = (
       lastDotIndex += slidesToShow - 1;
       break;
   }
+  // the below condition includes the last index if slidesToShow is decimal
   if (cellAlign === 'left' && slidesToShow % 1 !== 0) {
     lastDotIndex += slidesToShow - 1;
   }
@@ -163,6 +164,7 @@ export const getDotIndexes = (
     dotIndexes.push(i);
   }
 
+  // the below condition includes the last index if slidesToShow is not decimal and cellAlign = left and mode = page
   if (cellAlign === 'left' && scrollMode === 'page' && slidesToShow % 1 === 0) {
     lastDotIndex = slideCount - (slideCount % slidesToShow || slidesToShow);
   }
@@ -205,6 +207,7 @@ export const PagingDots = (props) => {
     <ul className={pagingDotsContainerClassName} style={getListStyles()}>
       {indexes.map((index, i) => {
         let isActive = props.currentSlide === index;
+        // the below condition checks and sets navigation dots active if the current slide falls in the current index range
         if (props.currentSlide < index && props.currentSlide > indexes[i - 1]) {
           isActive = true;
         }

--- a/src/default-controls.js
+++ b/src/default-controls.js
@@ -151,7 +151,7 @@ export const getDotIndexes = (
       lastDotIndex += slidesToShow - 1;
       break;
   }
-  if(cellAlign == 'left' && slidesToShow % 1 !== 0 ){
+  if (cellAlign === 'left' && slidesToShow % 1 !== 0) {
     lastDotIndex += slidesToShow - 1;
   }
 
@@ -163,8 +163,8 @@ export const getDotIndexes = (
     dotIndexes.push(i);
   }
 
-  if (cellAlign === 'left' && scrollMode === 'page' && slidesToShow % 1 == 0) {
-    lastDotIndex = slideCount - (slideCount % slidesToShow || slidesToShow)
+  if (cellAlign === 'left' && scrollMode === 'page' && slidesToShow % 1 === 0) {
+    lastDotIndex = slideCount - (slideCount % slidesToShow || slidesToShow);
   }
 
   dotIndexes.push(lastDotIndex);
@@ -203,10 +203,10 @@ export const PagingDots = (props) => {
   } = props.defaultControlsConfig;
   return (
     <ul className={pagingDotsContainerClassName} style={getListStyles()}>
-      {indexes.map((index , i) => {
-        let isActive = props.currentSlide === index
-        if(props.currentSlide < index && props.currentSlide > indexes[i-1]){
-          isActive = true
+      {indexes.map((index, i) => {
+        let isActive = props.currentSlide === index;
+        if (props.currentSlide < index && props.currentSlide > indexes[i - 1]) {
+          isActive = true;
         }
         return (
           <li

--- a/test/specs/default-controls.test.js
+++ b/test/specs/default-controls.test.js
@@ -88,7 +88,7 @@ describe('getDotIndexes', () => {
     expect(getDotIndexes(6, 2, 1, 'right')).toEqual([0, 2, 4, 5]);
   });
 
-  it('should return valid array of paging dot indexes when cellAlign = `center` || `right` and scrolMode=page', () => {
+  it('should return valid array of paging dot indexes when cellAlign = `center` || `right` and scrollMode=page', () => {
     // testing smaller number of pages when cellAlign = `center`
     expect(getDotIndexes(6, 2, 2, 'center', 'page')).toEqual([0, 2, 4, 5]);
     expect(getDotIndexes(6, 3, 5, 'center', 'page')).toEqual([0, 3, 5]);

--- a/test/specs/default-controls.test.js
+++ b/test/specs/default-controls.test.js
@@ -1,13 +1,37 @@
 import { getDotIndexes, nextButtonDisabled } from '../../src/default-controls';
 
 describe('getDotIndexes', () => {
-  it('should return valid array of paging dot indexes when cellAlign = `left`', () => {
+  it('should return valid array of paging dot indexes when cellAlign = `left` and scrollMode = `page`', () => {
+    // testing smaller number of pages
+    expect(getDotIndexes(6, 1, 1, 'left', 'page')).toEqual([0, 1, 2, 3, 4, 5]);
+    expect(getDotIndexes(6, 2, 1, 'left', 'page')).toEqual([0, 2, 4, 5]);
+    expect(getDotIndexes(6, 2, 2, 'left', 'page')).toEqual([0, 2, 4]);
+    expect(getDotIndexes(6, 2, 1.5, 'left', 'page')).toEqual([0, 2, 4, 5]);
+    expect(getDotIndexes(6, 1, 1.5, 'left', 'page')).toEqual([0, 1, 2, 3, 4, 5]);
+    expect(getDotIndexes(6, 3, 5, 'left', 'page')).toEqual([0, 5]);
+    expect(getDotIndexes(6, 1, 3, 'left', 'page')).toEqual([0, 1, 2, 3]);
+    expect(getDotIndexes(6, 5, 3, 'left', 'page')).toEqual([0, 3]);
+
+    // testing extreme scenarios on number of pages
+    expect(getDotIndexes(11, 5, 3, 'left', 'page')).toEqual([0, 5, 9]);
+    expect(getDotIndexes(11, 2, 7, 'left', 'page')).toEqual([0, 2, 7]);
+
+    // testing edge case scenarios
+    expect(getDotIndexes(5, 2, 6, 'left', 'page')).toEqual([0]);
+    expect(getDotIndexes(5, 6, 2, 'left', 'page')).toEqual([0, 4]);
+    expect(getDotIndexes(5, 5, 5, 'left', 'page')).toEqual([0]);
+  });
+
+  it('should return valid array of paging dot indexes when cellAlign = `left` and mode is remainder(default)', () => {
     // testing smaller number of pages
     expect(getDotIndexes(6, 1, 1, 'left')).toEqual([0, 1, 2, 3, 4, 5]);
     expect(getDotIndexes(6, 2, 1, 'left')).toEqual([0, 2, 4, 5]);
     expect(getDotIndexes(6, 2, 2, 'left')).toEqual([0, 2, 4]);
     expect(getDotIndexes(6, 3, 5, 'left')).toEqual([0, 1]);
     expect(getDotIndexes(6, 1, 3, 'left')).toEqual([0, 1, 2, 3]);
+    expect(getDotIndexes(6, 2, 1.5, 'left')).toEqual([0, 2, 4, 5]);
+    expect(getDotIndexes(6, 1, 1.5, 'left')).toEqual([0, 1, 2, 3, 4, 5]);
+    expect(getDotIndexes(6, 5, 3, 'left', 'page')).toEqual([0, 3]);
 
     // testing extreme scenarios on number of pages
     expect(getDotIndexes(11, 5, 3, 'left')).toEqual([0, 5, 8]);
@@ -24,11 +48,15 @@ describe('getDotIndexes', () => {
     expect(getDotIndexes(6, 2, 2, 'center')).toEqual([0, 2, 4, 5]);
     expect(getDotIndexes(6, 3, 5, 'center')).toEqual([0, 3, 5]);
     expect(getDotIndexes(6, 1, 3, 'center')).toEqual([0, 1, 2, 3, 4, 5]);
+    expect(getDotIndexes(6, 2, 1.5, 'center')).toEqual([0, 2, 4, 5]);
+    expect(getDotIndexes(6, 1, 1.5, 'center')).toEqual([0, 1, 2, 3, 4, 5]);
 
     // testing smaller number of pages cellAlign = `right`
     expect(getDotIndexes(6, 2, 2, 'right')).toEqual([0, 2, 4, 5]);
     expect(getDotIndexes(6, 3, 5, 'right')).toEqual([0, 3, 5]);
     expect(getDotIndexes(6, 1, 3, 'right')).toEqual([0, 1, 2, 3, 4, 5]);
+    expect(getDotIndexes(6, 2, 1.5, 'right')).toEqual([0, 2, 4, 5]);
+    expect(getDotIndexes(6, 1, 1.5, 'right')).toEqual([0, 1, 2, 3, 4, 5]);
 
     // testing extreme scenarios on number of pages when cellAlign = `center`
     expect(getDotIndexes(11, 5, 3, 'center')).toEqual([0, 5, 10]);
@@ -51,6 +79,44 @@ describe('getDotIndexes', () => {
     // testing if `center` and `right` cellAlign is disabled when slidesToScroll === 1
     expect(getDotIndexes(6, 2, 1, 'center')).toEqual([0, 2, 4, 5]);
     expect(getDotIndexes(6, 2, 1, 'right')).toEqual([0, 2, 4, 5]);
+  });
+
+  it('should return valid array of paging dot indexes when cellAlign = `center` || `right` and scrolMode=page', () => {
+    // testing smaller number of pages when cellAlign = `center`
+    expect(getDotIndexes(6, 2, 2, 'center', 'page')).toEqual([0, 2, 4, 5]);
+    expect(getDotIndexes(6, 3, 5, 'center', 'page')).toEqual([0, 3, 5]);
+    expect(getDotIndexes(6, 1, 3, 'center', 'page')).toEqual([0, 1, 2, 3, 4, 5]);
+    expect(getDotIndexes(6, 2, 1.5, 'center', 'page')).toEqual([0, 2, 4, 5]);
+    expect(getDotIndexes(6, 1, 1.5, 'center', 'page')).toEqual([0, 1, 2, 3, 4, 5]);
+
+    // testing smaller number of pages cellAlign = `right`
+    expect(getDotIndexes(6, 2, 2, 'right', 'page')).toEqual([0, 2, 4, 5]);
+    expect(getDotIndexes(6, 3, 5, 'right', 'page')).toEqual([0, 3, 5]);
+    expect(getDotIndexes(6, 1, 3, 'right', 'page')).toEqual([0, 1, 2, 3, 4, 5]);
+    expect(getDotIndexes(6, 2, 1.5, 'right', 'page')).toEqual([0, 2, 4, 5]);
+    expect(getDotIndexes(6, 1, 1.5, 'right', 'page')).toEqual([0, 1, 2, 3, 4, 5]);
+
+    // testing extreme scenarios on number of pages when cellAlign = `center`
+    expect(getDotIndexes(11, 5, 3, 'center', 'page')).toEqual([0, 5, 10]);
+    expect(getDotIndexes(11, 2, 7, 'center', 'page')).toEqual([0, 2, 4, 6, 8, 10]);
+
+    // testing extreme scenarios on number of pages when cellAlign = `right`
+    expect(getDotIndexes(11, 5, 3, 'right', 'page')).toEqual([0, 5, 10]);
+    expect(getDotIndexes(11, 2, 7, 'right', 'page')).toEqual([0, 2, 4, 6, 8, 10]);
+
+    // testing edge case scenarios when cellAlign = `center`
+    expect(getDotIndexes(5, 2, 6, 'center', 'page')).toEqual([0, 2, 4]);
+    expect(getDotIndexes(5, 6, 2, 'center', 'page')).toEqual([0, 4]);
+    expect(getDotIndexes(5, 5, 5, 'center', 'page')).toEqual([0, 4]);
+
+    // testing edge case scenarios when cellAlign = `right`
+    expect(getDotIndexes(5, 2, 6, 'right', 'page')).toEqual([0, 2, 4]);
+    expect(getDotIndexes(5, 6, 2, 'right', 'page')).toEqual([0, 4]);
+    expect(getDotIndexes(5, 5, 5, 'right', 'page')).toEqual([0, 4]);
+
+    // testing if `center` and `right` cellAlign is disabled when slidesToScroll === 1
+    expect(getDotIndexes(6, 2, 1, 'center', 'page')).toEqual([0, 2, 4, 5]);
+    expect(getDotIndexes(6, 2, 1, 'right', 'page')).toEqual([0, 2, 4, 5]);
   });
 });
 

--- a/test/specs/default-controls.test.js
+++ b/test/specs/default-controls.test.js
@@ -7,7 +7,14 @@ describe('getDotIndexes', () => {
     expect(getDotIndexes(6, 2, 1, 'left', 'page')).toEqual([0, 2, 4, 5]);
     expect(getDotIndexes(6, 2, 2, 'left', 'page')).toEqual([0, 2, 4]);
     expect(getDotIndexes(6, 2, 1.5, 'left', 'page')).toEqual([0, 2, 4, 5]);
-    expect(getDotIndexes(6, 1, 1.5, 'left', 'page')).toEqual([0, 1, 2, 3, 4, 5]);
+    expect(getDotIndexes(6, 1, 1.5, 'left', 'page')).toEqual([
+      0,
+      1,
+      2,
+      3,
+      4,
+      5
+    ]);
     expect(getDotIndexes(6, 3, 5, 'left', 'page')).toEqual([0, 5]);
     expect(getDotIndexes(6, 1, 3, 'left', 'page')).toEqual([0, 1, 2, 3]);
     expect(getDotIndexes(6, 5, 3, 'left', 'page')).toEqual([0, 3]);
@@ -31,7 +38,7 @@ describe('getDotIndexes', () => {
     expect(getDotIndexes(6, 1, 3, 'left')).toEqual([0, 1, 2, 3]);
     expect(getDotIndexes(6, 2, 1.5, 'left')).toEqual([0, 2, 4, 5]);
     expect(getDotIndexes(6, 1, 1.5, 'left')).toEqual([0, 1, 2, 3, 4, 5]);
-    expect(getDotIndexes(6, 5, 3, 'left', 'page')).toEqual([0, 3]);
+    expect(getDotIndexes(6, 5, 3, 'left')).toEqual([0, 3]);
 
     // testing extreme scenarios on number of pages
     expect(getDotIndexes(11, 5, 3, 'left')).toEqual([0, 5, 8]);
@@ -85,24 +92,59 @@ describe('getDotIndexes', () => {
     // testing smaller number of pages when cellAlign = `center`
     expect(getDotIndexes(6, 2, 2, 'center', 'page')).toEqual([0, 2, 4, 5]);
     expect(getDotIndexes(6, 3, 5, 'center', 'page')).toEqual([0, 3, 5]);
-    expect(getDotIndexes(6, 1, 3, 'center', 'page')).toEqual([0, 1, 2, 3, 4, 5]);
+    expect(getDotIndexes(6, 1, 3, 'center', 'page')).toEqual([
+      0,
+      1,
+      2,
+      3,
+      4,
+      5
+    ]);
     expect(getDotIndexes(6, 2, 1.5, 'center', 'page')).toEqual([0, 2, 4, 5]);
-    expect(getDotIndexes(6, 1, 1.5, 'center', 'page')).toEqual([0, 1, 2, 3, 4, 5]);
+    expect(getDotIndexes(6, 1, 1.5, 'center', 'page')).toEqual([
+      0,
+      1,
+      2,
+      3,
+      4,
+      5
+    ]);
 
     // testing smaller number of pages cellAlign = `right`
     expect(getDotIndexes(6, 2, 2, 'right', 'page')).toEqual([0, 2, 4, 5]);
     expect(getDotIndexes(6, 3, 5, 'right', 'page')).toEqual([0, 3, 5]);
     expect(getDotIndexes(6, 1, 3, 'right', 'page')).toEqual([0, 1, 2, 3, 4, 5]);
     expect(getDotIndexes(6, 2, 1.5, 'right', 'page')).toEqual([0, 2, 4, 5]);
-    expect(getDotIndexes(6, 1, 1.5, 'right', 'page')).toEqual([0, 1, 2, 3, 4, 5]);
+    expect(getDotIndexes(6, 1, 1.5, 'right', 'page')).toEqual([
+      0,
+      1,
+      2,
+      3,
+      4,
+      5
+    ]);
 
     // testing extreme scenarios on number of pages when cellAlign = `center`
     expect(getDotIndexes(11, 5, 3, 'center', 'page')).toEqual([0, 5, 10]);
-    expect(getDotIndexes(11, 2, 7, 'center', 'page')).toEqual([0, 2, 4, 6, 8, 10]);
+    expect(getDotIndexes(11, 2, 7, 'center', 'page')).toEqual([
+      0,
+      2,
+      4,
+      6,
+      8,
+      10
+    ]);
 
     // testing extreme scenarios on number of pages when cellAlign = `right`
     expect(getDotIndexes(11, 5, 3, 'right', 'page')).toEqual([0, 5, 10]);
-    expect(getDotIndexes(11, 2, 7, 'right', 'page')).toEqual([0, 2, 4, 6, 8, 10]);
+    expect(getDotIndexes(11, 2, 7, 'right', 'page')).toEqual([
+      0,
+      2,
+      4,
+      6,
+      8,
+      10
+    ]);
 
     // testing edge case scenarios when cellAlign = `center`
     expect(getDotIndexes(5, 2, 6, 'center', 'page')).toEqual([0, 2, 4]);


### PR DESCRIPTION
### Description

This is a bugfix for issue 720.The navigation dots of the last slide was not being set to active in some of the cases when scrollMode is(page/remainder) with cell align (center/left/right) . The same issue existed while scrolling backwards after reaching the last slide.

Fixes # (issue)

#### Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Manual testing along with unit test cases for all combinations

### Checklist: (Feel free to delete this section upon completion)

- [X] My code follows the style guidelines of this project (I have run `yarn lint`)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] For any breaking API changes, I have updated the type definitions in [`index.d.ts`](../index.d.ts)
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
