### PR TITLE
v5: support slidestoscroll and others

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -43,6 +43,7 @@
     "max-statements": 0,
     "no-invalid-this": 0,
     "@typescript-eslint/no-unused-vars": ["error"],
-    "@typescript-eslint/no-var-requires": 0
+    "@typescript-eslint/no-var-requires": 0,
+    "no-unused-expressions": 0
   }
 }

--- a/examples/nextjs/pages/index.tsx
+++ b/examples/nextjs/pages/index.tsx
@@ -42,7 +42,7 @@ const Home = () => {
 
       <main className={styles.main}>
         <h1>Nuka Carousel - SSR Example Formidable Labs</h1>
-        <Carousel slidesToShow={3} wrapAround >
+        <Carousel slidesToShow={3} wrapAround>
           {slides}
         </Carousel>
       </main>

--- a/src-v5/new/carousel.tsx
+++ b/src-v5/new/carousel.tsx
@@ -25,17 +25,22 @@ const Carousel = (props: CarouselProps): React.ReactElement => {
     ) {
       const [slide, endSlide] = getIndexes(
         currentSlide,
-        currentSlide + 1,
+        currentSlide + props.slidesToScroll,
         count
       );
       props.beforeSlide(slide, endSlide);
-      setAnimation(true);
+      !props.disableAnimation && setAnimation(true);
+
       setDirection(Directions.Next);
-      setCurrentSlide(currentSlide + 1);
-      setTimeout(() => {
-        props.afterSlide(currentSlide);
-        setAnimation(false);
-      }, props.speed || 500);
+      setCurrentSlide(currentSlide + props.slidesToScroll);
+
+      setTimeout(
+        () => {
+          props.afterSlide(currentSlide);
+          !props.disableAnimation && setAnimation(false);
+        },
+        !props.disableAnimation ? props.speed || 500 : 40
+      );
     }
   };
 
@@ -44,17 +49,20 @@ const Carousel = (props: CarouselProps): React.ReactElement => {
     if (!(props.autoplay && !props.wrapAround && currentSlide > 0)) {
       const [slide, endSlide] = getIndexes(
         currentSlide,
-        currentSlide - 1,
+        currentSlide - props.slidesToScroll,
         count
       );
       props.beforeSlide(slide, endSlide);
-      setAnimation(true);
+      !props.disableAnimation && setAnimation(true);
       setDirection(Directions.Prev);
-      setCurrentSlide(currentSlide - 1);
-      setTimeout(() => {
-        props.afterSlide(currentSlide);
-        setAnimation(false);
-      }, props.speed || 500);
+      setCurrentSlide(currentSlide - props.slidesToScroll);
+      setTimeout(
+        () => {
+          props.afterSlide(currentSlide);
+          !props.disableAnimation && setAnimation(false);
+        },
+        !props.disableAnimation ? props.speed || 500 : 40
+      ); // if animation is disabled decrease the speed to 40
     }
   };
 
