### PR TITLE
Fix/749 video height

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -5,15 +5,15 @@ import ReactDom from 'react-dom';
 // eslint-disable-next-line complexity
 export default function App() {
   const colors = [
-    '7732bb',
-    '047cc0',
-    '00884b',
-    'e3bc13',
-    'db7c00',
-    'aa231f',
-    'e3bc13',
-    'db7c00',
-    'aa231f'
+    '080a87',
+    '0f7d8c',
+    'd88913',
+    'f725b1',
+    'bc8ee5',
+    '5fb1f4',
+    '037f7b',
+    '4710a0',
+    '5eced6'
   ];
   const [animation, setAnimation] = useState(undefined);
   const [autoplay, setAutoplay] = useState(false);

--- a/demo/app.js
+++ b/demo/app.js
@@ -5,15 +5,15 @@ import ReactDom from 'react-dom';
 // eslint-disable-next-line complexity
 export default function App() {
   const colors = [
-    'c90ac3',
-    '0f7d8c',
-    'd88913',
-    'f725b1',
-    'bc8ee5',
-    '5fb1f4',
-    '037f7b',
-    '4710a0',
-    '5eced6'
+    '7732bb',
+    '047cc0',
+    '00884b',
+    'e3bc13',
+    'db7c00',
+    'aa231f',
+    'e3bc13',
+    'db7c00',
+    'aa231f'
   ];
   const [animation, setAnimation] = useState(undefined);
   const [autoplay, setAutoplay] = useState(false);

--- a/demo/app.js
+++ b/demo/app.js
@@ -5,7 +5,7 @@ import ReactDom from 'react-dom';
 // eslint-disable-next-line complexity
 export default function App() {
   const colors = [
-    '080a87',
+    'c90ac3',
     '0f7d8c',
     'd88913',
     'f725b1',

--- a/src/index.js
+++ b/src/index.js
@@ -225,15 +225,7 @@ export default class Carousel extends React.Component {
     const initializeHeight = (delay) => {
       this.timers.push(
         setTimeout(() => {
-          // If slideHeight is greater than zero, then
-          // assume the app has been initialized.  If not,
-          // keep trying to set dimensions until things work.
-          if (this.state.slideHeight > 0) {
-            return;
-          }
-
           this.setDimensions();
-
           // Increase delay per attempt so the checks
           // slowly decrease if content is taking forever to load.
           initializeHeight(delay + heightCheckDelay);

--- a/src/index.js
+++ b/src/index.js
@@ -225,7 +225,19 @@ export default class Carousel extends React.Component {
     const initializeHeight = (delay) => {
       this.timers.push(
         setTimeout(() => {
+          // If slideHeight is greater than zero and matches calculated slideHeight,
+          // assume the app has been initialized.  If not,
+          // keep trying to set dimensions until things work.
+          const { slideHeight } = this.calcSlideHeightAndWidth();
+          if (
+            this.state.slideHeight > 0 &&
+            this.state.slideHeight === slideHeight
+          ) {
+            return;
+          }
+
           this.setDimensions();
+
           // Increase delay per attempt so the checks
           // slowly decrease if content is taking forever to load.
           initializeHeight(delay + heightCheckDelay);

--- a/src/transitions/scroll-transition.js
+++ b/src/transitions/scroll-transition.js
@@ -188,6 +188,7 @@ export default class ScrollTransition extends React.Component {
       this.props.heightMode === 'current' && this.props.hasInteraction
         ? 'height 0.2s ease-out'
         : '0s';
+
     return {
       boxSizing: 'border-box',
       cursor: this.props.dragging === true ? 'pointer' : 'inherit',


### PR DESCRIPTION
### Description

We were bailing out too soon from `initializeCarouselHeight` - the slideHeight was greater than 0, but the content wasn't done loading. If we check the calculated slideHeight against our state, we can see they don't match and we should keep trying to run `setDimensions` until they match. 

Fixes #749 

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)


### Checklist: (Feel free to delete this section upon completion)

- [x] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)

