### PR TITLE
allow peeking slides when slide count is less than 3

### DIFF
--- a/src/transitions/scroll-transition.js
+++ b/src/transitions/scroll-transition.js
@@ -27,7 +27,10 @@ export default class ScrollTransition extends React.Component {
     let peekSlide = true;
     switch (this.props.cellAlign) {
       case 'left':
-        peekSlide = this.props.children.length > 2 ? true : false;
+        peekSlide =
+          this.props.children.length <= 2 && currentSlideIndex !== 0
+            ? false
+            : true;
         break;
       case 'center':
         peekSlide =
@@ -210,7 +213,6 @@ export default class ScrollTransition extends React.Component {
     const children = this.formatChildren(this.props.children);
     const deltaX = this.props.deltaX;
     const deltaY = this.props.deltaY;
-
     return (
       <ul
         className="slider-list"

--- a/src/transitions/scroll-transition.js
+++ b/src/transitions/scroll-transition.js
@@ -115,6 +115,7 @@ export default class ScrollTransition extends React.Component {
           -1;
       }
     }
+
     return targetPosition + offset || 0;
   }
 
@@ -213,6 +214,7 @@ export default class ScrollTransition extends React.Component {
     const children = this.formatChildren(this.props.children);
     const deltaX = this.props.deltaX;
     const deltaY = this.props.deltaY;
+
     return (
       <ul
         className="slider-list"

--- a/src/transitions/scroll-transition.js
+++ b/src/transitions/scroll-transition.js
@@ -21,11 +21,26 @@ export default class ScrollTransition extends React.Component {
   }
 
   /* eslint-disable complexity */
-  getSlideTargetPosition(currentSlideIndex, positionValue) {
+  getSlideTargetPosition(currentSlideIndex, positionValue, cellAlign) {
     let offset = 0;
+    // Below lines help to display peeking slides when number of slides is less than 3.
+    let peekSlide = true;
+    switch (cellAlign) {
+      case 'left':
+        peekSlide = this.props.children.length > 2 ? true : false;
+        break;
+      case 'center':
+        peekSlide =
+          this.props.children.length > 2 ||
+          this.props.currentSlide !== currentSlideIndex - 1
+            ? true
+            : false;
+        break;
+    }
 
     if (
       this.props.animation === 'zoom' &&
+      peekSlide &&
       (this.props.currentSlide === currentSlideIndex + 1 ||
         (this.props.currentSlide === 0 &&
           currentSlideIndex === this.props.children.length - 1))
@@ -97,13 +112,19 @@ export default class ScrollTransition extends React.Component {
           -1;
       }
     }
-
     return targetPosition + offset || 0;
   }
 
   /* eslint-enable complexity */
   formatChildren(children) {
-    const { top, left, currentSlide, slidesToShow, vertical } = this.props;
+    const {
+      top,
+      left,
+      currentSlide,
+      slidesToShow,
+      vertical,
+      cellAlign
+    } = this.props;
     const positionValue = vertical ? top : left;
 
     return React.Children.map(children, (child, index) => {
@@ -116,7 +137,7 @@ export default class ScrollTransition extends React.Component {
             currentSlide,
             slidesToShow
           )}`}
-          style={this.getSlideStyles(index, positionValue)}
+          style={this.getSlideStyles(index, positionValue, cellAlign)}
           key={index}
           onClick={handleSelfFocus}
           tabIndex={-1}
@@ -128,8 +149,12 @@ export default class ScrollTransition extends React.Component {
     });
   }
 
-  getSlideStyles(index, positionValue) {
-    const targetPosition = this.getSlideTargetPosition(index, positionValue);
+  getSlideStyles(index, positionValue, cellAlign) {
+    const targetPosition = this.getSlideTargetPosition(
+      index,
+      positionValue,
+      cellAlign
+    );
     const transformScale =
       this.props.animation === 'zoom' && this.props.currentSlide !== index
         ? Math.max(

--- a/src/transitions/scroll-transition.js
+++ b/src/transitions/scroll-transition.js
@@ -21,11 +21,11 @@ export default class ScrollTransition extends React.Component {
   }
 
   /* eslint-disable complexity */
-  getSlideTargetPosition(currentSlideIndex, positionValue, cellAlign) {
+  getSlideTargetPosition(currentSlideIndex, positionValue) {
     let offset = 0;
     // Below lines help to display peeking slides when number of slides is less than 3.
     let peekSlide = true;
-    switch (cellAlign) {
+    switch (this.props.cellAlign) {
       case 'left':
         peekSlide = this.props.children.length > 2 ? true : false;
         break;
@@ -117,14 +117,7 @@ export default class ScrollTransition extends React.Component {
 
   /* eslint-enable complexity */
   formatChildren(children) {
-    const {
-      top,
-      left,
-      currentSlide,
-      slidesToShow,
-      vertical,
-      cellAlign
-    } = this.props;
+    const { top, left, currentSlide, slidesToShow, vertical } = this.props;
     const positionValue = vertical ? top : left;
 
     return React.Children.map(children, (child, index) => {
@@ -137,7 +130,7 @@ export default class ScrollTransition extends React.Component {
             currentSlide,
             slidesToShow
           )}`}
-          style={this.getSlideStyles(index, positionValue, cellAlign)}
+          style={this.getSlideStyles(index, positionValue)}
           key={index}
           onClick={handleSelfFocus}
           tabIndex={-1}
@@ -149,12 +142,8 @@ export default class ScrollTransition extends React.Component {
     });
   }
 
-  getSlideStyles(index, positionValue, cellAlign) {
-    const targetPosition = this.getSlideTargetPosition(
-      index,
-      positionValue,
-      cellAlign
-    );
+  getSlideStyles(index, positionValue) {
+    const targetPosition = this.getSlideTargetPosition(index, positionValue);
     const transformScale =
       this.props.animation === 'zoom' && this.props.currentSlide !== index
         ? Math.max(


### PR DESCRIPTION
### Description

-- When Animation is set to "Zoom" and number of slides are 2, the peeking slides are not visible. 

Fixes #705 

#### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

-- Manual testing followed by executing all unit tests.

### Checklist: (Feel free to delete this section upon completion)

- [X] My code follows the style guidelines of this project (I have run `yarn lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] For any breaking API changes, I have updated the type definitions in [`index.d.ts`](../index.d.ts)
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
