### PR TITLE
fix: update wicg-inert and puppeteer

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "exenv": "^1.2.0",
     "prop-types": "^15.6.0",
     "react-move": "^6.1.0",
-    "wicg-inert": "^3.0.3"
+    "wicg-inert": "^3.1.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.4",
@@ -40,7 +40,7 @@
     "jest-enzyme": "^7.0.2",
     "jest-puppeteer-preset": "^2.0.1",
     "prettier": "2.1.2",
-    "puppeteer": "^5.2.1",
+    "puppeteer": "^5.5.0",
     "react": "^16.9.0",
     "react-dom": "^16.0.0",
     "tslint": "^5.12.0",

--- a/test/e2e/carousel.test.js
+++ b/test/e2e/carousel.test.js
@@ -24,7 +24,7 @@ describe('Nuka Carousel', () => {
     it('should show the previous slide when the Previous button is clicked.', async () => {
       await expect(page).toClick('button', { text: 'Next' });
       await expect(page).toMatch('Nuka Carousel: Slide 2');
-      await page.waitFor(600); // need to let slide transition complete
+      await page.waitForTimeout(600); // need to let slide transition complete
       await expect(page).toClick('button', { text: 'Prev' });
       await expect(page).toMatch('Nuka Carousel: Slide 1');
     });
@@ -59,23 +59,23 @@ describe('Nuka Carousel', () => {
       });
 
       it('should navigate to the first slide from the last.', async () => {
-        await page.waitFor(600); // need to let slide transition complete
+        await page.waitForTimeout(600); // need to let slide transition complete
         await expect(page).toClick('button', { text: '9' });
         await expect(page).toMatch('Nuka Carousel: Slide 9');
-        await page.waitFor(600); // need to let slide transition complete
+        await page.waitForTimeout(600); // need to let slide transition complete
         await expect(page).toClick('button', { text: 'Next' });
         await expect(page).toMatch('Nuka Carousel: Slide 1');
       });
 
       it('should navigate to the first slide from the second with only 3 slides.', async () => {
-        await page.waitFor(600); // need to let slide transition complete
+        await page.waitForTimeout(600); // need to let slide transition complete
         await expect(page).toClick('button', {
           text: 'Toggle Show 3 Slides Only'
         });
-        await page.waitFor(600); // need to let slide transition complete
+        await page.waitForTimeout(600); // need to let slide transition complete
         await expect(page).toClick('button', { text: '3' });
         await expect(page).toMatch('Nuka Carousel: Slide 3');
-        await page.waitFor(600); // need to let slide transition complete
+        await page.waitForTimeout(600); // need to let slide transition complete
         await expect(page).toClick('button', { text: 'Next' });
         await expect(page).toMatch('Nuka Carousel: Slide 1');
       });
@@ -87,31 +87,31 @@ describe('Nuka Carousel', () => {
 
     await expect(page).toClick('button', { text: 'Next' });
     await expect(page).toMatch('Nuka Carousel: Slide 2');
-    await page.waitFor(600);
+    await page.waitForTimeout(600);
 
     await expect(page).toClick('button', { text: 'Next' });
     await expect(page).toMatch('Nuka Carousel: Slide 3');
-    await page.waitFor(600);
+    await page.waitForTimeout(600);
 
     await expect(page).toClick('button', { text: 'Next' });
     await expect(page).toMatch('Nuka Carousel: Slide 4');
-    await page.waitFor(600);
+    await page.waitForTimeout(600);
 
     await expect(page).toClick('button', { text: 'Next' });
     await expect(page).toMatch('Nuka Carousel: Slide 5');
-    await page.waitFor(600);
+    await page.waitForTimeout(600);
 
     await expect(page).toClick('button', { text: 'Next' });
     await expect(page).toMatch('Nuka Carousel: Slide 6');
-    await page.waitFor(600);
+    await page.waitForTimeout(600);
 
     await expect(page).toClick('button', { text: 'Next' });
     await expect(page).toMatch('Nuka Carousel: Slide 7');
-    await page.waitFor(600);
+    await page.waitForTimeout(600);
 
     await expect(page).toClick('button', { text: 'Next' });
     await expect(page).toMatch('Nuka Carousel: Slide 8');
-    await page.waitFor(600);
+    await page.waitForTimeout(600);
 
     await expect(page).toClick('button', { text: 'Next' });
     await expect(page).toMatch('Nuka Carousel: Slide 9');
@@ -131,7 +131,7 @@ describe('Nuka Carousel', () => {
             text: 'Toggle Partially Visible Slides'
           });
           await expect(page).toClick('button', { text: 'Left' });
-          await page.waitFor(600); // need to let slide transition complete
+          await page.waitForTimeout(600); // need to let slide transition complete
 
           await nextThroughAllSlides();
         });
@@ -141,7 +141,7 @@ describe('Nuka Carousel', () => {
             text: 'Toggle Partially Visible Slides'
           });
           await expect(page).toClick('button', { text: 'Center' });
-          await page.waitFor(600); // need to let slide transition complete
+          await page.waitForTimeout(600); // need to let slide transition complete
 
           await nextThroughAllSlides();
         });
