### PR TITLE
feat: add adaptiveHeight property in v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ You can play with `&params` url parameter to add or remove any carousel paramete
 
 | Name | Type | Description |Default |
 | :------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :----------------------------------------------------------------------------------------------------------------- |
+| adaptiveHeight | `boolean`| If it's set to true, the carousel will adapt its height to the visible slides. | `false` |
 | afterSlide | `(index: number) => void`| Hook to be called after a slide is changed. |`() => {}`|
 | animation | `'zoom' \| 'fade'`| Adds a zoom effect on the currently visible slide or change the animation to `fade`. A `transform: scale(0.85)` is set as default when you are using zoom, however, the scale can be customized using `zoomScale` prop. Property is applied on all slides except the current 1. Use `cellAlign` to align the slide with zoom effect where you'd like. ||
 | autoplay | `boolean` | Autoplay mode active. | `false`|
@@ -230,6 +231,8 @@ The following list of parameters are deprecated in v5. The main reason is that t
 ### New parameters in v5
 
 - frameAriaLabel - customize the aria-label of the frame container of the carousel. This is useful when you have more than one carousel on the page. (Included in v5.0.3)
+
+- adaptiveHeight - this property is useful if you have slides with different height. The carousel with adapth its height to the slides. Replacement of `heightMode="current"` v4 property. (Included in v5.0.9)
 
 ### What about v5.1
 