@@ -83,17 +91,18 @@ const Carousel = (props: CarouselProps): React.ReactElement => {
   useEffect(() => {
     // makes the loop infinity
     if (props.wrapAround) {
-      const speed = props.speed || 500;
+      // if animation is disabled decrease the speed to 40
+      const speed = !props.disableAnimation ? props.speed || 500 : 40;
 
-      if (currentSlide === -props.slidesToShow) {
+      if (currentSlide <= -props.slidesToShow) {
         // prev
         setTimeout(() => {
-          setCurrentSlide(count - props.slidesToShow);
+          setCurrentSlide(count - -currentSlide);
         }, speed + 10);
-      } else if (currentSlide === count + props.slidesToShow) {
+      } else if (currentSlide >= count + props.slidesToShow) {
         // next
         setTimeout(() => {
-          setCurrentSlide(props.slidesToShow);
+          setCurrentSlide(currentSlide - count);
         }, speed + 10);
       }
     }
@@ -118,6 +127,7 @@ const Carousel = (props: CarouselProps): React.ReactElement => {
         count={count}
         typeOfSlide={typeOfSlide}
         wrapAround={props.wrapAround}
+        cellSpacing={props.cellSpacing}
       >
         {child}
       </Slide>
@@ -145,6 +155,7 @@ const Carousel = (props: CarouselProps): React.ReactElement => {
           props.children,
           direction,
           currentSlide,
+          props.slidesToScroll,
           animation,
           props.slidesToShow,
           props.cellAlign,

--- a/src-v5/new/controls.tsx
+++ b/src-v5/new/controls.tsx
@@ -52,7 +52,6 @@ const renderControls = (
           cellSpacing: props.cellSpacing,
           currentSlide,
           defaultControlsConfig: props.defaultControlsConfig || {},
-          // frameWidth: state.frameWidth, // but why?
           // goToSlide: (index) => goToSlide(index),
           goToSlide: () => {},
           nextSlide: () => nextSlide(),
@@ -61,7 +60,6 @@ const renderControls = (
           slideCount: count,
           slidesToScroll: props.slidesToScroll,
           slidesToShow: props.slidesToShow || 1,
-          // slideWidth: props.slideWidth,
           vertical: props.vertical,
           wrapAround: props.wrapAround
         })}

--- a/src-v5/new/default-carousel-props.tsx
+++ b/src-v5/new/default-carousel-props.tsx
@@ -37,9 +37,6 @@ const defaultProps = {
   onDragStart: () => {
     // do nothing
   },
-  onResize: () => {
-    // do nothing
-  },
   pauseOnHover: true,
   // renderAnnounceSlideMessage: defaultRenderAnnounceSlideMessage, // uncomment when is ready
   renderBottomCenterControls: (props: ControlProps) => (
@@ -51,7 +48,6 @@ const defaultProps = {
   renderCenterRightControls: (props: ControlProps) => <NextButton {...props} />,
   scrollMode: ScrollMode.Remainder,
   slideIndex: 0,
-  slideListMargin: 10,
   slideOffset: 25,
   slidesToScroll: 1,
   slidesToShow: 1,

--- a/src-v5/new/slide.tsx
+++ b/src-v5/new/slide.tsx
@@ -3,13 +3,18 @@ import React, { CSSProperties, ReactNode } from 'react';
 const getSlideWidth = (count: number, wrapAround?: boolean): string =>
   `${wrapAround ? 100 / (3 * count) : 100 / count}%`;
 
-const getSlideStyles = (count: number, wrapAround?: boolean): CSSProperties => {
+const getSlideStyles = (
+  count: number,
+  wrapAround?: boolean,
+  cellSpacing?: number
+): CSSProperties => {
   const width = getSlideWidth(count, wrapAround);
 
   return {
     width,
     height: '100%',
-    display: 'inline-block'
+    display: 'inline-block',
+    padding: `0 ${cellSpacing ? cellSpacing / 2 : 0}px`
   };
 };
 
@@ -17,16 +22,18 @@ const Slide = ({
   count,
   children,
   typeOfSlide,
-  wrapAround
+  wrapAround,
+  cellSpacing
 }: {
   count: number;
   children: ReactNode | ReactNode[];
   typeOfSlide?: 'prev-cloned' | 'next-cloned';
   wrapAround?: boolean;
+  cellSpacing?: number;
 }): JSX.Element => (
   <div
     className={`slide ${typeOfSlide || ''}`}
-    style={getSlideStyles(count, wrapAround)}
+    style={getSlideStyles(count, wrapAround, cellSpacing)}
   >
     {children}
   </div>

--- a/src-v5/new/slider-list.ts
+++ b/src-v5/new/slider-list.ts
@@ -21,20 +21,19 @@ const getTransition = (
   direction: Directions | null,
   initialValue: number,
   currentSlide: number,
+  slidesToScroll: number,
   wrapAround?: boolean
 ): number => {
   if (direction === Directions.Next || direction === Directions.Prev) {
     if (wrapAround) {
       const slideTransition = 100 / (3 * count);
-      const fullTransition = slideTransition; // multiply with slidesToScroll
       const currentTransition =
         initialValue - slideTransition * (currentSlide - 1);
 
-      return currentTransition - fullTransition;
+      return currentTransition - slideTransition;
     }
     const slideTransition = (100 / count) * currentSlide;
-    const fullTransition = slideTransition; // multiply with slidesToScroll
-    return -(fullTransition + initialValue);
+    return -(slideTransition + initialValue);
   }
 
   return initialValue;
@@ -43,6 +42,7 @@ const getTransition = (
 const getPositioning = (
   cellAlign: 'left' | 'right' | 'center',
   slidesToShow: number,
+  slidesToScroll: number,
   count: number,
   direction: Directions | null,
   currentSlide: number,
@@ -55,6 +55,7 @@ const getPositioning = (
       direction,
       initialValue,
       currentSlide,
+      slidesToScroll,
       wrapAround
     );
     return `translate3d(${horizontalMove}%, 0, 0)`;
@@ -74,6 +75,7 @@ const getPositioning = (
       direction,
       initialValue,
       currentSlide,
+      slidesToScroll,
       wrapAround
     );
     return `translate3d(${horizontalMove}%, 0, 0)`;
@@ -95,6 +97,7 @@ const getPositioning = (
       direction,
       initialValue,
       currentSlide,
+      slidesToScroll,
       wrapAround
     );
     return `translate3d(${horizontalMove}%, 0, 0)`;
@@ -107,6 +110,7 @@ export const getSliderListStyles = (
   children: ReactNode | ReactNode[],
   direction: Directions | null,
   currentSlide: number,
+  slidesToScroll: number,
   animation: boolean,
   slidesToShow?: number,
   cellAlign?: 'left' | 'right' | 'center',
@@ -119,6 +123,7 @@ export const getSliderListStyles = (
   const positioning = getPositioning(
     cellAlign || Alignment.Left,
     slidesToShow || 1,
+    slidesToScroll,
     count,
     direction,
     currentSlide,

--- a/src-v5/new/types.ts
+++ b/src-v5/new/types.ts
@@ -190,17 +190,17 @@ export interface CarouselProps {
   autoplayReverse: boolean; // migrated
   beforeSlide: (currentSlideIndex: number, endSlideIndex: number) => void; // migrated
   cellAlign: Alignment; // migrated
-  cellSpacing: number;
+  cellSpacing: number; // migrated
   children: ReactNode | ReactNode[]; // migrated
   className?: string; // migrated
-  defaultControlsConfig: DefaultControlsConfig;
-  disableAnimation: boolean;
+  defaultControlsConfig: DefaultControlsConfig; // migrated, needs more testing
+  disableAnimation: boolean; // migrated
   disableEdgeSwiping: boolean;
   dragging: boolean;
   easing: D3EasingFunctions;
   edgeEasing: D3EasingFunctions;
   enableKeyboardControls: boolean;
-  framePadding: string;
+  framePadding: string; // to be deprecated
   getControlsContainerStyles: (key: Positions) => CSSProperties;
   height: string; // to be deprecated
   heightMode: HeightMode; // to be deprecated
@@ -211,7 +211,6 @@ export interface CarouselProps {
   onDragStart: (
     e: React.TouchEvent<HTMLDivElement> | React.MouseEvent<HTMLDivElement>
   ) => void;
-  onResize: () => void;
   opacityScale?: number;
   pauseOnHover: boolean; // migrated
   renderAnnounceSlideMessage?: RenderAnnounceSlideMessage; // change it to be mandatory when you update the default prop
@@ -225,10 +224,9 @@ export interface CarouselProps {
   renderTopLeftControls?: RenderControls; // migrated
   renderTopRightControls?: RenderControls; // migrated
   scrollMode: ScrollMode;
-  slideIndex: number; // ???
-  slideListMargin: number; // ???
+  slideIndex: number; // to be deprecated
   slideOffset: number;
-  slidesToScroll: number;
+  slidesToScroll: number; // migrated
   slidesToShow: number; // migrated
   slideWidth: number | string; // to be deprecated
   speed: number; // migrated
@@ -251,7 +249,6 @@ export type TransitionProps = Pick<
   | 'dragging'
   | 'heightMode'
   | 'opacityScale'
-  | 'slideListMargin'
   | 'slideOffset'
   | 'slidesToScroll'
   | 'vertical'


### PR DESCRIPTION
Migrated to V5:
- defaultControlsConfig
- cellSpacing
- slidesToScroll
- disableAnimation

Deprecated and removed in V5:
- slideListMargin
- onResize
Both are not documented and not needed in the new version of the library. The carousel is fully responsive now and margins and paddings can be added with `className` or `style` property or wrapping the carousel in custom div.