### PR TITLE
fix: bind blockEvent method to this

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -83,6 +83,7 @@ export default class Carousel extends React.Component {
     this.getOffsetDeltas = this.getOffsetDeltas.bind(this);
     this.getTargetLeft = this.getTargetLeft.bind(this);
     this.getTouchEvents = this.getTouchEvents.bind(this);
+    this.blockEvent = this.blockEvent.bind(this);
     this.goToSlide = this.goToSlide.bind(this);
     this.handleFocus = this.handleFocus.bind(this);
     this.handleBlur = this.handleBlur.bind(this);
@@ -281,30 +282,31 @@ export default class Carousel extends React.Component {
     }
   }
 
-  getLockScrollEvents() {
-    const blockEvent = (e) => {
-      if (this.state.dragging) {
-        const direction = swipeDirection(
-          this.touchObject.startX,
-          e.touches[0].pageX,
-          this.touchObject.startY,
-          e.touches[0].pageY,
-          this.props.vertical
-        );
-        if (direction !== 0) {
-          e.preventDefault();
-        }
+  blockEvent(e) {
+    if (this.state.dragging) {
+      const direction = swipeDirection(
+        this.touchObject.startX,
+        e.touches[0].pageX,
+        this.touchObject.startY,
+        e.touches[0].pageY,
+        this.props.vertical
+      );
+      if (direction !== 0) {
+        e.preventDefault();
       }
-    };
+    }
+  }
 
+  getLockScrollEvents() {
     const lockTouchScroll = () => {
-      document.addEventListener('touchmove', blockEvent, {
+      document.addEventListener('touchmove', this.blockEvent, {
         passive: false
       });
     };
+    console.log(document);
 
     const unlockTouchScroll = () => {
-      document.removeEventListener('touchmove', blockEvent, {
+      document.removeEventListener('touchmove', this.blockEvent, {
         passive: false
       });
     };

--- a/src/index.js
+++ b/src/index.js
@@ -303,7 +303,6 @@ export default class Carousel extends React.Component {
         passive: false
       });
     };
-    console.log(document);
 
     const unlockTouchScroll = () => {
       document.removeEventListener('touchmove', this.blockEvent, {


### PR DESCRIPTION
### Description

Bind blockEvent method to `this` in order to properly remove the touchmove event listener on unmount

Fixes #787 

#### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

`npm run test`
manual testing

