### PR TITLE
fix: ensure after slide index is correct

### DIFF
--- a/src-v5/carousel.tsx
+++ b/src-v5/carousel.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable complexity */
 
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState, useRef, useCallback } from "react";
 import Slide from './slide';
 import { getSliderListStyles } from './slider-list';
 import { CarouselProps, KeyCodeFunction } from './types';
@@ -41,14 +41,8 @@ export const Carousel = (props: CarouselProps): React.ReactElement => {
 
   const carouselRef = props.innerRef || carouselEl;
 
-  const moveSlide = (to?: number) => {
-    const [slide] = getIndexes(
-      currentSlide,
-      currentSlide - slidesToScroll,
-      count
-    );
-
-    const nextIndex = () => {
+  const getNextIndex = useCallback(
+    (to?: number) => {
       const index = to ?? currentSlide;
       if (index < 0) {
         return index + count;
@@ -57,15 +51,25 @@ export const Carousel = (props: CarouselProps): React.ReactElement => {
         return 0;
       }
       return index;
-    };
+    },
+    [count, currentSlide]
+  );
 
-    typeof to === 'number' && props.beforeSlide(slide, nextIndex());
+  const moveSlide = (to?: number) => {
+    const [slide] = getIndexes(
+      currentSlide,
+      currentSlide - slidesToScroll,
+      count
+    );
+
+    const nextIndex = getNextIndex(to);
+    typeof to === 'number' && props.beforeSlide(slide, nextIndex);
     !props.disableAnimation && setAnimation(true);
     setCurrentSlide(to ?? currentSlide);
     setTimeout(
       () => {
         if (!isMounted.current) return;
-        typeof to === 'number' && props.afterSlide(nextIndex());
+        typeof to === 'number' && props.afterSlide(nextIndex);
         !props.disableAnimation && setAnimation(false);
       },
       !props.disableAnimation ? props.speed || 500 : 40

--- a/src-v5/carousel.tsx
+++ b/src-v5/carousel.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable complexity */
 
-import React, { useEffect, useState, useRef, useCallback } from "react";
+import React, { useEffect, useState, useRef, useCallback } from 'react';
 import Slide from './slide';
 import { getSliderListStyles } from './slider-list';
 import { CarouselProps, KeyCodeFunction } from './types';

--- a/src-v5/carousel.tsx
+++ b/src-v5/carousel.tsx
@@ -49,12 +49,20 @@ export const Carousel = (props: CarouselProps): React.ReactElement => {
     );
     to && props.beforeSlide(slide, endSlide);
     !props.disableAnimation && setAnimation(true);
-
     setCurrentSlide(to ?? currentSlide);
     setTimeout(
       () => {
         if (!isMounted.current) return;
-        to && props.afterSlide(currentSlide);
+
+        let nextIndex = to ?? currentSlide;
+        if (nextIndex < 0) {
+          nextIndex += count;
+        }
+        if (nextIndex === count) {
+          nextIndex = 0;
+        }
+
+        typeof to === 'number' && props.afterSlide(nextIndex);
         !props.disableAnimation && setAnimation(false);
       },
       !props.disableAnimation ? props.speed || 500 : 40

--- a/src-v5/carousel.tsx
+++ b/src-v5/carousel.tsx
@@ -42,27 +42,30 @@ export const Carousel = (props: CarouselProps): React.ReactElement => {
   const carouselRef = props.innerRef || carouselEl;
 
   const moveSlide = (to?: number) => {
-    const [slide, endSlide] = getIndexes(
+    const [slide] = getIndexes(
       currentSlide,
       currentSlide - slidesToScroll,
       count
     );
-    to && props.beforeSlide(slide, endSlide);
+
+    const nextIndex = () => {
+      const index = to ?? currentSlide;
+      if (index < 0) {
+        return index + count;
+      }
+      if (index === count) {
+        return 0;
+      }
+      return index;
+    };
+
+    typeof to === 'number' && props.beforeSlide(slide, nextIndex());
     !props.disableAnimation && setAnimation(true);
     setCurrentSlide(to ?? currentSlide);
     setTimeout(
       () => {
         if (!isMounted.current) return;
-
-        let nextIndex = to ?? currentSlide;
-        if (nextIndex < 0) {
-          nextIndex += count;
-        }
-        if (nextIndex === count) {
-          nextIndex = 0;
-        }
-
-        typeof to === 'number' && props.afterSlide(nextIndex);
+        typeof to === 'number' && props.afterSlide(nextIndex());
         !props.disableAnimation && setAnimation(false);
       },
       !props.disableAnimation ? props.speed || 500 : 40


### PR DESCRIPTION
### Description

Fixes `afterSlide` to give us the correct slide index that is normalized for the number of slides.


https://user-images.githubusercontent.com/1738349/158188643-29281779-cb09-45cf-966e-07d32b7b11ec.mov



#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
