### PR TITLE
Add support for event handlers for drag end and on drag

### DIFF
--- a/src-v5/carousel.tsx
+++ b/src-v5/carousel.tsx
@@ -212,10 +212,13 @@ export const Carousel = (props: CarouselProps): React.ReactElement => {
     };
   }, []);
 
-  const handleDragEnd = () => {
+  const handleDragEnd = (
+    e?: React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>
+  ) => {
     if (!props.dragging || !dragging) return;
 
     setDragging(false);
+    props.onDragEnd(e);
 
     if (Math.abs(move) <= dragThreshold) {
       moveSlide();
@@ -234,11 +237,12 @@ export const Carousel = (props: CarouselProps): React.ReactElement => {
     prevMove.current = 0;
   };
 
-  const onTouchStart = () => {
+  const onTouchStart = (e?: React.TouchEvent<HTMLDivElement>) => {
     if (!props.swiping) {
       return;
     }
     setDragging(true);
+    props.onDragStart(e);
   };
 
   const handlePointerMove = (m: number) => {
@@ -287,12 +291,13 @@ export const Carousel = (props: CarouselProps): React.ReactElement => {
     if (!props.dragging) return;
 
     setDragging(true);
+    props.onDragStart(e);
   };
 
   const onMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
     if (!props.dragging || !dragging) return;
 
-    props.onDragStart(e);
+    props.onDrag(e);
 
     const offsetX =
       e.clientX - (carouselRef.current?.getBoundingClientRect().left || 0);
@@ -301,9 +306,9 @@ export const Carousel = (props: CarouselProps): React.ReactElement => {
     handlePointerMove(moveValue);
   };
 
-  const onMouseUp = (e?: React.MouseEvent<HTMLDivElement>) => {
+  const onMouseUp = (e: React.MouseEvent<HTMLDivElement>) => {
     e?.preventDefault();
-    handleDragEnd();
+    handleDragEnd(e);
   };
 
   const onMouseEnter = () => {

--- a/src-v5/default-carousel-props.tsx
+++ b/src-v5/default-carousel-props.tsx
@@ -35,6 +35,12 @@ const defaultProps = {
   onDragStart: () => {
     // do nothing
   },
+  onDrag: () => {
+    // do nothing
+  },
+  onDragEnd: () => {
+    // do nothing
+  },
   pauseOnHover: true,
   renderAnnounceSlideMessage: defaultRenderAnnounceSlideMessage,
   renderBottomCenterControls: (props: ControlProps) => (

--- a/src-v5/types.ts
+++ b/src-v5/types.ts
@@ -200,8 +200,14 @@ export interface CarouselProps {
   innerRef?: MutableRefObject<HTMLDivElement>; // migrated
   keyCodeConfig: KeyCodeConfig; // migrated
   onDragStart: (
-    e: React.TouchEvent<HTMLDivElement> | React.MouseEvent<HTMLDivElement>
+    e?: React.TouchEvent<HTMLDivElement> | React.MouseEvent<HTMLDivElement>
   ) => void; // migrated
+  onDrag: (
+    e?: React.TouchEvent<HTMLDivElement> | React.MouseEvent<HTMLDivElement>
+  ) => void;
+  onDragEnd: (
+    e?: React.TouchEvent<HTMLDivElement> | React.MouseEvent<HTMLDivElement>
+  ) => void;
   opacityScale?: number;
   pauseOnHover: boolean; // migrated - tested
   renderAnnounceSlideMessage: RenderAnnounceSlideMessage; // migrated


### PR DESCRIPTION
### Description

Currently the drag start handler gets called for all drag movements. This PR separates out drag start, onDrag, and drag end into 3 different handlers. This lets the consumer add interactivity or disable interactivity when the user is swiping. 


#### Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### How Has This Been Tested?

Using the Next example and ensuring the correct methods are called the correct number of times.

- dragStart should only ever get called once per drag
- onDrag should get called several times as the user swipes
- dragEnd should only ever get called once per drag

<img width="607" alt="Screen Shot 2022-03-06 at 3 23 49 PM" src="https://user-images.githubusercontent.com/1738349/156942924-4bbbbe2f-a153-4ac9-8911-4f550810d98d.png">

