### PR TITLE
fix: slides display and an issue with adaptiveheight

### DIFF
--- a/src-v5/carousel.tsx
+++ b/src-v5/carousel.tsx
@@ -26,7 +26,7 @@ export const Carousel = (props: CarouselProps): React.ReactElement => {
   const [dragging, setDragging] = useState<boolean>(false);
   const [move, setMove] = useState<number>(0);
   const [frameHeight, setFrameHeight] = useState<number>(0);
-  const visibleHeights = useRef<SlideHeight[]>([])
+  const visibleHeights = useRef<SlideHeight[]>([]);
   const [keyboardMove, setKeyboardMove] = useState<KeyCodeFunction>(null);
   const carouselWidth = useRef<number | null>(null);
 

--- a/src-v5/carousel.tsx
+++ b/src-v5/carousel.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect, useState, useRef, useCallback } from 'react';
 import Slide from './slide';
 import { getSliderListStyles } from './slider-list';
-import { CarouselProps, KeyCodeFunction } from './types';
+import { CarouselProps, KeyCodeFunction, SlideHeight } from './types';
 import renderControls from './controls';
 import defaultProps from './default-carousel-props';
 import {
@@ -26,6 +26,7 @@ export const Carousel = (props: CarouselProps): React.ReactElement => {
   const [dragging, setDragging] = useState<boolean>(false);
   const [move, setMove] = useState<number>(0);
   const [frameHeight, setFrameHeight] = useState<number>(0);
+  const visibleHeights = useRef<SlideHeight[]>([])
   const [keyboardMove, setKeyboardMove] = useState<KeyCodeFunction>(null);
   const carouselWidth = useRef<number | null>(null);
 
@@ -395,6 +396,7 @@ export const Carousel = (props: CarouselProps): React.ReactElement => {
           cellAlign={props.cellAlign}
           setFrameHeight={setFrameHeight}
           frameHeight={frameHeight}
+          visibleHeights={visibleHeights}
           adaptiveHeight={props.adaptiveHeight}
         >
           {child}

--- a/src-v5/slide.tsx
+++ b/src-v5/slide.tsx
@@ -1,4 +1,10 @@
-import React, { CSSProperties, ReactNode, useRef, useEffect, MutableRefObject } from 'react';
+import React, {
+  CSSProperties,
+  ReactNode,
+  useRef,
+  useEffect,
+  MutableRefObject
+} from 'react';
 import { Alignment, SlideHeight } from './types';
 
 const getSlideWidth = (count: number, wrapAround?: boolean): string =>
@@ -127,29 +133,38 @@ const Slide = ({
 
   const slideRef = useRef<HTMLDivElement>(null);
 
+  // eslint-disable-next-line complexity
   useEffect(() => {
     const node = slideRef.current;
     if (node) {
+      const slideHeight = node.getBoundingClientRect()?.height;
       if (isVisible) {
         node.removeAttribute('inert');
       } else {
         node.setAttribute('inert', 'true');
       }
-    }
-    if (adaptiveHeight && node && isVisible && slidesToShow === 1) {
-      const slideHeight = node.getBoundingClientRect()?.height;
-      if (slideHeight !== frameHeight) {
-        setFrameHeight(slideHeight)
-      }
-    } else if (adaptiveHeight && node && isVisible && slidesToShow > 1) {
-      const slideHeight = node.getBoundingClientRect()?.height;
-      visibleHeights.current = [...visibleHeights.current, {
-        height: slideHeight,
-        slideIndex: customIndex
-      }]
-    } else if (adaptiveHeight && !isVisible) {
-      if (visibleHeights.current.findIndex(v => v.slideIndex === customIndex) > -1) {
-        visibleHeights.current = visibleHeights.current.filter(v => v.slideIndex !== customIndex)
+
+      if (adaptiveHeight && isVisible && slidesToShow === 1) {
+        if (slideHeight !== frameHeight) {
+          setFrameHeight(slideHeight);
+        }
+      } else if (adaptiveHeight && isVisible && slidesToShow > 1) {
+        visibleHeights.current = [
+          ...visibleHeights.current,
+          {
+            height: slideHeight,
+            slideIndex: customIndex
+          }
+        ];
+      } else if (
+        adaptiveHeight &&
+        !isVisible &&
+        visibleHeights.current.findIndex((v) => v.slideIndex === customIndex) >
+          -1
+      ) {
+        visibleHeights.current = visibleHeights.current.filter(
+          (v) => v.slideIndex !== customIndex
+        );
       }
     }
   }, [isVisible]);
@@ -159,15 +174,15 @@ const Slide = ({
       const newFrameHeight = visibleHeights.current.reduce((acc, value) => {
         if (acc >= value.height) {
           return acc;
-        } 
+        }
         return value.height;
-      }, 0)
+      }, 0);
 
       if (newFrameHeight !== frameHeight) {
-        setFrameHeight(newFrameHeight)
+        setFrameHeight(newFrameHeight);
       }
     }
-  }, [adaptiveHeight, visibleHeights.current])
+  }, [adaptiveHeight, visibleHeights.current]);
 
   return (
     <div

--- a/src-v5/slide.tsx
+++ b/src-v5/slide.tsx
@@ -1,5 +1,5 @@
-import React, { CSSProperties, ReactNode, useRef, useEffect } from 'react';
-import { Alignment } from './types';
+import React, { CSSProperties, ReactNode, useRef, useEffect, MutableRefObject } from 'react';
+import { Alignment, SlideHeight } from './types';
 
 const getSlideWidth = (count: number, wrapAround?: boolean): string =>
   `${wrapAround ? 100 / (3 * count) : 100 / count}%`;
@@ -21,9 +21,8 @@ const getSlideStyles = (
 
   return {
     width,
-    height: '100%',
-    display: 'inline-block',
-    verticalAlign: adaptiveHeight ? 'top' : 'inherit',
+    flex: 1,
+    height: adaptiveHeight ? '100%' : 'auto',
     padding: `0 ${cellSpacing ? cellSpacing / 2 : 0}px`,
     transition: animation ? `${speed || animationSpeed}ms ease 0s` : 'none',
     transform: `${
@@ -95,6 +94,7 @@ const Slide = ({
   cellAlign,
   setFrameHeight,
   frameHeight,
+  visibleHeights,
   adaptiveHeight
 }: {
   count: number;
@@ -112,6 +112,7 @@ const Slide = ({
   cellAlign: Alignment;
   setFrameHeight: (h: number) => void;
   frameHeight: number;
+  visibleHeights: MutableRefObject<SlideHeight[]>;
   adaptiveHeight: boolean;
 }): JSX.Element => {
   const customIndex = wrapAround
@@ -135,13 +136,38 @@ const Slide = ({
         node.setAttribute('inert', 'true');
       }
     }
-    if (adaptiveHeight && node && isVisible) {
+    if (adaptiveHeight && node && isVisible && slidesToShow === 1) {
       const slideHeight = node.getBoundingClientRect()?.height;
-      if (slideHeight > frameHeight) {
-        setFrameHeight(slideHeight);
+      if (slideHeight !== frameHeight) {
+        setFrameHeight(slideHeight)
+      }
+    } else if (adaptiveHeight && node && isVisible && slidesToShow > 1) {
+      const slideHeight = node.getBoundingClientRect()?.height;
+      visibleHeights.current = [...visibleHeights.current, {
+        height: slideHeight,
+        slideIndex: customIndex
+      }]
+    } else if (adaptiveHeight && !isVisible) {
+      if (visibleHeights.current.findIndex(v => v.slideIndex === customIndex) > -1) {
+        visibleHeights.current = visibleHeights.current.filter(v => v.slideIndex !== customIndex)
       }
     }
   }, [isVisible]);
+
+  useEffect(() => {
+    if (adaptiveHeight && slidesToShow > 1) {
+      const newFrameHeight = visibleHeights.current.reduce((acc, value) => {
+        if (acc >= value.height) {
+          return acc;
+        } 
+        return value.height;
+      }, 0)
+
+      if (newFrameHeight !== frameHeight) {
+        setFrameHeight(newFrameHeight)
+      }
+    }
+  }, [adaptiveHeight, visibleHeights.current])
 
   return (
     <div

--- a/src-v5/slider-list.ts
+++ b/src-v5/slider-list.ts
@@ -166,6 +166,7 @@ export const getSliderListStyles = (
       animation && slideAnimation !== 'fade'
         ? `${speed || 500}ms ease 0s`
         : 'none',
-    transform: positioning
+    transform: positioning,
+    display: 'flex'
   };
 };

--- a/src-v5/types.ts
+++ b/src-v5/types.ts
@@ -39,7 +39,7 @@ type SlideChildren = {
 export type SlideHeight = {
   height: number;
   slideIndex: number;
-}
+};
 
 export interface Slide {
   children?: [SlideChildren];

--- a/src-v5/types.ts
+++ b/src-v5/types.ts
@@ -36,6 +36,11 @@ type SlideChildren = {
   offsetHeight: number;
 };
 
+export type SlideHeight = {
+  height: number;
+  slideIndex: number;
+}
+
 export interface Slide {
   children?: [SlideChildren];
   offsetHeight: number;


### PR DESCRIPTION
### Description
Currently we used display: inline-block to render the slides, but this cause few issues as divs cannot be with same height next each other, so I migrated them to flex. Also this PR is fixing an issue with adaptiveHeight when visible slides are more than 1
