### PR TITLE
Make explicit children prop for React 18 @types/react issue

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -147,6 +147,11 @@ export interface CarouselProps {
   cellSpacing?: number;
 
   /**
+   * Explicit children prop to resolve issue with @types/react v18
+   */
+  children?: React.ReactNode;
+
+  /**
    * Additional className
    */
   className?: string;


### PR DESCRIPTION
### Description

Simply adds `children` as an explicit prop to `CarouselProps` in `index.d.ts`, since that's what TypeScript is using as its type definition.

Fixes #889 


#### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

#### Testing

Tested with installing this version on https://github.com/riceboyler/nuka-types and it resolved the Typescript error.