--- a/src-v5/carousel.tsx
+++ b/src-v5/carousel.tsx
@@ -25,7 +25,7 @@ export const Carousel = (props: CarouselProps): React.ReactElement => {
   const [pause, setPause] = useState<boolean>(false);
   const [dragging, setDragging] = useState<boolean>(false);
   const [move, setMove] = useState<number>(0);
-  const [frameHeight, setFrameHeight] = useState<number>(0)
+  const [frameHeight, setFrameHeight] = useState<number>(0);
   const [keyboardMove, setKeyboardMove] = useState<KeyCodeFunction>(null);
   const carouselWidth = useRef<number | null>(null);
 

--- a/src-v5/carousel.tsx
+++ b/src-v5/carousel.tsx
@@ -25,6 +25,7 @@ export const Carousel = (props: CarouselProps): React.ReactElement => {
   const [pause, setPause] = useState<boolean>(false);
   const [dragging, setDragging] = useState<boolean>(false);
   const [move, setMove] = useState<number>(0);
+  const [frameHeight, setFrameHeight] = useState<number>(0)
   const [keyboardMove, setKeyboardMove] = useState<KeyCodeFunction>(null);
   const carouselWidth = useRef<number | null>(null);
 
@@ -380,6 +381,9 @@ export const Carousel = (props: CarouselProps): React.ReactElement => {
           speed={props.speed}
           zoomScale={props.zoomScale}
           cellAlign={props.cellAlign}
+          setFrameHeight={setFrameHeight}
+          frameHeight={frameHeight}
+          adaptiveHeight={props.adaptiveHeight}
         >
           {child}
         </Slide>
@@ -419,6 +423,7 @@ export const Carousel = (props: CarouselProps): React.ReactElement => {
           width: '100%',
           position: 'relative',
           outline: 'none',
+          height: props.adaptiveHeight ? `${frameHeight}px` : 'auto',
           ...props.style
         }}
         aria-label={props.frameAriaLabel}

--- a/src-v5/default-carousel-props.tsx
+++ b/src-v5/default-carousel-props.tsx
@@ -4,6 +4,7 @@ import { PagingDots, PreviousButton, NextButton } from './default-controls';
 import { defaultRenderAnnounceSlideMessage } from './announce-slide';
 
 const defaultProps = {
+  adaptiveHeight: false,
   afterSlide: () => {
     // do nothing
   },

--- a/src-v5/slide.tsx
+++ b/src-v5/slide.tsx
@@ -12,7 +12,8 @@ const getSlideStyles = (
   cellSpacing?: number,
   animation?: 'zoom' | 'fade',
   speed?: number,
-  zoomScale?: number
+  zoomScale?: number,
+  adaptiveHeight?: boolean
 ): CSSProperties => {
   const width = getSlideWidth(count, wrapAround);
   const visibleSlideOpacity = isVisibleSlide ? 1 : 0;
@@ -22,6 +23,7 @@ const getSlideStyles = (
     width,
     height: '100%',
     display: 'inline-block',
+    verticalAlign: adaptiveHeight ? 'top' : 'inherit',
     padding: `0 ${cellSpacing ? cellSpacing / 2 : 0}px`,
     transition: animation ? `${speed || animationSpeed}ms ease 0s` : 'none',
     transform: `${
@@ -90,7 +92,10 @@ const Slide = ({
   speed,
   slidesToShow,
   zoomScale,
-  cellAlign
+  cellAlign,
+  setFrameHeight,
+  frameHeight,
+  adaptiveHeight,
 }: {
   count: number;
   children: ReactNode | ReactNode[];
@@ -105,6 +110,9 @@ const Slide = ({
   slidesToShow: number;
   zoomScale?: number;
   cellAlign: Alignment;
+  setFrameHeight: (h: number) => void,
+  frameHeight: number,
+  adaptiveHeight: boolean
 }): JSX.Element => {
   const customIndex = wrapAround
     ? generateIndex(index, count, typeOfSlide)
@@ -127,6 +135,12 @@ const Slide = ({
         node.setAttribute('inert', 'true');
       }
     }
+    if (adaptiveHeight && node && isVisible) {
+      const slideHeight = node.getBoundingClientRect()?.height;
+      if (slideHeight !== frameHeight) {
+        setFrameHeight(slideHeight)
+      }
+    }
   }, [isVisible]);
 
   return (
@@ -143,7 +157,8 @@ const Slide = ({
         cellSpacing,
         animation,
         speed,
-        zoomScale
+        zoomScale,
+        adaptiveHeight
       )}
     >
       {children}

--- a/src-v5/slide.tsx
+++ b/src-v5/slide.tsx
@@ -95,7 +95,7 @@ const Slide = ({
   cellAlign,
   setFrameHeight,
   frameHeight,
-  adaptiveHeight,
+  adaptiveHeight
 }: {
   count: number;
   children: ReactNode | ReactNode[];
@@ -110,9 +110,9 @@ const Slide = ({
   slidesToShow: number;
   zoomScale?: number;
   cellAlign: Alignment;
-  setFrameHeight: (h: number) => void,
-  frameHeight: number,
-  adaptiveHeight: boolean
+  setFrameHeight: (h: number) => void;
+  frameHeight: number;
+  adaptiveHeight: boolean;
 }): JSX.Element => {
   const customIndex = wrapAround
     ? generateIndex(index, count, typeOfSlide)
@@ -138,7 +138,7 @@ const Slide = ({
     if (adaptiveHeight && node && isVisible) {
       const slideHeight = node.getBoundingClientRect()?.height;
       if (slideHeight !== frameHeight) {
-        setFrameHeight(slideHeight)
+        setFrameHeight(slideHeight);
       }
     }
   }, [isVisible]);

--- a/src-v5/slide.tsx
+++ b/src-v5/slide.tsx
@@ -137,7 +137,7 @@ const Slide = ({
     }
     if (adaptiveHeight && node && isVisible) {
       const slideHeight = node.getBoundingClientRect()?.height;
-      if (slideHeight !== frameHeight) {
+      if (slideHeight > frameHeight) {
         setFrameHeight(slideHeight);
       }
     }

--- a/src-v5/types.ts
+++ b/src-v5/types.ts
@@ -171,6 +171,7 @@ export type RenderControlFunctionNames =
 type RenderControls = (props: ControlProps) => ReactElement;
 
 export interface CarouselProps {
+  adaptiveHeight: boolean;
   afterSlide: (index: number) => void;
   animation?: 'zoom' | 'fade';
   autoplay: boolean;


### PR DESCRIPTION
### Description
Currently in v5 if you have slides with different height, the carousel will be always with the height of the biggest slide. With this PR we are introducing the new property `adaptiveHeight` which will allow the carousel to adapt its height to the visible slides. This feature was requested in this issue #870  

Fixes #870 

Video:

https://user-images.githubusercontent.com/12056467/162384493-2cd92664-a02b-4685-88ed-375369a7fd04.mov


