### PR TITLE
Fix: remove preventDefault from touch handler

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -344,10 +344,6 @@ export default class Carousel extends React.Component {
           this.props.vertical
         );
 
-        if (direction !== 0) {
-          e.preventDefault();
-        }
-
         const length = this.props.vertical
           ? Math.round(
               Math.sqrt(


### PR DESCRIPTION
### Description
This update removes the `preventDefault` call from `onTouchMove` handler. As outlined in [Issue 732](https://github.com/FormidableLabs/nuka-carousel/issues/732), React 17 has updated the way they are [handling Event Delegation](https://reactjs.org/blog/2020/10/20/react-v17.html#changes-to-event-delegation) which caused issues related to the way Chrome implements touch and scroll events as [passive by default](https://github.com/facebook/react/pull/19654). The changes by React and Chrome made it so that touch events on Chrome (while using React17) would result in the console being spammed with console warnings about using `preventDefault` within a passive event callback. These warnings continue as long as you continue the touch+drag which has the potential to cause performance issues.

There doesn't seem to be any drawback to removing the `preventDefault` from the touch handler, however it is possible that the `preventDefault` was masking/preventing touch handler defaults on child elements passed to the Carousel, potentially making this a "breaking change" as far as versioning is concerned and should be noted in any changelog.

Fixes # (732)

#### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [?] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How Has This Been Tested?
Manually verified the absence of the console warnings and verified that existing functionality is maintained across all (OS X) desktop browser.