### PR TITLE
fix: missing slide when slides are equal to the slidesToShow prop

### DIFF
--- a/src/transitions/scroll-transition.js
+++ b/src/transitions/scroll-transition.js
@@ -21,7 +21,12 @@ export default class ScrollTransition extends React.Component {
   }
 
   /* eslint-disable complexity */
-  getSlideTargetPosition(currentSlideIndex, positionValue) {
+  getSlideTargetPosition(
+    currentSlideIndex,
+    positionValue,
+    childrenLength,
+    slidesToShow
+  ) {
     let offset = 0;
     // Below lines help to display peeking slides when number of slides is less than 3.
     let peekSlide = true;
@@ -102,13 +107,18 @@ export default class ScrollTransition extends React.Component {
       const slidesAfter = slidesInViewAfter + slidesOutOfViewAfter;
 
       const distanceFromStart = Math.abs(startSlideIndex - currentSlideIndex);
+
+      const isDistanceBiggerThanSlides =
+        childrenLength === slidesToShow
+          ? distanceFromStart > slidesAfter
+          : distanceFromStart >= slidesAfter;
       if (currentSlideIndex < startSlideIndex) {
         if (distanceFromStart > slidesBefore) {
           targetPosition =
             (this.props.slideWidth + this.props.cellSpacing) *
             (this.props.slideCount + currentSlideIndex);
         }
-      } else if (distanceFromStart >= slidesAfter) {
+      } else if (isDistanceBiggerThanSlides) {
         targetPosition =
           (this.props.slideWidth + this.props.cellSpacing) *
           (this.props.slideCount - currentSlideIndex) *
@@ -123,6 +133,7 @@ export default class ScrollTransition extends React.Component {
   formatChildren(children) {
     const { top, left, currentSlide, slidesToShow, vertical } = this.props;
     const positionValue = vertical ? top : left;
+    const childrenLength = React.Children.count(children);
 
     return React.Children.map(children, (child, index) => {
       const isVisible = isFullyVisible(index, this.props);
@@ -136,7 +147,12 @@ export default class ScrollTransition extends React.Component {
           )}`}
           aria-label={`slide ${index + 1} of ${children.length}`}
           role="group"
-          style={this.getSlideStyles(index, positionValue)}
+          style={this.getSlideStyles(
+            index,
+            positionValue,
+            childrenLength,
+            slidesToShow
+          )}
           key={index}
           onClick={handleSelfFocus}
           tabIndex={-1}
@@ -148,8 +164,13 @@ export default class ScrollTransition extends React.Component {
     });
   }
 
-  getSlideStyles(index, positionValue) {
-    const targetPosition = this.getSlideTargetPosition(index, positionValue);
+  getSlideStyles(index, positionValue, childrenLength, slidesToShow) {
+    const targetPosition = this.getSlideTargetPosition(
+      index,
+      positionValue,
+      childrenLength,
+      slidesToShow
+    );
     const transformScale =
       this.props.animation === 'zoom' && this.props.currentSlide !== index
         ? Math.max(

--- a/test/specs/carousel.test.js
+++ b/test/specs/carousel.test.js
@@ -1,4 +1,4 @@
-/*eslint max-nested-callbacks: ["error", 5]*/
+/* eslint max-nested-callbacks: ["error", 5]*/
 import { createRef } from 'react';
 import Carousel from '../../src';
 
@@ -97,6 +97,18 @@ describe('<Carousel />', () => {
       );
       const children = wrapper.find('.slide-visible');
       expect(children).toHaveLength(1);
+    });
+
+    it('should render visible child with the `slide-visible` class when slidesToShow is equal to children', () => {
+      const wrapper = mount(
+        <Carousel slidesToShow={3}>
+          <p>Slide 1</p>
+          <p>Slide 2</p>
+          <p>Slide 3</p>
+        </Carousel>
+      );
+      const children = wrapper.find('.slide-visible');
+      expect(children).toHaveLength(3);
     });
 
     it('should render controls by default.', () => {

--- a/test/specs/fade-transition.test.js
+++ b/test/specs/fade-transition.test.js
@@ -1,4 +1,4 @@
-/*eslint max-nested-callbacks: ["error", 5]*/
+/* eslint max-nested-callbacks: ["error", 5]*/
 import FadeTransition from '../../src/transitions/fade-transition';
 
 describe('<FadeTransition />', () => {

--- a/test/specs/scroll-transition.test.js
+++ b/test/specs/scroll-transition.test.js
@@ -1,4 +1,4 @@
-/*eslint max-nested-callbacks: ["error", 4]*/
+/* eslint max-nested-callbacks: ["error", 4]*/
 import ScrollTransition from '../../src/transitions/scroll-transition';
 
 describe('<ScrollTransition />', () => {


### PR DESCRIPTION
### Description
When carousel children are equal to the slides, the last slide is missing in the latest version of the library. This is caused by fix earlier this week

#### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist: (Feel free to delete this section upon completion)

- [x] My code follows the style guidelines of this project (I have run `yarn lint`)
- [x] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
