### PR TITLE
fix: prevent initializeCarouselHeight loop to fix browser crash

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -222,7 +222,8 @@ export default class Carousel extends React.Component {
   }
 
   initializeCarouselHeight() {
-    const heightCheckDelay = 200;
+    const initialDelay = 200;
+    let timesChecked = 0;
     const initializeHeight = (delay) => {
       this.timers.push(
         setTimeout(() => {
@@ -238,15 +239,24 @@ export default class Carousel extends React.Component {
           }
 
           this.setDimensions();
+          ++timesChecked;
 
           // Increase delay per attempt so the checks
           // slowly decrease if content is taking forever to load.
-          initializeHeight(delay + heightCheckDelay);
+          //
+          // If we've checked more than 10 times, it's probably never going
+          // to load, so we stop checking. Otherwise, the page will freeze
+          // after a long period:
+          // See https://github.com/FormidableLabs/nuka-carousel/issues/798
+          if (timesChecked > 10) {
+            // Add exponential backoff to check more slowly
+            initializeHeight(delay * 1.5);
+          }
         }, delay)
       );
     };
 
-    initializeHeight(heightCheckDelay);
+    initializeHeight(initialDelay);
   }
 
   establishChildNodesMutationObserver() {


### PR DESCRIPTION
### Description

#### Background

On a page that has an instance of nuka-carousel inside a hidden or 0-height div, the `setTimeout` in `initializeCarouselHeight` will infinitely loop since the measured slide height will always be 0.

When the user leaves the tab, setTimeouts may not be executed in the background, and when they return to the tab, the tab will crash: see #798 for others who've encountered this.

#### Fix

Set a limit on how many times the timeout will run before giving up. I set this to 10, since it already seems like plenty, and by the 10th iteration, it'll wait for over 10 seconds already.

Fixes #798

#### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I installed a version of the package on a website that was having the issue.

I then ran this code in Chrome console to log any setTimeout calls.

```js
const origSetTimeout = window.setTimeout;
window.setTimeout = (...args) => { console.log('Called setTimeout', args); console.trace(); origSetTimeout(...args) }
```

I verified that the page stopped showing new calls to "Called setTimeout" after a minute or so

### Checklist: (Feel free to delete this section upon completion)

- [X] My code follows the style guidelines of this project (I have run `yarn lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] For any breaking API changes, I have updated the type definitions in [`index.d.ts`](../index.d.ts)
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules