### PR TITLE
FrameHeight calculation updated

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1014,7 +1014,7 @@ export default class Carousel extends React.Component {
     const frame = this.frame;
     const { slideHeight, slideWidth } = this.calcSlideHeightAndWidth(props);
 
-    const frameHeight = slideHeight + props.cellSpacing * (slidesToShow - 1);
+    const frameHeight = (slideHeight + props.cellSpacing) * (slidesToShow - 1);
     const frameWidth = props.vertical ? frameHeight : frame.offsetWidth;
 
     let { slidesToScroll } = getPropsByTransitionMode(props, [

--- a/src/utilities/utilities.js
+++ b/src/utilities/utilities.js
@@ -171,7 +171,7 @@ export const calcSomeInitialState = (props) => {
     ? (props.initialSlideHeight || 0) * props.slidesToShow
     : props.initialSlideHeight || 0;
 
-  const frameHeight = slideHeight + props.cellSpacing * (slidesToShow - 1);
+  const frameHeight = (slideHeight + props.cellSpacing) * (slidesToShow - 1);
 
   const frameWidth = props.vertical ? frameHeight : '100%';
   return {


### PR DESCRIPTION
### Description

FrameHeight should be calculated as per slidesToShow in case vertical is set to true. In the existing code the frameHeight is being incorrectly calculated as 
`slideHeight + props.cellSpacing * (slidesToShow - 1)` first multiplies cellSpacing with (slidesToShow-1) and adds it to slideHeight instead of adding slideHeight and cellSpacing and then multiplying it with (slidesToShow-1).

This needs to be updated to `(slideHeight + props.cellSpacing) * (slidesToShow - 1);` so that the frameHeight is correctly calculated.
Fixes #756

#### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist: (Feel free to delete this section upon completion)

- [x] My code follows the style guidelines of this project (I have run `yarn lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] For any breaking API changes, I have updated the type definitions in [`index.d.ts`](../index.d.ts)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
