### PR TITLE
detect pinch zoom in touch events

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -336,6 +336,12 @@ export default class Carousel extends React.Component {
 
     return {
       onTouchStart: (e) => {
+        //detect pinch zoom
+        if (e.touches.length === 2) {
+          this.handleMouseOver();
+          return;
+        }
+
         this.touchObject = {
           startX: e.touches[0].pageX,
           startY: e.touches[0].pageY
@@ -347,6 +353,10 @@ export default class Carousel extends React.Component {
         });
       },
       onTouchMove: (e) => {
+        if (e.touches.length === 2) {
+          return;
+        }
+
         const direction = swipeDirection(
           this.touchObject.startX,
           e.touches[0].pageX,
@@ -395,6 +405,11 @@ export default class Carousel extends React.Component {
         });
       },
       onTouchEnd: (e) => {
+        if (e.touches.length === 2) {
+          this.handleMouseOut();
+          return;
+        }
+
         this.handleSwipe(e);
         this.handleMouseOut();
       },


### PR DESCRIPTION
### Description

On mobile, it is difficult to pinch zoom the carousel because of how we are detecting touch events and length. This PR updates these methods with an extra check for detecting when a user is pinching to zoom on the carousel.

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Manually on a mobile device and in desktop to ensure existing functionality 
Running unit tests
