### PR TITLE
fix: set proper offset for slider-list for first render

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1151,6 +1151,10 @@ export default class Carousel extends React.Component {
     const mouseEvents = this.getMouseEvents();
     const TransitionControl = Transitions[this.props.transitionMode];
     const validChildren = getValidChildren(this.props.children);
+    const {
+      tx: [startTx],
+      ty: [startTy]
+    } = this.getOffsetDeltas();
 
     return (
       <div
@@ -1180,7 +1184,7 @@ export default class Carousel extends React.Component {
         >
           <Animate
             show
-            start={{ tx: 0, ty: 0 }}
+            start={{ tx: startTx, ty: startTy }}
             update={() => {
               const { tx, ty } = this.getOffsetDeltas();
 

--- a/test/specs/carousel.test.js
+++ b/test/specs/carousel.test.js
@@ -175,6 +175,20 @@ describe('<Carousel />', () => {
       expect(slider).toHaveLength(1);
     });
 
+    it('should set the offset for `slider-list` depending on `currentSlide` on first render', () => {
+      const wrapper = mount(
+        <Carousel slideIndex={1} slideWidth={100} initialSlideWidth={100}>
+          <p>Slide 1</p>
+          <p>Slide 2</p>
+          <p>Slide 3</p>
+        </Carousel>
+      );
+      const sliderList = wrapper.find('ul.slider-list');
+      expect(sliderList.prop('style').transform).toBe(
+        'translate3d(-100px, 0px, 0)'
+      );
+    });
+
     it('should set slideHeight to max value by default', () => {
       const firstSlideNode = document.createElement('div');
       const secondSlideNode = document.createElement('div');


### PR DESCRIPTION
### Description

If the `currentSlide` and `initialSlideWidth` props are present on the carousel, the carousel should display the slide specified by `currentSlide` for the first render.
This is achieved by providing proper value for the `start` prop to `Animate`.

Fixes: #463 (This issue doesn't exactly describe the bug that this PR fixes)

#### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
The PR also adds the relevant unit tests. 

### Checklist: (Feel free to delete this section upon completion)

- [x] My code follows the style guidelines of this project (I have run `yarn lint`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] For any breaking API changes, I have updated the type definitions in [`index.d.ts`](../index.d.ts)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