@@ -151,7 +151,7 @@ describe('Nuka Carousel', () => {
             text: 'Toggle Partially Visible Slides'
           });
           await expect(page).toClick('button', { text: 'Right' });
-          await page.waitFor(600); // need to let slide transition complete
+          await page.waitForTimeout(600); // need to let slide transition complete
 
           await nextThroughAllSlides();
         });
@@ -168,7 +168,7 @@ describe('Nuka Carousel', () => {
       it('should set currentSlide opacity to 1 and visibility to inherit', async () => {
         const activeSlide = 3;
         await expect(page).toClick('button', { text: `${activeSlide}` });
-        await page.waitFor(600); // need to let slide transition complete
+        await page.waitForTimeout(600); // need to let slide transition complete
 
         const styles = await page.evaluate(
           getStyles,
@@ -184,7 +184,7 @@ describe('Nuka Carousel', () => {
         const activeSlide = 4;
         const slideCount = 6;
         await expect(page).toClick('button', { text: `${activeSlide}` });
-        await page.waitFor(600); // need to let slide transition complete
+        await page.waitForTimeout(600); // need to let slide transition complete
 
         for (let i = 0; i < slideCount; i++) {
           if (i !== activeSlide - 1) {
@@ -233,7 +233,7 @@ describe('Nuka Carousel', () => {
       await page.mouse.move(startX - metrics.width / 3.0, startY);
       await page.mouse.up();
       await expect(page).toMatch('Nuka Carousel: Slide 2');
-      await page.waitFor(600); // need to let slide transition complete
+      await page.waitForTimeout(600); // need to let slide transition complete
       await page.mouse.move(startX, startY);
       await page.mouse.down();
       await page.mouse.move(startX + metrics.width / 3.0, startY);
@@ -265,7 +265,7 @@ describe('Nuka Carousel', () => {
       await page.mouse.move(startX + metrics.width / 3.0, startY);
       await page.mouse.up();
       await expect(page).toMatch('Nuka Carousel: Slide 9');
-      await page.waitFor(600); // need to let slide transition complete
+      await page.waitForTimeout(600); // need to let slide transition complete
       await page.mouse.move(startX, startY);
       await page.mouse.down();
       await page.mouse.move(startX - metrics.width / 3.0, startY);
@@ -296,7 +296,7 @@ describe('Nuka Carousel', () => {
 
       await expect(page).toClick('button', { text: 'Prev' });
       await expect(page).toMatch('Nuka Carousel: Slide 9');
-      await page.waitFor(600); // need to let slide transition complete
+      await page.waitForTimeout(600); // need to let slide transition complete
       firstSlide = await page.evaluate(getStyles, `.slider-slide:first-child`, [
         'left'
       ]);
@@ -315,7 +315,7 @@ describe('Nuka Carousel', () => {
       await expect(page).toClick('button', { text: 'Toggle Wrap Around' });
       await expect(page).toClick('button', { text: 'Prev' });
       await expect(page).toMatch('Nuka Carousel: Slide 9');
-      await page.waitFor(600); // need to let slide transition complete
+      await page.waitForTimeout(600); // need to let slide transition complete
       const getComputedStyleLeft = () => {
         const e = document.querySelector('.slider-slide:last-child');
         return window.getComputedStyle(e).left;
@@ -335,10 +335,10 @@ describe('Nuka Carousel', () => {
       await expect(page).toClick('button', { text: 'Toggle Wrap Around' });
       await expect(page).toClick('button', { text: '9' });
       await expect(page).toMatch('Nuka Carousel: Slide 9');
-      await page.waitFor(600); // need to let slide transition complete
+      await page.waitForTimeout(600); // need to let slide transition complete
       await expect(page).toClick('button', { text: 'Next' });
       await expect(page).toMatch('Nuka Carousel: Slide 1');
-      await page.waitFor(600); // need to let slide transition complete
+      await page.waitForTimeout(600); // need to let slide transition complete
       const getComputedStyleLeft = () => {
         const e = document.querySelector('.slider-slide:first-child');
         return window.getComputedStyle(e).left;
@@ -358,7 +358,7 @@ describe('Nuka Carousel', () => {
       await expect(page).toClick('button', { text: 'Toggle Wrap Around' });
       await expect(page).toClick('button', { text: 'Prev' });
       await expect(page).toMatch('Nuka Carousel: Slide 9');
-      await page.waitFor(600); // need to let slide transition complete
+      await page.waitForTimeout(600); // need to let slide transition complete
       const getTextDecoration = () => {
         const e = document.querySelector('.slider-control-topcenter div');
         return window.getComputedStyle(e).textDecorationLine;
@@ -381,10 +381,10 @@ describe('Nuka Carousel', () => {
       await expect(page).toClick('button', { text: 'Toggle Wrap Around' });
       await expect(page).toClick('button', { text: '9' });
       await expect(page).toMatch('Nuka Carousel: Slide 9');
-      await page.waitFor(600); // need to let slide transition complete
+      await page.waitForTimeout(600); // need to let slide transition complete
       await expect(page).toClick('button', { text: 'Next' });
       await expect(page).toMatch('Nuka Carousel: Slide 1');
-      await page.waitFor(600); // need to let slide transition complete
+      await page.waitForTimeout(600); // need to let slide transition complete
       const getTextDecoration = () => {
         const e = document.querySelector('.slider-control-topcenter div');
         return window.getComputedStyle(e).textDecorationLine;
@@ -438,7 +438,7 @@ describe('Nuka Carousel', () => {
       expect(textDecoration).toMatch('none');
 
       await expect(page).toClick('button', { text: 'Next' });
-      await page.waitFor(600); // need to let slide transition complete
+      await page.waitForTimeout(600); // need to let slide transition complete
 
       await expect(page).toMatch('Nuka Carousel: Slide 2');
 
@@ -491,7 +491,7 @@ describe('Nuka Carousel', () => {
 
       it('should not partially show first slide when on last slide.', async () => {
         await expect(page).toClick('button', { text: '6' });
-        await page.waitFor(transitionSpeed); // need to let slide transition complete
+        await page.waitForTimeout(transitionSpeed); // need to let slide transition complete
         const styles = await page.evaluate(
           getStyles,
           '.slider-slide:first-child',
@@ -503,7 +503,7 @@ describe('Nuka Carousel', () => {
       it('should partially show previous and next slide when on a middle slide.', async () => {
         const slide = 3;
         await expect(page).toClick('button', { text: `${slide}` });
-        await page.waitFor(transitionSpeed); // need to let slide transition complete
+        await page.waitForTimeout(transitionSpeed); // need to let slide transition complete
 
         const prevSlide = slide - 1;
         const prevStyles = await page.evaluate(
@@ -548,7 +548,7 @@ describe('Nuka Carousel', () => {
 
       it('should partially show first slide when on last slide.', async () => {
         await expect(page).toClick('button', { text: '6' });
-        await page.waitFor(transitionSpeed); // need to let slide transition complete
+        await page.waitForTimeout(transitionSpeed); // need to let slide transition complete
         const styles = await page.evaluate(
           getStyles,
           '.slider-slide:first-child',
@@ -562,7 +562,7 @@ describe('Nuka Carousel', () => {
       it('should partially show previous and next slide when on a middle slide.', async () => {
         const slide = 3;
         await expect(page).toClick('button', { text: `${slide}` });
-        await page.waitFor(transitionSpeed); // need to let slide transition complete
+        await page.waitForTimeout(transitionSpeed); // need to let slide transition complete
 
         const prevSlide = slide - 1;
         const prevStyles = await page.evaluate(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2881,10 +2881,10 @@ detect-node@^2.0.4:
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
   integrity sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==
 
-devtools-protocol@0.0.781568:
-  version "0.0.781568"
-  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.781568.tgz#4cdca90a952d2c77831096ff6cd32695d8715a04"
-  integrity sha512-9Uqnzy6m6zEStluH9iyJ3iHyaQziFnMnLeC8vK0eN6smiJmIx7+yB64d67C2lH/LZra+5cGscJAJsNXO+MdPMg==
+devtools-protocol@0.0.818844:
+  version "0.0.818844"
+  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.818844.tgz#d1947278ec85b53e4c8ca598f607a28fa785ba9e"
+  integrity sha512-AD1hi7iVJ8OD0aMLQU5VK0XH9LDlA1+BcPIgrAxPfaibx2DbWucuyOhc4oyQCbnvDDO68nN6/LcKfqTP343Jjg==
 
 diff-sequences@^24.9.0:
   version "24.9.0"
@@ -5758,7 +5758,7 @@ mime@1.6.0:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
-mime@^2.0.3, mime@^2.4.4:
+mime@^2.4.4:
   version "2.4.6"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.6.tgz#e5b407c90db442f2beb5b162373d07b69affa4d1"
   integrity sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==
@@ -5928,6 +5928,11 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+node-fetch@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-forge@^0.10.0:
   version "0.10.0"
@@ -6689,16 +6694,16 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-puppeteer@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-5.2.1.tgz#7f0564f0a5384f352a38c8cc42af875cd87f4ea6"
-  integrity sha512-PZoZG7u+T6N1GFWBQmGVG162Ak5MAy8nYSVpeeQrwJK2oYUlDWpHEJPcd/zopyuEMTv7DiztS1blgny1txR2qw==
+puppeteer@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-5.5.0.tgz#331a7edd212ca06b4a556156435f58cbae08af00"
+  integrity sha512-OM8ZvTXAhfgFA7wBIIGlPQzvyEETzDjeRa4mZRCRHxYL+GNH5WAuYUQdja3rpWZvkX/JKqmuVgbsxDNsDFjMEg==
   dependencies:
     debug "^4.1.0"
-    devtools-protocol "0.0.781568"
+    devtools-protocol "0.0.818844"
     extract-zip "^2.0.0"
     https-proxy-agent "^4.0.0"
-    mime "^2.0.3"
+    node-fetch "^2.6.1"
     pkg-dir "^4.2.0"
     progress "^2.0.1"
     proxy-from-env "^1.0.0"
@@ -8515,10 +8520,10 @@ which@^1.2.12, which@^1.2.14, which@^1.2.9, which@^1.3.0, which@^1.3.1:
   dependencies:
     isexe "^2.0.0"
 
-wicg-inert@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/wicg-inert/-/wicg-inert-3.0.3.tgz#7d05eaed64176887ee4c66fc0c4d6fe4b38ccce5"
-  integrity sha512-XwXf8K0NN4cpagjBlZ2/j/5Sjf6dW3HNbfywEy1y6Z8PJKvSHVGiuc5Id/9RZ6EmGq+GQCGTo7B2SK0Misbr6g==
+wicg-inert@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/wicg-inert/-/wicg-inert-3.1.0.tgz#6525f12db188b83f0051bed2ddcf6c1aa5b17590"
+  integrity sha512-P0ZiWaN9SxOkJbYtF/PIwmIRO8UTqTJtyl33QTQlHfAb6h15T0Dp5m7WTJ8N6UWIoj+KU5M0a8EtfRZLlHiP0Q==
 
 word-wrap@~1.2.3:
   version "1.2.3"


### PR DESCRIPTION
### Description

Puppeteer is deprecating `waitFor` - this updates that package and uses new `waitForTimeout` method
Wicg-inert was updated to take advantage of fixes in that package related to Nuka

Fixes #696 

### How Has This Been Tested?

yarn test & yarn test-e2e



