### PR TITLE
fix: flip inequality check in initializeCarouselHeight

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -248,7 +248,7 @@ export default class Carousel extends React.Component {
           // to load, so we stop checking. Otherwise, the page will freeze
           // after a long period:
           // See https://github.com/FormidableLabs/nuka-carousel/issues/798
-          if (timesChecked > 10) {
+          if (timesChecked < 10) {
             // Add exponential backoff to check more slowly
             initializeHeight(delay * 1.5);
           }


### PR DESCRIPTION
### Description

#804 got merged so quickly that I didn't managed to get my push for a small bug in that fix! This MR flips the sign of the branch to recurse.

#### Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Same as in #804

I installed a version of the package on a website that was having the issue.

I then ran this code in Chrome console to log any setTimeout calls.

```js
const origSetTimeout = window.setTimeout;
window.setTimeout = (...args) => { console.log('Called setTimeout', args); console.trace(); origSetTimeout(...args) }
```

I verified that the page stopped showing new calls to "Called setTimeout" after a minute or so

### Checklist: (Feel free to delete this section upon completion)

- [X] My code follows the style guidelines of this project (I have run `yarn lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] For any breaking API changes, I have updated the type definitions in [`index.d.ts`](../index.d.ts)
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules