### PR TITLE
fix: input typing in slides

### DIFF
--- a/examples/nextjs/pages/index.tsx
+++ b/examples/nextjs/pages/index.tsx
@@ -2,6 +2,7 @@ import 'wicg-inert';
 import Head from 'next/head';
 import styles from '../styles/Home.module.css';
 import Carousel from '../../../src-v5/';
+import { useState } from 'react';
 
 const colors = [
   '7732bb',
@@ -21,21 +22,24 @@ const colors = [
 ];
 
 const Home = ({ urlParams }) => {
+  const [inputValue, setInputValue] = useState('')
   const colorsArray = colors.slice(0, Number(urlParams.slides || 9));
 
   const slides = colorsArray.map((color, index) => (
-    <img
-      src={`https://via.placeholder.com/400/${color}/ffffff/&text=slide${
-        index + 1
-      }`}
-      alt={`Slide ${index + 1}`}
-      key={color}
-      data-slide={`Slide ${index + 1}`}
-      style={{
-        width: '100%',
-        height: 400
-      }}
-    />
+    <div key={color}>
+      <input value={inputValue} onChange={e => setInputValue(e.target.value)} />
+      <img
+        src={`https://via.placeholder.com/400/${color}/ffffff/&text=slide${
+          index + 1
+        }`}
+        alt={`Slide ${index + 1}`}
+        data-slide={`Slide ${index + 1}`}
+        style={{
+          width: '100%',
+          height: 400
+        }}
+      />
+    </div>
   ));
 
   const carouselParams = urlParams.params ? JSON.parse(urlParams.params) : {};

--- a/examples/nextjs/pages/index.tsx
+++ b/examples/nextjs/pages/index.tsx
@@ -2,7 +2,6 @@ import 'wicg-inert';
 import Head from 'next/head';
 import styles from '../styles/Home.module.css';
 import Carousel from '../../../src-v5/';
-import { useState } from 'react';
 
 const colors = [
   '7732bb',
@@ -22,24 +21,21 @@ const colors = [
 ];
 
 const Home = ({ urlParams }) => {
-  const [inputValue, setInputValue] = useState('')
   const colorsArray = colors.slice(0, Number(urlParams.slides || 9));
 
   const slides = colorsArray.map((color, index) => (
-    <div key={color}>
-      <input value={inputValue} onChange={e => setInputValue(e.target.value)} />
-      <img
-        src={`https://via.placeholder.com/400/${color}/ffffff/&text=slide${
-          index + 1
-        }`}
-        alt={`Slide ${index + 1}`}
-        data-slide={`Slide ${index + 1}`}
-        style={{
-          width: '100%',
-          height: 400
-        }}
-      />
-    </div>
+    <img
+      src={`https://via.placeholder.com/400/${color}/ffffff/&text=slide${
+        index + 1
+      }`}
+      key={color}
+      alt={`Slide ${index + 1}`}
+      data-slide={`Slide ${index + 1}`}
+      style={{
+        width: '100%',
+        height: 400
+      }}
+    />
   ));
 
   const carouselParams = urlParams.params ? JSON.parse(urlParams.params) : {};

--- a/src-v5/carousel.tsx
+++ b/src-v5/carousel.tsx
@@ -44,8 +44,10 @@ export const Carousel = (props: CarouselProps): React.ReactElement => {
 
   useEffect(() => {
     // disable img draggable attribute by default, this will improve the dragging
-    document.querySelectorAll('.slider-list img').forEach(el => el.setAttribute('draggable', 'false'))
-  }, [])
+    document
+      .querySelectorAll('.slider-list img')
+      .forEach((el) => el.setAttribute('draggable', 'false'));
+  }, []);
 
   const slidesToScroll =
     props.animation === 'fade' ? props.slidesToShow : props.slidesToScroll;

--- a/src-v5/carousel.tsx
+++ b/src-v5/carousel.tsx
@@ -42,6 +42,11 @@ export const Carousel = (props: CarouselProps): React.ReactElement => {
     []
   );
 
+  useEffect(() => {
+    // disable img draggable attribute by default, this will improve the dragging
+    document.querySelectorAll('.slider-list img').forEach(el => el.setAttribute('draggable', 'false'))
+  }, [])
+
   const slidesToScroll =
     props.animation === 'fade' ? props.slidesToShow : props.slidesToScroll;
   const dragThreshold = (carouselWidth.current || 0) / props.slidesToShow / 2;
@@ -187,10 +192,10 @@ export const Carousel = (props: CarouselProps): React.ReactElement => {
     if (props.enableKeyboardControls && keyboardMove && focus.current) {
       switch (keyboardMove) {
         case 'nextSlide':
-          nextSlide(); // set boundaries for !wrapAround
+          nextSlide();
           break;
         case 'previousSlide':
-          prevSlide(); // set boundaries for !wrapAround
+          prevSlide();
           break;
         case 'firstSlide':
           setCurrentSlide(0);
@@ -322,7 +327,6 @@ export const Carousel = (props: CarouselProps): React.ReactElement => {
   const onMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
     if (!props.dragging) return;
 
-    e?.preventDefault();
     carouselRef?.current?.focus();
 
     setDragging(true);


### PR DESCRIPTION
### Description
Currently is not possible to type in inputs inside the slides, because we are preventing the default behaviour when user click on slide. This was done with the idea to improve the dragging and prevent the dragging of "ghost" image when user try to drag. The preventDefault is removed now and we are setting dragging="false" to all images in the carousel.

Fixes #694 

Tested on Chrome and Safari on desktop and mobile