### PR TITLE
fix PreviousButton, NextButton and PagingDots definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -500,19 +500,10 @@ export interface CarouselState {
 }
 
 export interface PreviousButtonProps extends CarouselSlideRenderControlProps {}
-export class PreviousButton extends React.FunctionalComponent<PreviousButtonProps> {}
+export const PreviousButton: React.FC<PreviousButtonProps>;
 
 export interface NextButtonProps extends CarouselSlideRenderControlProps {}
-export class NextButton extends React.FunctionalComponent<NextButtonProps> {}
+export const NextButton: React.FC<NextButtonProps>;
 
 export interface PagingDotsProps extends CarouselSlideRenderControlProps {}
-export class PagingDots extends React.FunctionalComponent<PagingDotsProps> {
-  public getButtonStyles(active: boolean): React.CSSProperties;
-  public getListStyles(): React.CSSProperties;
-  public getDotIndexes(
-    slideCount: number,
-    slidesToScroll: CarouselSlidesToScrollProp,
-    slidesToShow: number,
-    cellAlign: CarouselCellAlignProp
-  ): number[];
-}
+export const PagingDots: React.FC<PagingDotsProps>;


### PR DESCRIPTION
### Description

This PR changes `React.FunctionalComponent` type definitions to `React.FC`.

The PreviousButton, NextButton and PagingDots definitions [have recently been updated](https://github.com/FormidableLabs/nuka-carousel/pull/729) from `React.Component` to `React.FunctionalComponent`. However, the PR contains a typo, as [there is no `FunctionalComponent` typing](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L543).

While I wholeheartedly agree with the reasoning behind using the full written out name, I opted to go for `React.FC` instead, just to prevent any future typos or mistakes!

Fixes #736.

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

`yarn run check` was run without errors.
