### PR TITLE
fix: scroll mode remainder is not working when slides to show is float number

### DIFF
--- a/src-v5/carousel.tsx
+++ b/src-v5/carousel.tsx
@@ -17,7 +17,6 @@ import AnnounceSlide from './announce-slide';
 
 export const Carousel = (props: CarouselProps): React.ReactElement => {
   const count = React.Children.count(props.children);
-
   const [currentSlide, setCurrentSlide] = useState<number>(
     props.autoplayReverse ? count - props.slidesToShow : props.slideIndex
   );
@@ -98,7 +97,8 @@ export const Carousel = (props: CarouselProps): React.ReactElement => {
         props.wrapAround,
         currentSlide,
         count,
-        props.slidesToScroll
+        props.slidesToScroll,
+        props.slidesToShow
       );
       moveSlide(nextPosition);
     } else {

--- a/src-v5/utils.ts
+++ b/src-v5/utils.ts
@@ -62,17 +62,18 @@ export const getNextMoveIndex = (
   wrapAround: boolean,
   currentSlide: number,
   count: number,
-  slidesToScroll: number
+  slidesToScroll: number,
+  slidesToShow: number
 ) => {
   if (
     !wrapAround &&
     scrollMode === ScrollMode.remainder &&
-    count < currentSlide + slidesToScroll * 2
+    count < currentSlide + (slidesToScroll + slidesToShow)
   ) {
-    const remindedSlides = count - (currentSlide + slidesToScroll);
+    const remindedSlides =
+      count - (currentSlide + slidesToScroll) - (slidesToShow - slidesToScroll);
     return currentSlide + remindedSlides;
   }
-
   return currentSlide + slidesToScroll;
 };
 


### PR DESCRIPTION


### Description
Currently when user have float number as slidesToShow or any number but slidesToScroll is 1, the scrollMode=remainder property is not working. This PR is fixing these issues and is improving the performance of the dots.

https://user-images.githubusercontent.com/12056467/167580565-3365afcb-8702-4890-a9c3-e111f24f9a9b.mov


