### PR TITLE
[v5.0.0] Replace position absolute with width and translate

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "prettier-fix": "prettier \"**/*.{js,json,ts,tsx,css,md}\" --write",
     "preversion": "npm run check",
     "start": "webpack-dev-server --mode development",
+    "start:next": "cd ./examples/nextjs && yarn dev",
     "test": "jest test --config jest.unit.config.js",
     "test-e2e": "jest test --config jest.e2e.config.js",
     "version": "npm run build",

--- a/src-v5/carousel.tsx
+++ b/src-v5/carousel.tsx
@@ -818,12 +818,20 @@ export class Carousel extends Component<CarouselProps, CarouselState> {
   }
 
   // Animation Method
-
+  // eslint-disable-next-line complexity
   getTargetLeft(touchOffset?: number | null, slide?: number | null): number {
     const target = slide || this.state.currentSlide;
+    const count = React.Children.count(this.props.children);
+    let offset = getAlignmentOffset(
+      target,
+      { ...this.props, ...this.state },
+      this.props.children
+    );
 
-    let offset = getAlignmentOffset(target, { ...this.props, ...this.state });
-    let left = this.state.slideWidth * target;
+    let left =
+      this.props.wrapAround && target >= count - (this.props.slidesToShow || 1)
+        ? -(this.state.slideWidth * (count - target))
+        : this.state.slideWidth * target;
 
     const lastSlide =
       this.state.currentSlide > 0 &&
@@ -876,10 +884,14 @@ export class Carousel extends Component<CarouselProps, CarouselState> {
       slidesToShow
     } = this.state;
     const { tx, ty } = this.getOffsetDeltas();
-    const offset = getAlignmentOffset(currentSlide, {
-      ...this.props,
-      ...this.state
-    });
+    const offset = getAlignmentOffset(
+      currentSlide,
+      {
+        ...this.props,
+        ...this.state
+      },
+      this.props.children
+    );
 
     if (this.props.vertical && typeof slideHeight === 'number') {
       const rowHeight = slideHeight / slidesToShow;

--- a/src-v5/default-controls.tsx
+++ b/src-v5/default-controls.tsx
@@ -65,7 +65,8 @@ export const nextButtonDisabled = ({
       cellAlign,
       cellSpacing,
       frameWidth,
-      slideWidth
+      slideWidth,
+      wrapAround
     });
 
     const relativePosition = positionValue - alignmentOffset;

--- a/src-v5/utilities/slides.tsx
+++ b/src-v5/utilities/slides.tsx
@@ -1,0 +1,42 @@
+import React, { CSSProperties } from 'react';
+import { TransitionProps } from '../types';
+import {
+  getSlideClassName,
+  handleSelfFocus,
+  isFullyVisible
+} from './utilities';
+
+export const getSlides = (
+  children: TransitionProps['children'],
+  getSlideStyles: (index: number) => CSSProperties,
+  props: TransitionProps,
+  slidesPosition: 'left' | 'right' | 'primary'
+) => {
+  const { currentSlide, slidesToShow } = props;
+  const length = React.Children.count(children);
+
+  const elements = React.Children.map(children, (child, index) => {
+    const isVisible = isFullyVisible(index, props);
+    const inert = isVisible ? {} : { inert: 'true' };
+    return (
+      <div
+        className={`slider-slide slide-${slidesPosition}${getSlideClassName(
+          index,
+          currentSlide,
+          slidesToShow
+        )}`}
+        aria-label={`slide ${index + 1} of ${length}`}
+        role="group"
+        style={getSlideStyles(index)}
+        key={`${slidesPosition}-${index}`}
+        onClick={handleSelfFocus}
+        tabIndex={-1}
+        {...inert}
+      >
+        {child}
+      </div>
+    );
+  });
+
+  return elements || [];
+};

--- a/src-v5/utilities/style-utilities.ts
+++ b/src-v5/utilities/style-utilities.ts
@@ -30,15 +30,18 @@ export const getAlignmentOffset = (
   slideIndex: number,
   config: Pick<
     CarouselState & CarouselProps,
-    'cellAlign' | 'cellSpacing' | 'frameWidth' | 'slideWidth'
-  >
+    'cellAlign' | 'cellSpacing' | 'frameWidth' | 'slideWidth' | 'wrapAround'
+  >,
+  children?: TransitionProps['children']
 ): number => {
   let offset = 0;
+  const length = React.Children.count(children);
+
   const frameWidth = config.frameWidth || 0;
 
   switch (config.cellAlign) {
     case Alignment.Left: {
-      offset = 0;
+      offset = config.wrapAround ? -(config.slideWidth * length) : 0;
       offset -= config.cellSpacing * slideIndex;
       break;
     }


### PR DESCRIPTION
### Description
Remove absolute positioning of slides and use width and translate in the slider-list. Also add additional slides in front and back so we can swipe easily with animation when we use carousel with wrapAround. These slides that are just helpers currently are tripling the slides on the page, but this will be reduced in next PR.