### PR TITLE
Improve SVG dot accessibility

### DIFF
--- a/src/default-controls.js
+++ b/src/default-controls.js
@@ -241,7 +241,13 @@ export const PagingDots = (props) => {
               onClick={props.goToSlide.bind(null, index)}
               aria-label={`slide ${index + 1} bullet`}
             >
-              <svg className="paging-dot" width="6" height="6">
+              <svg
+                className="paging-dot"
+                width="6"
+                height="6"
+                aria-hidden="true"
+                focusable="false"
+              >
                 <circle cx="3" cy="3" r="3" />
               </svg>
             </button>


### PR DESCRIPTION
## Description

Added `aria-hidden=true focusable=false` to SVG dot navigation to improve accessibility.

Fixes #780 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

* ran prettier, check, test-e2e
* verified code in DevTools
* tested with VoiceOver on Safari 14.0.3

### Checklist: (Feel free to delete this section upon completion)

- [x] My code follows the style guidelines of this project (I have run `yarn lint`)
- [x] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
