### PR TITLE
fix: react18 strict mode unmount

### DIFF
--- a/src-v5/carousel.tsx
+++ b/src-v5/carousel.tsx
@@ -35,12 +35,12 @@ export const Carousel = (props: CarouselProps): React.ReactElement => {
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isMounted = useRef<boolean>(true);
 
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
       isMounted.current = false;
-    },
-    []
-  );
+    };
+  }, []);
 
   useEffect(() => {
     // disable img draggable attribute by default, this will improve the dragging


### PR DESCRIPTION
### Description
React18 in strict mode will call unmount and remount on component render and it's breaking our behaviour to understand when the component is unmount. More info [here](https://reactjs.org/blog/2022/03/29/react-v18.html#new-strict-mode-behaviors)

Fixes #879 