### PR TITLE
fix: Last image is not rendered when carousel has 3 slides and its centered

### DIFF
--- a/src/transitions/scroll-transition.js
+++ b/src/transitions/scroll-transition.js
@@ -108,7 +108,7 @@ export default class ScrollTransition extends React.Component {
             (this.props.slideWidth + this.props.cellSpacing) *
             (this.props.slideCount + currentSlideIndex);
         }
-      } else if (distanceFromStart > slidesAfter) {
+      } else if (distanceFromStart >= slidesAfter) {
         targetPosition =
           (this.props.slideWidth + this.props.cellSpacing) *
           (this.props.slideCount - currentSlideIndex) *

--- a/test/e2e/carousel.test.js
+++ b/test/e2e/carousel.test.js
@@ -586,6 +586,35 @@ describe('Nuka Carousel', () => {
           'true'
         );
       });
+
+      it('should partially show previous and next slide', async () => {
+        await expect(page).toClick('button', {
+          text: 'Toggle Show 3 Slides Only'
+        });
+
+        const prevSlide = 3;
+        const prevStyles = await page.evaluate(
+          getStyles,
+          `.slider-slide:nth-child(${prevSlide})`,
+          ['left', 'width']
+        );
+
+        const correctPrevLeft = -parseFloat(prevStyles.width);
+        expect(`${approximately(prevStyles.left, correctPrevLeft)}`).toMatch(
+          'true'
+        );
+
+        const nextSlide = 2;
+        const nextStyles = await page.evaluate(
+          getStyles,
+          `.slider-slide:nth-child(${nextSlide})`,
+          ['left', 'width']
+        );
+        const correctNextLeft = parseFloat(nextStyles.width);
+        expect(`${approximately(nextStyles.left, correctNextLeft)}`).toMatch(
+          'true'
+        );
+      });
     });
   });
 });

--- a/test/e2e/carousel.test.js
+++ b/test/e2e/carousel.test.js
@@ -587,7 +587,7 @@ describe('Nuka Carousel', () => {
         );
       });
 
-      it('should partially show previous and next slide', async () => {
+      it('should partially show previous and next slide with 3 slides only', async () => {
         await expect(page).toClick('button', {
           text: 'Toggle Show 3 Slides Only'
         });


### PR DESCRIPTION
### Description
When we have three slides in centered carousel with withAround option, the last slide is not visible. More information here: https://github.com/FormidableLabs/nuka-carousel/issues/809


Before the fix:

https://user-images.githubusercontent.com/12056467/142645447-fe0d632e-9c1f-416f-b1ca-490c8882ea6f.mov


After the fix:

https://user-images.githubusercontent.com/12056467/142645479-f579d128-7d37-4d9e-a34a-4e94552967a8.mov



Fixes #809 

#### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Manually and a new e2e test is added. All test suites are passing successfully

### Checklist: (Feel free to delete this section upon completion)

- [x] My code follows the style guidelines of this project (I have run `yarn lint`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

