### PR TITLE
add transition when height mode is current

### DIFF
--- a/src/transitions/scroll-transition.js
+++ b/src/transitions/scroll-transition.js
@@ -167,7 +167,9 @@ export default class ScrollTransition extends React.Component {
       this.props.cellSpacing * React.Children.count(this.props.children);
     const transform = `translate3d(${deltaX}px, ${deltaY}px, 0)`;
     const transition =
-      this.props.heightMode === 'current' ? 'height 0.2s ease-out' : '0s';
+      this.props.heightMode === 'current' && this.props.hasInteraction
+        ? 'height 0.2s ease-out'
+        : '0s';
     return {
       boxSizing: 'border-box',
       cursor: this.props.dragging === true ? 'pointer' : 'inherit',
@@ -215,6 +217,7 @@ ScrollTransition.propTypes = {
   deltaY: PropTypes.number,
   dragging: PropTypes.bool,
   frameWidth: PropTypes.number,
+  hasInteraction: PropTypes.bool,
   heightMode: PropTypes.oneOf(['first', 'current', 'max']),
   isWrappingAround: PropTypes.bool,
   left: PropTypes.number,

--- a/src/transitions/scroll-transition.js
+++ b/src/transitions/scroll-transition.js
@@ -166,7 +166,8 @@ export default class ScrollTransition extends React.Component {
     const spacingOffset =
       this.props.cellSpacing * React.Children.count(this.props.children);
     const transform = `translate3d(${deltaX}px, ${deltaY}px, 0)`;
-
+    const transition =
+      this.props.heightMode === 'current' ? 'height 0.2s ease-out' : '0s';
     return {
       boxSizing: 'border-box',
       cursor: this.props.dragging === true ? 'pointer' : 'inherit',
@@ -184,7 +185,8 @@ export default class ScrollTransition extends React.Component {
       touchAction: `pinch-zoom ${this.props.vertical ? 'pan-x' : 'pan-y'}`,
       transform,
       WebkitTransform: transform,
-      width: 'auto'
+      width: 'auto',
+      transition
     };
   }
 

--- a/src/utilities/style-utilities.js
+++ b/src/utilities/style-utilities.js
@@ -174,6 +174,7 @@ export const getTransitionProps = (props, state) => {
     currentSlide: state.currentSlide,
     dragging: props.dragging,
     frameWidth: parseInt(state.frameWidth),
+    hasInteraction: state.hasInteraction,
     heightMode: props.heightMode,
     isWrappingAround: state.isWrappingAround,
     left: state.left,


### PR DESCRIPTION
### Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

- Added a css ease out transition property when the heightMode is set to "current"

Fixes #721 

#### Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Manual testing  followed by executing all unit tests and E2E tests
### Checklist: (Feel free to delete this section upon completion)

- [X] My code follows the style guidelines of this project (I have run `yarn lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] For any breaking API changes, I have updated the type definitions in [`index.d.ts`](../index.d.ts)
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
