### PR TITLE
Perf: Use more modern screen-reader only styles

### DIFF
--- a/src/announce-slide.js
+++ b/src/announce-slide.js
@@ -3,11 +3,14 @@ import React from 'react';
 const AnnounceSlide = ({ message }) => {
   const styles = {
     position: 'absolute',
-    left: '-10000px',
-    top: 'auto',
     width: '1px',
     height: '1px',
-    overflow: 'hidden'
+    overflow: 'hidden',
+    padding: 0,
+    margin: '-1px',
+    clip: 'rect(0, 0, 0, 0)',
+    'white-space': 'nowrap',
+    border: 0,
   };
   return (
     <div aria-live="polite" aria-atomic="true" style={styles} tabIndex={-1}>


### PR DESCRIPTION
### Description

See: https://a11y-guidelines.orange.com/en/web/components-examples/accessible-hiding/. 

This improves performance, since the previously used `left: -1000px` technique created huge layers when the div was close to (or overlapped) an element which got promoted to its own layer.

#### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

See screenshot: https://prnt.sc/1qae4pk
After swapping the css, the layers are gone.

### Checklist: (Feel free to delete this section upon completion)
