### PR TITLE
v5: Migrate scrollPage: reminded property to v5

### DIFF
--- a/examples/nextjs/pages/index.tsx
+++ b/examples/nextjs/pages/index.tsx
@@ -12,7 +12,12 @@ const colors = [
   'aa231f',
   'e3bc13',
   'db7c00',
-  'aa231f'
+  'aa231f',
+  'ccc',
+  'ddd',
+  '000',
+  '111',
+  '222'
 ];
 
 const Home = ({ urlParams }) => {

--- a/src-v5/README.md
+++ b/src-v5/README.md
@@ -52,7 +52,7 @@ or
 
 **Depreceted parameters**
 
-The following list of parameters will be deprecated in v5. The main reason is that there is other approach which you can use to achieve the same thing, without increasing the complexity of the library. For example: `width` the width of the carousel can be easily manipulated by the parent container where developer placed the carousel. `scrollMode` can be achieved easily with `slidesToScroll` property and etc. We are open for discussions if you really need some of these parameters. Feel free to raise an issue or start discussion in the repository, so we can help.
+The following list of parameters will be deprecated in v5. The main reason is that there is other approach which you can use to achieve the same thing, without increasing the complexity of the library. For example: `width` the width of the carousel can be easily manipulated by the parent container where developer placed the carousel. We are open for discussions if you really need some of these parameters. Feel free to raise an issue or start discussion in the repository, so we can help.
 
 - autoGenerateStyleTag
 - framePadding
@@ -61,7 +61,6 @@ The following list of parameters will be deprecated in v5. The main reason is th
 - heightMode
 - initialSlideHeight
 - initialSlideWidth
-- scrollMode
 - slideOffset
 - slideWidth
 - transitionMode

--- a/src-v5/carousel.tsx
+++ b/src-v5/carousel.tsx
@@ -6,7 +6,7 @@ import { getSliderListStyles } from './slider-list';
 import { CarouselProps, KeyCodeFunction } from './types';
 import renderControls from './controls';
 import defaultProps from './default-carousel-props';
-import { getIndexes, addEvent, removeEvent } from './utils';
+import { getIndexes, addEvent, removeEvent, getNextMoveIndex, getPrevMoveIndex } from './utils';
 import AnnounceSlide from './announce-slide';
 
 export const Carousel = (props: CarouselProps): React.ReactElement => {
@@ -78,7 +78,8 @@ export const Carousel = (props: CarouselProps): React.ReactElement => {
 
   const nextSlide = () => {
     if (props.wrapAround || currentSlide < count - props.slidesToScroll) {
-      moveSlide(currentSlide + slidesToScroll);
+      const nextPosition = getNextMoveIndex(props.scrollMode, props.wrapAround, currentSlide, count, props.slidesToScroll)
+      moveSlide(nextPosition);
     } else {
       moveSlide();
     }
@@ -87,7 +88,8 @@ export const Carousel = (props: CarouselProps): React.ReactElement => {
   const prevSlide = () => {
     // boundary
     if (props.wrapAround || currentSlide > 0) {
-      moveSlide(currentSlide - slidesToScroll);
+      const prevPosition = getPrevMoveIndex(props.scrollMode, props.wrapAround, currentSlide, props.slidesToScroll)
+      moveSlide(prevPosition);
     } else {
       moveSlide();
     }

--- a/src-v5/carousel.tsx
+++ b/src-v5/carousel.tsx
@@ -6,7 +6,13 @@ import { getSliderListStyles } from './slider-list';
 import { CarouselProps, KeyCodeFunction } from './types';
 import renderControls from './controls';
 import defaultProps from './default-carousel-props';
-import { getIndexes, addEvent, removeEvent, getNextMoveIndex, getPrevMoveIndex } from './utils';
+import {
+  getIndexes,
+  addEvent,
+  removeEvent,
+  getNextMoveIndex,
+  getPrevMoveIndex
+} from './utils';
 import AnnounceSlide from './announce-slide';
 
 export const Carousel = (props: CarouselProps): React.ReactElement => {
@@ -78,7 +84,13 @@ export const Carousel = (props: CarouselProps): React.ReactElement => {
 
   const nextSlide = () => {
     if (props.wrapAround || currentSlide < count - props.slidesToScroll) {
-      const nextPosition = getNextMoveIndex(props.scrollMode, props.wrapAround, currentSlide, count, props.slidesToScroll)
+      const nextPosition = getNextMoveIndex(
+        props.scrollMode,
+        props.wrapAround,
+        currentSlide,
+        count,
+        props.slidesToScroll
+      );
       moveSlide(nextPosition);
     } else {
       moveSlide();
@@ -88,7 +100,12 @@ export const Carousel = (props: CarouselProps): React.ReactElement => {
   const prevSlide = () => {
     // boundary
     if (props.wrapAround || currentSlide > 0) {
-      const prevPosition = getPrevMoveIndex(props.scrollMode, props.wrapAround, currentSlide, props.slidesToScroll)
+      const prevPosition = getPrevMoveIndex(
+        props.scrollMode,
+        props.wrapAround,
+        currentSlide,
+        props.slidesToScroll
+      );
       moveSlide(prevPosition);
     } else {
       moveSlide();

--- a/src-v5/controls.tsx
+++ b/src-v5/controls.tsx
@@ -57,6 +57,7 @@ const renderControls = (
           goToSlide: (index) => moveSlide(index),
           nextSlide: () => nextSlide(),
           previousSlide: () => prevSlide(),
+          scrollMode: props.scrollMode,
           slideCount: count,
           slidesToScroll,
           slidesToShow: props.slidesToShow || 1,

--- a/src-v5/default-carousel-props.tsx
+++ b/src-v5/default-carousel-props.tsx
@@ -50,6 +50,7 @@ const defaultProps = {
     <PreviousButton {...props} />
   ),
   renderCenterRightControls: (props: ControlProps) => <NextButton {...props} />,
+  scrollMode: 'page',
   slideIndex: 0,
   slideOffset: 25,
   slidesToScroll: 1,

--- a/src-v5/default-controls.tsx
+++ b/src-v5/default-controls.tsx
@@ -122,13 +122,17 @@ export const NextButton = (props: ControlProps) => {
   );
 };
 
-export const getDotIndexes = (slideCount: number, slidesToScroll: number, scrollMode: ScrollMode) => {
+export const getDotIndexes = (
+  slideCount: number,
+  slidesToScroll: number,
+  scrollMode: ScrollMode
+) => {
   const dotIndexes = [];
   const scrollSlides = slidesToScroll === 0 ? 1 : slidesToScroll;
 
   for (let i = 0; i < slideCount; i += scrollSlides) {
     if (scrollMode === ScrollMode.reminder && i + scrollSlides > slideCount) {
-      dotIndexes.push(i - (scrollSlides - (slideCount - i)))
+      dotIndexes.push(i - (scrollSlides - (slideCount - i)));
     } else {
       dotIndexes.push(i);
     }
@@ -155,7 +159,11 @@ export const PagingDots = (props: ControlProps) => {
     fill: 'black'
   });
 
-  const indexes = getDotIndexes(props.slideCount, props.slidesToScroll, props.scrollMode);
+  const indexes = getDotIndexes(
+    props.slideCount,
+    props.slidesToScroll,
+    props.scrollMode
+  );
   const {
     pagingDotsContainerClassName,
     pagingDotsClassName,

--- a/src-v5/default-controls.tsx
+++ b/src-v5/default-controls.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable complexity */
 import React, { CSSProperties } from 'react';
-import { ControlProps } from './types';
+import { ControlProps, ScrollMode } from './types';
 
 const defaultButtonStyles = (disabled: boolean): CSSProperties => ({
   border: 0,
@@ -122,12 +122,16 @@ export const NextButton = (props: ControlProps) => {
   );
 };
 
-export const getDotIndexes = (slideCount: number, slidesToScroll: number) => {
+export const getDotIndexes = (slideCount: number, slidesToScroll: number, scrollMode: ScrollMode) => {
   const dotIndexes = [];
   const scrollSlides = slidesToScroll === 0 ? 1 : slidesToScroll;
 
   for (let i = 0; i < slideCount; i += scrollSlides) {
-    dotIndexes.push(i);
+    if (scrollMode === ScrollMode.reminder && i + scrollSlides > slideCount) {
+      dotIndexes.push(i - (scrollSlides - (slideCount - i)))
+    } else {
+      dotIndexes.push(i);
+    }
   }
 
   return dotIndexes;
@@ -151,7 +155,7 @@ export const PagingDots = (props: ControlProps) => {
     fill: 'black'
   });
 
-  const indexes = getDotIndexes(props.slideCount, props.slidesToScroll);
+  const indexes = getDotIndexes(props.slideCount, props.slidesToScroll, props.scrollMode);
   const {
     pagingDotsContainerClassName,
     pagingDotsClassName,

--- a/src-v5/default-controls.tsx
+++ b/src-v5/default-controls.tsx
@@ -131,7 +131,7 @@ export const getDotIndexes = (
   const scrollSlides = slidesToScroll === 0 ? 1 : slidesToScroll;
 
   for (let i = 0; i < slideCount; i += scrollSlides) {
-    if (scrollMode === ScrollMode.reminder && i + scrollSlides > slideCount) {
+    if (scrollMode === ScrollMode.remainder && i + scrollSlides > slideCount) {
       dotIndexes.push(i - (scrollSlides - (slideCount - i)));
     } else {
       dotIndexes.push(i);

--- a/src-v5/types.ts
+++ b/src-v5/types.ts
@@ -41,6 +41,11 @@ export interface Slide {
   offsetHeight: number;
 }
 
+export enum ScrollMode {
+  page = 'page',
+  reminder = 'reminder',
+}
+
 export enum D3EasingFunctions {
   EaseLinear = 'easeLinear',
   EaseQuad = 'easeQuad',
@@ -149,6 +154,7 @@ export interface ControlProps {
   left?: number; // obsolete
   nextSlide: () => void;
   previousSlide: () => void;
+  scrollMode: ScrollMode;
   slideCount: number;
   slidesToScroll: number;
   slidesToShow: number;
@@ -220,7 +226,7 @@ export interface CarouselProps {
   renderTopCenterControls?: RenderControls; // migrated
   renderTopLeftControls?: RenderControls; // migrated
   renderTopRightControls?: RenderControls; // migrated
-  // scrollMode: ScrollMode; // to be deprecated
+  scrollMode: ScrollMode; // migrated
   slideIndex: number; // ???
   slideOffset: number; // to be deprecated
   slidesToScroll: number; // migrated - tested for !wrapAround

--- a/src-v5/types.ts
+++ b/src-v5/types.ts
@@ -43,7 +43,7 @@ export interface Slide {
 
 export enum ScrollMode {
   page = 'page',
-  reminder = 'reminder'
+  remainder = 'remainder'
 }
 
 export enum D3EasingFunctions {

--- a/src-v5/types.ts
+++ b/src-v5/types.ts
@@ -43,7 +43,7 @@ export interface Slide {
 
 export enum ScrollMode {
   page = 'page',
-  reminder = 'reminder',
+  reminder = 'reminder'
 }
 
 export enum D3EasingFunctions {

--- a/src-v5/utils.ts
+++ b/src-v5/utils.ts
@@ -1,4 +1,4 @@
-import { ScrollMode } from "./types";
+import { ScrollMode } from './types';
 
 export const getIndexes = (
   slide: number,
@@ -57,20 +57,38 @@ export const removeEvent = (
   }
 };
 
-
-export const getNextMoveIndex = (scrollMode: ScrollMode, wrapAround: boolean, currentSlide: number, count: number, slidesToScroll: number) => {
-  if (!wrapAround && scrollMode === ScrollMode.reminder && count < currentSlide + (slidesToScroll * 2)) {
-    const remindedSlides =  count - (currentSlide + slidesToScroll);
+export const getNextMoveIndex = (
+  scrollMode: ScrollMode,
+  wrapAround: boolean,
+  currentSlide: number,
+  count: number,
+  slidesToScroll: number
+) => {
+  if (
+    !wrapAround &&
+    scrollMode === ScrollMode.reminder &&
+    count < currentSlide + slidesToScroll * 2
+  ) {
+    const remindedSlides = count - (currentSlide + slidesToScroll);
     return currentSlide + remindedSlides;
   }
 
   return currentSlide + slidesToScroll;
-}
+};
 
-export const getPrevMoveIndex = (scrollMode: ScrollMode, wrapAround: boolean, currentSlide: number, slidesToScroll: number) => {
-  if (!wrapAround && scrollMode === ScrollMode.reminder && 0 > currentSlide - slidesToScroll) {
+export const getPrevMoveIndex = (
+  scrollMode: ScrollMode,
+  wrapAround: boolean,
+  currentSlide: number,
+  slidesToScroll: number
+) => {
+  if (
+    !wrapAround &&
+    scrollMode === ScrollMode.reminder &&
+    currentSlide - slidesToScroll < 0
+  ) {
     return 0;
   }
 
   return currentSlide - slidesToScroll;
-}
+};

--- a/src-v5/utils.ts
+++ b/src-v5/utils.ts
@@ -1,3 +1,5 @@
+import { ScrollMode } from "./types";
+
 export const getIndexes = (
   slide: number,
   endSlide: number,
@@ -54,3 +56,21 @@ export const removeEvent = (
     elem[`on${type}`] = null;
   }
 };
+
+
+export const getNextMoveIndex = (scrollMode: ScrollMode, wrapAround: boolean, currentSlide: number, count: number, slidesToScroll: number) => {
+  if (!wrapAround && scrollMode === ScrollMode.reminder && count < currentSlide + (slidesToScroll * 2)) {
+    const remindedSlides =  count - (currentSlide + slidesToScroll);
+    return currentSlide + remindedSlides;
+  }
+
+  return currentSlide + slidesToScroll;
+}
+
+export const getPrevMoveIndex = (scrollMode: ScrollMode, wrapAround: boolean, currentSlide: number, slidesToScroll: number) => {
+  if (!wrapAround && scrollMode === ScrollMode.reminder && 0 > currentSlide - slidesToScroll) {
+    return 0;
+  }
+
+  return currentSlide - slidesToScroll;
+}

--- a/src-v5/utils.ts
+++ b/src-v5/utils.ts
@@ -66,7 +66,7 @@ export const getNextMoveIndex = (
 ) => {
   if (
     !wrapAround &&
-    scrollMode === ScrollMode.reminder &&
+    scrollMode === ScrollMode.remainder &&
     count < currentSlide + slidesToScroll * 2
   ) {
     const remindedSlides = count - (currentSlide + slidesToScroll);
@@ -84,7 +84,7 @@ export const getPrevMoveIndex = (
 ) => {
   if (
     !wrapAround &&
-    scrollMode === ScrollMode.reminder &&
+    scrollMode === ScrollMode.remainder &&
     currentSlide - slidesToScroll < 0
   ) {
     return 0;


### PR DESCRIPTION
### Description

As it was removed firstly, we are migrating `scrollPage: reminded` back to v5. Currently if we have v5 carousel without `wrapAround` and slides are not even to slidesToShow, we can see white screen in the end of the carousel. This can be prevented by adding scrollPage: reminded property.

This PR covers the straightforward scenario when slidesToShow and slidesToScroll are equal. There is no point slidesToScroll is more than slidesToShow, because some slides will be missed. Next PR will cover the scenario when slidesToScroll is less than slidesToShow. 