### PR TITLE
V5: keyboard controls & transition mode migration

### DIFF
--- a/examples/nextjs/pages/index.tsx
+++ b/examples/nextjs/pages/index.tsx
@@ -42,7 +42,7 @@ const Home = () => {
 
       <main className={styles.main}>
         <h1>Nuka Carousel - SSR Example Formidable Labs</h1>
-        <Carousel slidesToShow={3} wrapAround>
+        <Carousel slidesToShow={3} wrapAround animation='fade'>
           {slides}
         </Carousel>
       </main>

--- a/examples/nextjs/pages/index.tsx
+++ b/examples/nextjs/pages/index.tsx
@@ -42,7 +42,7 @@ const Home = () => {
 
       <main className={styles.main}>
         <h1>Nuka Carousel - SSR Example Formidable Labs</h1>
-        <Carousel slidesToShow={3} wrapAround animation='fade'>
+        <Carousel slidesToShow={3} wrapAround>
           {slides}
         </Carousel>
       </main>

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@types/d3-ease": "^3.0.0",
     "@types/exenv": "^1.2.0",
     "@types/react": "^16.9.56",
+    "@types/react-dom": "^17.0.11",
     "@typescript-eslint/eslint-plugin": "^5.5.0",
     "@typescript-eslint/parser": "^5.5.0",
     "babel-loader": "8.1.0",

--- a/src-v5/new/carousel.tsx
+++ b/src-v5/new/carousel.tsx
@@ -162,7 +162,11 @@ const Carousel = (props: CarouselProps): React.ReactElement => {
     ) {
       const keyConfig = props.keyCodeConfig;
       for (const func in keyConfig) {
-        if (keyConfig[func].includes((e as KeyboardEvent).keyCode)) {
+        if (
+          keyConfig[func as keyof typeof keyConfig]?.includes(
+            (e as KeyboardEvent).keyCode
+          )
+        ) {
           setKeyboardMove(func as KeyCodeFunction);
         }
       }

--- a/src-v5/new/carousel.tsx
+++ b/src-v5/new/carousel.tsx
@@ -1,10 +1,12 @@
+/* eslint-disable complexity */
+
 import React, { useEffect, useState, useRef } from 'react';
 import Slide from './slide';
 import { getSliderListStyles } from './slider-list';
-import { CarouselProps, Directions } from './types';
+import { CarouselProps, Directions, KeyCodeFunction } from './types';
 import renderControls from './controls';
 import defaultProps from './default-carousel-props';
-import { getIndexes } from './utils';
+import { getIndexes, addEvent, removeEvent } from './utils';
 import AnnounceSlide from './announce-slide';
 
 const Carousel = (props: CarouselProps): React.ReactElement => {
@@ -14,11 +16,14 @@ const Carousel = (props: CarouselProps): React.ReactElement => {
   const [pause, setPause] = useState<boolean>(false);
   const [dragging, setDragging] = useState<boolean>(false);
   const [move, setMove] = useState<number>(0);
+  const [keyboardMove, setKeyboardMove] = useState<KeyCodeFunction>(null);
   const carouselWidth = useRef<number | null>(null);
-  const prevMove = useRef<number>(0);
-  const carouselEl = useRef<HTMLDivElement>(null);
 
   const count = React.Children.count(props.children);
+
+  const focus = useRef<boolean>(false);
+  const prevMove = useRef<number>(0);
+  const carouselEl = useRef<HTMLDivElement>(null);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const nextSlide = () => {
@@ -118,11 +123,63 @@ const Carousel = (props: CarouselProps): React.ReactElement => {
   }, [currentSlide]);
 
   useEffect(() => {
+    if (props.enableKeyboardControls && keyboardMove && focus.current) {
+      switch (keyboardMove) {
+        case 'nextSlide':
+          nextSlide(); // set boundaries for !wrapAround
+          break;
+        case 'previousSlide':
+          prevSlide(); // set boundaries for !wrapAround
+          break;
+        case 'firstSlide':
+          setCurrentSlide(0);
+          break;
+        case 'lastSlide':
+          setCurrentSlide(count - props.slidesToShow);
+          break;
+        case 'pause':
+          if (pause && props.autoplay) {
+            setPause(false);
+            break;
+          } else if (props.autoplay) {
+            setPause(true);
+            break;
+          }
+          break;
+      }
+      setKeyboardMove(null);
+    }
+  }, [keyboardMove]);
+
+  const onKeyPress = (e: Event) => {
+    if (
+      props.enableKeyboardControls &&
+      focus.current &&
+      (e as KeyboardEvent).keyCode
+    ) {
+      const keyConfig = props.keyCodeConfig;
+      for (const func in keyConfig) {
+        if (keyConfig[func].includes((e as KeyboardEvent).keyCode)) {
+          setKeyboardMove(func as KeyCodeFunction);
+        }
+      }
+    }
+  };
+
+  useEffect(() => {
     if (carouselEl && carouselEl.current) {
       carouselWidth.current = carouselEl.current.offsetWidth;
     } else if (props.innerRef) {
       carouselWidth.current = props.innerRef.current.offsetWidth;
     }
+
+    if (props.enableKeyboardControls) {
+      addEvent(document, 'keydown', onKeyPress);
+    }
+
+    return () => {
+      removeEvent(document, 'keydown', onKeyPress);
+    };
   }, []);
 
   const onTouchStart = () => {
@@ -161,19 +218,31 @@ const Carousel = (props: CarouselProps): React.ReactElement => {
     if (dragging) {
       const moveValue = (carouselWidth?.current || 0) - e.touches[0].pageX;
       const newPrevValue = moveValue - prevMove.current;
-
       props.onDragStart(e);
-      setMove(
+
+      const moveState =
         newPrevValue > 20 && newPrevValue > -20
           ? move + 20
-          : move + newPrevValue
-      );
+          : move + newPrevValue;
+
+      if (
+        !props.wrapAround &&
+        props.disableEdgeSwiping &&
+        ((currentSlide <= 0 && moveState <= 0) ||
+          (moveState > 0 && currentSlide >= count - props.slidesToShow))
+      ) {
+        return;
+      }
+
+      setMove(moveState);
       prevMove.current = moveValue;
     }
   };
 
   const onMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
     e?.preventDefault();
+    const carouselRef = props.innerRef || carouselEl;
+    carouselRef?.current?.focus();
 
     if (!props.dragging) {
       return;
@@ -181,6 +250,7 @@ const Carousel = (props: CarouselProps): React.ReactElement => {
 
     setDragging(true);
   };
+
   const onMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
     if (!props.dragging) {
       return;
@@ -194,11 +264,21 @@ const Carousel = (props: CarouselProps): React.ReactElement => {
 
       props.onDragStart(e);
 
-      setMove(
+      const moveState =
         newPrevValue > 20 && newPrevValue > -20
           ? move + 20
-          : move + newPrevValue
-      );
+          : move + newPrevValue;
+
+      if (
+        !props.wrapAround &&
+        props.disableEdgeSwiping &&
+        ((currentSlide <= 0 && moveState <= 0) ||
+          (moveState > 0 && currentSlide >= count - props.slidesToShow))
+      ) {
+        return;
+      }
+
+      setMove(moveState);
       prevMove.current = moveValue;
     }
   };
@@ -239,27 +319,33 @@ const Carousel = (props: CarouselProps): React.ReactElement => {
   };
 
   const renderSlides = (typeOfSlide?: 'prev-cloned' | 'next-cloned') => {
-    const slides = React.Children.map(props.children, (child, index) => (
-      <Slide
-        key={index}
-        count={count}
-        isCurrentSlide={
-          props.wrapAround
-            ? currentSlide === index ||
-              currentSlide === index + count ||
-              currentSlide === index - count
-            : currentSlide === index
-        }
-        typeOfSlide={typeOfSlide}
-        wrapAround={props.wrapAround}
-        cellSpacing={props.cellSpacing}
-        animation={props.animation}
-        speed={props.speed}
-        zoomScale={props.zoomScale}
-      >
-        {child}
-      </Slide>
-    ));
+    const slides = React.Children.map(props.children, (child, index) => {
+      const isCurrentSlide = props.wrapAround
+        ? currentSlide === index ||
+          currentSlide === index + count ||
+          currentSlide === index - count
+        : currentSlide === index;
+
+      return (
+        <Slide
+          key={`${typeOfSlide}-${index}`}
+          count={count}
+          currentSlide={currentSlide}
+          index={index}
+          isCurrentSlide={isCurrentSlide}
+          typeOfSlide={typeOfSlide}
+          wrapAround={props.wrapAround}
+          cellSpacing={props.cellSpacing}
+          animation={props.animation}
+          slidesToShow={props.slidesToShow}
+          speed={props.speed}
+          zoomScale={props.zoomScale}
+          cellAlign={props.cellAlign}
+        >
+          {child}
+        </Slide>
+      );
+    });
 
     return slides;
   };
@@ -269,6 +355,7 @@ const Carousel = (props: CarouselProps): React.ReactElement => {
     currentSlide - props.slidesToScroll,
     count
   );
+
   return (
     <div
       style={{
@@ -290,8 +377,14 @@ const Carousel = (props: CarouselProps): React.ReactElement => {
           overflow: 'hidden',
           width: '100%',
           position: 'relative',
+          outline: 'none',
           ...props.style
         }}
+        aria-label="carousel-slider"
+        role="region"
+        tabIndex={0}
+        onFocus={() => (focus.current = true)}
+        onBlur={() => (focus.current = false)}
         ref={props.innerRef || carouselEl}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}

--- a/src-v5/new/carousel.tsx
+++ b/src-v5/new/carousel.tsx
@@ -26,6 +26,9 @@ const Carousel = (props: CarouselProps): React.ReactElement => {
   const carouselEl = useRef<HTMLDivElement>(null);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  const slidesToScroll =
+    props.animation === 'fade' ? props.slidesToShow : props.slidesToScroll;
+
   const nextSlide = () => {
     // TODO: change the boundary for cellAlign=center and right
     // boundary
@@ -38,7 +41,7 @@ const Carousel = (props: CarouselProps): React.ReactElement => {
     ) {
       const [slide, endSlide] = getIndexes(
         currentSlide,
-        currentSlide + props.slidesToScroll,
+        currentSlide + slidesToScroll,
         count
       );
 
@@ -46,7 +49,7 @@ const Carousel = (props: CarouselProps): React.ReactElement => {
       !props.disableAnimation && setAnimation(true);
 
       setDirection(Directions.Next);
-      setCurrentSlide(currentSlide + props.slidesToScroll);
+      setCurrentSlide(currentSlide + slidesToScroll);
 
       setTimeout(
         () => {
@@ -63,13 +66,13 @@ const Carousel = (props: CarouselProps): React.ReactElement => {
     if (!(props.autoplay && !props.wrapAround && currentSlide > 0)) {
       const [slide, endSlide] = getIndexes(
         currentSlide,
-        currentSlide - props.slidesToScroll,
+        currentSlide - slidesToScroll,
         count
       );
       props.beforeSlide(slide, endSlide);
       !props.disableAnimation && setAnimation(true);
       setDirection(Directions.Prev);
-      setCurrentSlide(currentSlide - props.slidesToScroll);
+      setCurrentSlide(currentSlide - slidesToScroll);
       setTimeout(
         () => {
           props.afterSlide(currentSlide);
@@ -352,7 +355,7 @@ const Carousel = (props: CarouselProps): React.ReactElement => {
 
   const [slide] = getIndexes(
     currentSlide,
-    currentSlide - props.slidesToScroll,
+    currentSlide - slidesToScroll,
     count
   );
 
@@ -406,7 +409,8 @@ const Carousel = (props: CarouselProps): React.ReactElement => {
             props.cellAlign,
             props.wrapAround,
             props.speed,
-            move
+            move,
+            props.animation
           )}
         >
           {props.wrapAround ? renderSlides('prev-cloned') : null}
@@ -414,7 +418,14 @@ const Carousel = (props: CarouselProps): React.ReactElement => {
           {props.wrapAround ? renderSlides('next-cloned') : null}
         </div>
       </div>
-      {renderControls(props, count, currentSlide, nextSlide, prevSlide)}
+      {renderControls(
+        props,
+        count,
+        currentSlide,
+        nextSlide,
+        prevSlide,
+        slidesToScroll
+      )}
     </div>
   );
 };

--- a/src-v5/new/controls.tsx
+++ b/src-v5/new/controls.tsx
@@ -21,7 +21,8 @@ const renderControls = (
   count: number,
   currentSlide: number,
   nextSlide: () => void,
-  prevSlide: () => void
+  prevSlide: () => void,
+  slidesToScroll: number
 ): React.ReactElement[] | null => {
   if (props.withoutControls) {
     return null;
@@ -58,7 +59,7 @@ const renderControls = (
           previousSlide: () => prevSlide(),
           scrollMode: props.scrollMode,
           slideCount: count,
-          slidesToScroll: props.slidesToScroll,
+          slidesToScroll,
           slidesToShow: props.slidesToShow || 1,
           vertical: props.vertical,
           wrapAround: props.wrapAround

--- a/src-v5/new/default-carousel-props.tsx
+++ b/src-v5/new/default-carousel-props.tsx
@@ -34,7 +34,13 @@ const defaultProps = {
   getControlsContainerStyles: () => ({}),
   height: 'inherit',
   heightMode: HeightMode.Max,
-  keyCodeConfig: {},
+  keyCodeConfig: {
+    nextSlide: [39, 68, 38, 87],
+    previousSlide: [37, 65, 40, 83],
+    firstSlide: [81],
+    lastSlide: [69],
+    pause: [32]
+  },
   onDragStart: () => {
     // do nothing
   },

--- a/src-v5/new/slide.tsx
+++ b/src-v5/new/slide.tsx
@@ -16,12 +16,14 @@ const getSlideStyles = (
 ): CSSProperties => {
   const width = getSlideWidth(count, wrapAround);
   const visibleSlideOpacity = isVisibleSlide ? 1 : 0;
+  const animationSpeed = animation === 'fade' ? 200 : 500;
+
   return {
     width,
     height: '100%',
     display: 'inline-block',
     padding: `0 ${cellSpacing ? cellSpacing / 2 : 0}px`,
-    transition: animation ? `${speed || 500}ms ease 0s` : 'none',
+    transition: animation ? `${speed || animationSpeed}ms ease 0s` : 'none',
     transform: `${
       animation === 'zoom'
         ? `scale(${isCurrentSlide ? 1 : zoomScale || 0.85})`

--- a/src-v5/new/slide.tsx
+++ b/src-v5/new/slide.tsx
@@ -1,4 +1,5 @@
 import React, { CSSProperties, ReactNode } from 'react';
+import { Alignment } from './types';
 
 const getSlideWidth = (count: number, wrapAround?: boolean): string =>
   `${wrapAround ? 100 / (3 * count) : 100 / count}%`;
@@ -6,14 +7,15 @@ const getSlideWidth = (count: number, wrapAround?: boolean): string =>
 const getSlideStyles = (
   count: number,
   isCurrentSlide: boolean,
+  isVisibleSlide: boolean,
   wrapAround?: boolean,
   cellSpacing?: number,
-  animation?: 'zoom',
+  animation?: 'zoom' | 'fade',
   speed?: number,
   zoomScale?: number
 ): CSSProperties => {
   const width = getSlideWidth(count, wrapAround);
-
+  const visibleSlideOpacity = isVisibleSlide ? 1 : 0;
   return {
     width,
     height: '100%',
@@ -21,46 +23,116 @@ const getSlideStyles = (
     padding: `0 ${cellSpacing ? cellSpacing / 2 : 0}px`,
     transition: animation ? `${speed || 500}ms ease 0s` : 'none',
     transform: `${
-      animation ? `scale(${isCurrentSlide ? 1 : zoomScale || 0.85})` : 'initial'
-    }`
+      animation === 'zoom'
+        ? `scale(${isCurrentSlide ? 1 : zoomScale || 0.85})`
+        : 'initial'
+    }`,
+    opacity: animation === 'fade' ? visibleSlideOpacity : 1
   };
+};
+
+const isVisibleSlide = (
+  currentSlide: number,
+  index: number,
+  slidesToShow: number,
+  cellAlign: Alignment
+) => {
+  if (slidesToShow === 1) {
+    return false;
+  }
+
+  if (cellAlign === Alignment.Left) {
+    return index < currentSlide + slidesToShow && index > currentSlide;
+  }
+
+  if (cellAlign === Alignment.Center) {
+    return (
+      (index >= currentSlide - slidesToShow / 2 && index < currentSlide) ||
+      (index > currentSlide && index <= currentSlide + slidesToShow / 2)
+    );
+  }
+
+  if (cellAlign === Alignment.Right) {
+    return index < currentSlide && index > currentSlide - slidesToShow;
+  }
+
+  return false;
+};
+
+const generateIndex = (
+  index: number,
+  count: number,
+  typeOfSlide?: 'prev-cloned' | 'next-cloned'
+): number => {
+  if (typeOfSlide === 'prev-cloned') {
+    return index - count;
+  }
+
+  if (typeOfSlide === 'next-cloned') {
+    return index + count;
+  }
+
+  return index;
 };
 
 const Slide = ({
   count,
   children,
+  currentSlide,
+  index,
   isCurrentSlide,
   typeOfSlide,
   wrapAround,
   cellSpacing,
   animation,
   speed,
-  zoomScale
+  slidesToShow,
+  zoomScale,
+  cellAlign
 }: {
   count: number;
   children: ReactNode | ReactNode[];
+  currentSlide: number;
+  index: number;
   isCurrentSlide: boolean;
   typeOfSlide?: 'prev-cloned' | 'next-cloned';
   wrapAround?: boolean;
   cellSpacing?: number;
-  animation?: 'zoom';
+  animation?: 'zoom' | 'fade';
   speed?: number;
+  slidesToShow: number;
   zoomScale?: number;
-}): JSX.Element => (
-  <div
-    className={`slide ${typeOfSlide || ''}`}
-    style={getSlideStyles(
-      count,
-      isCurrentSlide,
-      wrapAround,
-      cellSpacing,
-      animation,
-      speed,
-      zoomScale
-    )}
-  >
-    {children}
-  </div>
-);
+  cellAlign: Alignment;
+}): JSX.Element => {
+  const customIndex = wrapAround
+    ? generateIndex(index, count, typeOfSlide)
+    : index;
+  const isVisible = isVisibleSlide(
+    currentSlide,
+    customIndex,
+    slidesToShow,
+    cellAlign
+  );
+
+  return (
+    <div
+      className={`slide ${typeOfSlide || ''} ${
+        isCurrentSlide || isVisible ? 'slide-visible' : ''
+      }`}
+      style={getSlideStyles(
+        count,
+        isCurrentSlide,
+        isCurrentSlide || isVisible,
+        wrapAround,
+        cellSpacing,
+        animation,
+        speed,
+        zoomScale
+      )}
+    >
+      {children}
+    </div>
+  );
+};
 
 export default Slide;

--- a/src-v5/new/slider-list.ts
+++ b/src-v5/new/slider-list.ts
@@ -148,7 +148,8 @@ export const getSliderListStyles = (
   cellAlign?: 'left' | 'right' | 'center',
   wrapAround?: boolean,
   speed?: number,
-  move?: number
+  move?: number,
+  slideAnimation?: 'fade' | 'zoom'
 ): CSSProperties => {
   const count = React.Children.count(children);
 
@@ -166,7 +167,10 @@ export const getSliderListStyles = (
   return {
     width,
     textAlign: 'left',
-    transition: animation ? `${speed || 500}ms ease 0s` : 'none',
+    transition:
+      animation && slideAnimation !== 'fade'
+        ? `${speed || 500}ms ease 0s`
+        : 'none',
     transform: positioning
   };
 };

--- a/src-v5/new/types.ts
+++ b/src-v5/new/types.ts
@@ -119,6 +119,14 @@ export interface KeyCodeConfig {
   previousSlide?: number[];
 }
 
+export type KeyCodeFunction =
+  | 'nextSlide'
+  | 'previousSlide'
+  | 'firstSlide'
+  | 'lastSlide'
+  | 'pause'
+  | null;
+
 export interface KeyCodeMap {
   [key: number]: keyof KeyCodeConfig;
 }
@@ -183,8 +191,8 @@ type RenderControls = (props: ControlProps) => ReactElement;
 
 export interface CarouselProps {
   afterSlide: (index: number) => void; // migrated
-  animation?: 'zoom'; // migrated
-  autoGenerateStyleTag: boolean; // deprecated
+  animation?: 'zoom' | 'fade'; // migrated
+  autoGenerateStyleTag: boolean; // to be deprecated
   autoplay: boolean; // migrated
   autoplayInterval: number; // migrated
   autoplayReverse: boolean; // migrated
@@ -195,22 +203,22 @@ export interface CarouselProps {
   className?: string; // migrated
   defaultControlsConfig: DefaultControlsConfig; // migrated, needs more testing
   disableAnimation: boolean; // migrated
-  disableEdgeSwiping: boolean;
+  disableEdgeSwiping: boolean; // migrated
   dragging: boolean; // migrated
   easing: D3EasingFunctions;
   edgeEasing: D3EasingFunctions;
-  enableKeyboardControls: boolean;
+  enableKeyboardControls: boolean; // migrated
   framePadding: string; // to be deprecated
-  getControlsContainerStyles: (key: Positions) => CSSProperties;
+  getControlsContainerStyles: (key: Positions) => CSSProperties; // to be deprecated
   height: string; // to be deprecated
   heightMode: HeightMode; // to be deprecated
   initialSlideHeight?: number; // to be deprecated
   initialSlideWidth?: number; // to be deprecated
   innerRef?: MutableRefObject<HTMLDivElement>; // migrated
-  keyCodeConfig: KeyCodeConfig;
+  keyCodeConfig: KeyCodeConfig; // migrated
   onDragStart: (
     e: React.TouchEvent<HTMLDivElement> | React.MouseEvent<HTMLDivElement>
-  ) => void;
+  ) => void; // migrated
   opacityScale?: number;
   pauseOnHover: boolean; // migrated
   renderAnnounceSlideMessage: RenderAnnounceSlideMessage; // migrated
@@ -225,14 +233,14 @@ export interface CarouselProps {
   renderTopRightControls?: RenderControls; // migrated
   scrollMode: ScrollMode; // to be deprecated
   slideIndex: number; // to be deprecated
-  slideOffset: number;
+  slideOffset: number; // to be deprecated
   slidesToScroll: number; // migrated
   slidesToShow: number; // migrated
   slideWidth: number | string; // to be deprecated
   speed: number; // migrated
   style: CSSProperties; // migrated
   swiping: boolean; // migrated
-  transitionMode: TransitionMode;
+  transitionMode: TransitionMode; // to be deprecated
   vertical: boolean;
   width: string; // to be deprecated
   withoutControls: boolean; // migrated

--- a/src-v5/new/utils.ts
+++ b/src-v5/new/utils.ts
@@ -20,3 +20,37 @@ export const getIndexes = (
 
   return [slideIndex, endSlideIndex];
 };
+
+export const addEvent = (
+  elem: Window | Document,
+  type: string,
+  eventHandle: EventListener
+): void => {
+  if (elem === null || typeof elem === 'undefined') {
+    return;
+  }
+  if (elem.addEventListener) {
+    elem.addEventListener(type, eventHandle, false);
+  } else if (elem.attachEvent) {
+    elem.attachEvent(`on${type}`, eventHandle);
+  } else {
+    elem[`on${type}`] = eventHandle;
+  }
+};
+
+export const removeEvent = (
+  elem: Window | Document,
+  type: string,
+  eventHandle: EventListener
+): void => {
+  if (elem === null || typeof elem === 'undefined') {
+    return;
+  }
+  if (elem.removeEventListener) {
+    elem.removeEventListener(type, eventHandle, false);
+  } else if (elem.detachEvent) {
+    elem.detachEvent(`on${type}`, eventHandle);
+  } else {
+    elem[`on${type}`] = null;
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2772,6 +2772,13 @@
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
   integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
 
+"@types/react-dom@^17.0.11":
+  version "17.0.11"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.11.tgz#e1eadc3c5e86bdb5f7684e00274ae228e7bcc466"
+  integrity sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-syntax-highlighter@11.0.5":
   version "11.0.5"
   resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.5.tgz#0d546261b4021e1f9d85b50401c0a42acb106087"


### PR DESCRIPTION
Migrate:
 - disableEdgeSwiping
 - transitionMode = fade
 - enableKeyboardControls
 - keyCodeConfig

To be deprecated: 
- getControlsContainerStyles
- slideOffset
- transitionMode -> migrated to animation


Video of animation = fade:

https://user-images.githubusercontent.com/12056467/150093886-3f021fba-a227-42f7-bf8c-f1ced8e74492.mov


https://user-images.githubusercontent.com/12056467/150093903-c76baa00-35f0-466b-b7ca-dd43f22e2df0.mov


