### PR TITLE
v5: migrate next and prev buttons actions

### DIFF
--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -8,9 +8,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "next": "12.0.4",
-    "react": "^16.9.0",
-    "react-dom": "^16.9.0"
+    "next": "12.0.4"
   },
   "devDependencies": {
     "eslint": "7",

--- a/examples/nextjs/yarn.lock
+++ b/examples/nextjs/yarn.lock
@@ -1841,7 +1841,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
-loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -2287,7 +2287,7 @@ progress@^2.0.0:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
-prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -2355,16 +2355,6 @@ raw-body@2.4.1:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-react-dom@^16.9.0:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
-  integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.19.1"
-
 react-is@17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
@@ -2379,15 +2369,6 @@ react-refresh@0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
-
-react@^16.9.0:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
-  integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
 
 readable-stream@^3.5.0, readable-stream@^3.6.0:
   version "3.6.0"
@@ -2495,14 +2476,6 @@ safe-buffer@~5.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
-
-scheduler@^0.19.1:
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
-  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 semver@^6.0.0, semver@^6.3.0:
   version "6.3.0"

--- a/src-v5/new/carousel.tsx
+++ b/src-v5/new/carousel.tsx
@@ -1,11 +1,24 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Slide from './slide';
 import { getSliderListStyles } from './slider-list';
-import { CarouselProps } from './types';
+import { CarouselProps, Directions } from './types';
 import renderControls from './controls';
 import defaultProps from './default-carousel-props';
 
 const Carousel = (props: CarouselProps): React.ReactElement => {
+  const [currentSlide, setCurrentSlide] = useState<number>(0);
+  const [direction, setDirection] = useState<Directions | null>(null);
+
+  const nextSlide = () => {
+    setDirection(Directions.Next);
+    setCurrentSlide(currentSlide + 1);
+  };
+
+  const prevSlide = () => {
+    setDirection(Directions.Prev);
+    setCurrentSlide(currentSlide - 1);
+  };
+
   const count = React.Children.count(props.children);
   const slides = React.Children.map(props.children, (child, index) => (
     <Slide key={index} count={count}>
@@ -19,20 +32,23 @@ const Carousel = (props: CarouselProps): React.ReactElement => {
       style={{
         overflow: 'hidden',
         width: '100%',
-        position: 'relative'
+        position: 'relative',
+        ...props.style
       }}
     >
       <div
         className="slider-list"
         style={getSliderListStyles(
           props.children,
+          direction,
+          currentSlide,
           props.slidesToShow,
           props.cellAlign
         )}
       >
         {slides}
       </div>
-      {renderControls(props, count)}
+      {renderControls(props, count, currentSlide, nextSlide, prevSlide)}
     </div>
   );
 };

--- a/src-v5/new/controls.tsx
+++ b/src-v5/new/controls.tsx
@@ -18,9 +18,15 @@ const controlsMap: ControlMap = [
 
 const renderControls = (
   props: CarouselProps,
-  count: number
-): React.ReactElement[] =>
-  controlsMap.map((control) => {
+  count: number,
+  currentSlide: number,
+  nextSlide: () => void,
+  prevSlide: () => void
+): React.ReactElement[] | null => {
+  if (props.withoutControls) {
+    return null;
+  }
+  return controlsMap.map((control) => {
     if (
       !props[control.funcName] ||
       typeof props[control.funcName] !== 'function'
@@ -44,16 +50,13 @@ const renderControls = (
         {props[control.funcName]?.({
           cellAlign: props.cellAlign,
           cellSpacing: props.cellSpacing,
-          // currentSlide: state.currentSlide,
-          currentSlide: 0,
+          currentSlide,
           defaultControlsConfig: props.defaultControlsConfig || {},
           // frameWidth: state.frameWidth, // but why?
           // goToSlide: (index) => goToSlide(index),
-          // nextSlide: () => nextSlide(),
-          // previousSlide: () => previousSlide(),
           goToSlide: () => {},
-          nextSlide: () => {},
-          previousSlide: () => {},
+          nextSlide: () => nextSlide(),
+          previousSlide: () => prevSlide(),
           scrollMode: props.scrollMode,
           slideCount: count,
           slidesToScroll: props.slidesToScroll,
@@ -65,5 +68,6 @@ const renderControls = (
       </div>
     );
   });
+};
 
 export default renderControls;

--- a/src-v5/new/default-controls.tsx
+++ b/src-v5/new/default-controls.tsx
@@ -42,51 +42,28 @@ export const PreviousButton = (props: ControlProps) => {
   );
 };
 
-// But why???
 export const nextButtonDisabled = ({
-  cellAlign,
-  cellSpacing,
   currentSlide,
-  positionValue,
   slideCount,
   slidesToShow,
-  wrapAround,
-  scrollMode,
-  slidesToScroll
-}: ControlProps & { positionValue: number }) => {
-  let buttonDisabled = false;
-
-  if (!wrapAround) {
-    // const alignmentOffset = getAlignmentOffset(currentSlide, {
-    //   cellAlign,
-    //   cellSpacing,
-    //   frameWidth,
-    //   slideWidth
-    // });
-    const alignmentOffset = 0;
-
-    const relativePosition = positionValue - alignmentOffset;
-
-    // const width = slideWidth + cellSpacing;
-    const width = cellSpacing;
-    const endOffset =
-      cellAlign === 'center' ? 2 * alignmentOffset : alignmentOffset;
-    const endPosition = -width * slideCount + width * slidesToShow - endOffset;
-
-    buttonDisabled =
-      relativePosition < endPosition ||
-      Math.abs(relativePosition - endPosition) < 0.01;
+  wrapAround
+}: ControlProps) => {
+  // inifite carousel with visible slides that are less than all slides
+  if (wrapAround && slidesToShow < slideCount) {
+    return false;
   }
-  // return true if its last slide or slideCount =0
-  const lastSlide =
-    currentSlide > 0 && currentSlide + slidesToScroll >= slideCount;
-  if (
-    (lastSlide && !wrapAround && scrollMode === 'remainder') ||
-    slideCount === 0
-  ) {
-    return (buttonDisabled = true);
+
+  // inifite carousel with visible slide equal or less than all slides
+  if (wrapAround) {
+    return true;
   }
-  return buttonDisabled;
+
+  // if the last slide is not visible return false (button is not disabled)
+  if (currentSlide + slidesToShow < slideCount) {
+    return false;
+  }
+
+  return true;
 };
 
 export const NextButton = (props: ControlProps) => {
@@ -103,11 +80,7 @@ export const NextButton = (props: ControlProps) => {
     nextButtonText
   } = defaultControlsConfig;
 
-  const disabled = nextButtonDisabled({
-    ...props,
-    // positionValue: vertical ? top : left
-    positionValue: 0
-  });
+  const disabled = nextButtonDisabled(props);
 
   return (
     <button

--- a/src-v5/new/slider-list.ts
+++ b/src-v5/new/slider-list.ts
@@ -1,5 +1,5 @@
 import React, { CSSProperties, ReactNode } from 'react';
-import { Alignment } from './types';
+import { Alignment, Directions } from './types';
 
 const getSliderListWidth = (count: number, slidesToShow?: number): string => {
   const visibleSlides = slidesToShow || 1;
@@ -7,23 +7,50 @@ const getSliderListWidth = (count: number, slidesToShow?: number): string => {
   return `${(count * 100) / visibleSlides}%`;
 };
 
-const getInitialPositioning = (
+const getTransition = (
+  count: number,
+  direction: Directions | null,
+  initialValue: number,
+  currentSlide: number
+): number => {
+  const slideTransition = (100 / count) * currentSlide;
+  const fullTransition = slideTransition; // multiply with slidesToScroll
+
+  if (direction === Directions.Next || direction === Directions.Prev) {
+    return -(fullTransition + initialValue);
+  }
+
+  return initialValue;
+};
+
+const getPositioning = (
   cellAlign: 'left' | 'right' | 'center',
   slidesToShow: number,
-  count: number
+  count: number,
+  direction: Directions | null,
+  currentSlide: number
 ): string => {
   if (!cellAlign || cellAlign === Alignment.Left) {
-    return 'translate3d(0, 0, 0)';
+    const horizontalMove = getTransition(count, direction, 0, currentSlide);
+    return `translate3d(${horizontalMove}%, 0, 0)`;
   }
   if (cellAlign === Alignment.Right) {
-    const right =
-      slidesToShow > 1 ? `${(100 / count) * (slidesToShow - 1)}%` : 0;
-    return `translate3d(${right}, 0, 0)`;
+    const right = slidesToShow > 1 ? (100 / count) * (slidesToShow - 1) : 0;
+
+    const horizontalMove = getTransition(count, direction, right, currentSlide);
+    return `translate3d(${horizontalMove}%, 0, 0)`;
   }
   if (cellAlign === Alignment.Center) {
     const center =
-      slidesToShow > 1 ? `${(100 / count) * Math.floor(slidesToShow / 2)}%` : 0;
-    return `translate3d(${center}, 0, 0)`;
+      slidesToShow > 1 ? (100 / count) * Math.floor(slidesToShow / 2) : 0;
+
+    const horizontalMove = getTransition(
+      count,
+      direction,
+      center,
+      currentSlide
+    );
+    return `translate3d(${horizontalMove}%, 0, 0)`;
   }
 
   return 'translate3d(0, 0, 0)';
@@ -31,21 +58,26 @@ const getInitialPositioning = (
 
 export const getSliderListStyles = (
   children: ReactNode | ReactNode[],
+  direction: Directions | null,
+  currentSlide: number,
   slidesToShow?: number,
   cellAlign?: 'left' | 'right' | 'center'
 ): CSSProperties => {
   const count = React.Children.count(children);
 
   const width = getSliderListWidth(count, slidesToShow);
-  const initialPositioning = getInitialPositioning(
+  const positioning = getPositioning(
     cellAlign || Alignment.Left,
     slidesToShow || 1,
-    count
+    count,
+    direction,
+    currentSlide
   );
 
   return {
     width,
     textAlign: 'left',
-    transform: initialPositioning
+    transition: '500ms ease 0s',
+    transform: positioning
   };
 };

--- a/src-v5/new/types.ts
+++ b/src-v5/new/types.ts
@@ -13,6 +13,13 @@ export enum Alignment {
   Left = 'left'
 }
 
+export enum Directions {
+  Next = 'next',
+  Prev = 'prev',
+  Up = 'up',
+  Down = 'down'
+}
+
 export enum Positions {
   TopLeft = 'TopLeft',
   TopCenter = 'TopCenter',
@@ -182,9 +189,9 @@ export interface CarouselProps {
   autoplayInterval: number;
   autoplayReverse: boolean;
   beforeSlide: (currentSlideIndex: number, endSlideIndex: number) => void;
-  cellAlign: Alignment;
+  cellAlign: Alignment; // migrated
   cellSpacing: number;
-  children: ReactNode | ReactNode[];
+  children: ReactNode | ReactNode[]; // migrated
   className?: string;
   defaultControlsConfig: DefaultControlsConfig;
   disableAnimation: boolean;
@@ -195,10 +202,10 @@ export interface CarouselProps {
   enableKeyboardControls: boolean;
   framePadding: string;
   getControlsContainerStyles: (key: Positions) => CSSProperties;
-  height: string;
-  heightMode: HeightMode;
-  initialSlideHeight?: number;
-  initialSlideWidth?: number;
+  height: string; // to be deprecated
+  heightMode: HeightMode; // to be deprecated
+  initialSlideHeight?: number; // to be deprecated
+  initialSlideWidth?: number; // to be deprecated
   innerRef?: MutableRefObject<HTMLDivElement>;
   keyCodeConfig: KeyCodeConfig;
   onDragStart: (
@@ -208,29 +215,29 @@ export interface CarouselProps {
   opacityScale?: number;
   pauseOnHover: boolean;
   renderAnnounceSlideMessage?: RenderAnnounceSlideMessage; // change it to be mandatory when you update the default prop
-  renderBottomCenterControls: RenderControls;
-  renderBottomLeftControls?: RenderControls;
-  renderBottomRightControls?: RenderControls;
-  renderCenterCenterControls?: RenderControls;
-  renderCenterLeftControls: RenderControls;
-  renderCenterRightControls: RenderControls;
-  renderTopCenterControls?: RenderControls;
-  renderTopLeftControls?: RenderControls;
-  renderTopRightControls?: RenderControls;
+  renderBottomCenterControls: RenderControls; // migrated
+  renderBottomLeftControls?: RenderControls; // migrated
+  renderBottomRightControls?: RenderControls; // migrated
+  renderCenterCenterControls?: RenderControls; // migrated
+  renderCenterLeftControls: RenderControls; // migrated
+  renderCenterRightControls: RenderControls; // migrated
+  renderTopCenterControls?: RenderControls; // migrated
+  renderTopLeftControls?: RenderControls; // migrated
+  renderTopRightControls?: RenderControls; // migrated
   scrollMode: ScrollMode;
-  slideIndex: number;
-  slideListMargin: number;
+  slideIndex: number; // ???
+  slideListMargin: number; // ???
   slideOffset: number;
   slidesToScroll: number;
-  slidesToShow: number;
-  slideWidth: number | string;
+  slidesToShow: number; // migrated
+  slideWidth: number | string; // to be deprecated
   speed: number;
-  style: CSSProperties;
+  style: CSSProperties; // migrated
   swiping: boolean;
   transitionMode: TransitionMode;
   vertical: boolean;
-  width: string;
-  withoutControls: boolean;
+  width: string; // to be deprecated
+  withoutControls: boolean; // migrated
   wrapAround: boolean;
   zoomScale?: number;
 }


### PR DESCRIPTION
Migrated in this PR:

 - style prop for carousel list div. It'll be great to support styled-component, tailwind css and other css in js. Something for the future

https://user-images.githubusercontent.com/12056467/146393438-0e0984fa-89ca-4eb6-8323-1ecc07de53de.mov

 - Added next and prev button actions

Video:


Next PR:
- swiping
- autoplay