### PR TITLE
feat: allow changing slides via a CarouselRef; add more className props

### DIFF
--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -44,6 +44,16 @@ A `string` prop that gives the carousel frame an id attribute which can be uniqu
 
 ---
 
+### `carouselRef`
+A React ref `Ref<CarouselRef>` for carousel element that can be used to change slides from a parent.
+
+- `nextSlide()`: go to the next slide
+- `prevSlide()`: go to the previous slide
+- `goToSlide(targetSlideUnbounded: number)`: can advance to any slide by its index. Negative indexes or indexes greater than the number of slides are allowed. The function will translate the index.
+
+
+---
+
 ### `cellAlign`
 An enum `'left' | 'center' | 'right'` for when displaying more than one slide, sets which position to anchor the current slide. Default value: `'left'`.
 
@@ -55,7 +65,7 @@ A `number` representing pixels for the spacing between slides. Default value: `0
 ---
 
 ### `className`
-A `string` for the CSS selectors to be applied to the slider frame.
+A `string` for the CSS classes to be applied to the slider frame.
 
 ---
 
@@ -111,6 +121,11 @@ A configuration object for the key codes to override the default keyboard keys c
 
 ### `landmark`
 A `boolean` that determines whether role should be a region landmark or have role group. Role and label have been moved from the slider frame to the parent carousel element so controls are contained within the label and role. Landmark regions should be intentional, so the default value is set to `false`.
+
+---
+
+### `listClassName`
+A `string` for the CSS classes to add to the slider list, which is the scrollable container that contains all the items.
 
 ---
 
@@ -196,6 +211,11 @@ A function to render custom controls for the bottom right area of the carousel. 
 
 ### `scrollMode`
 An enum `'page' | 'remainder'` for showing whitespace when you scroll to the end of a carousel with `wrapAround` set to `false`. Setting to `'remainder'` will not show the whitespace. Default value: `'page'`.
+
+---
+
+### `slideClassName`
+A `string` for the CSS classes to add to each slide of the carousel.
 
 ---
 

--- a/packages/nuka/src/hooks/use-frame-height.ts
+++ b/packages/nuka/src/hooks/use-frame-height.ts
@@ -52,13 +52,29 @@ export const useFrameHeight = (
       // Use the ref's value since it's always the latest value
       const latestVisibleHeights = visibleHeightsRef.current;
       let newVisibleHeights: SlideHeight[];
+
       if (height === null) {
+        // Remove the entry
         newVisibleHeights = latestVisibleHeights.filter(
           (slideHeight) => slideHeight.slideIndex !== slideIndex
         );
       } else {
-        newVisibleHeights = [...latestVisibleHeights, { slideIndex, height }];
+        // Replace the entry if it exists
+        let foundSlide = false;
+        newVisibleHeights = latestVisibleHeights.map((heightInfo) => {
+          if (heightInfo.slideIndex === slideIndex) {
+            foundSlide = true;
+            return { slideIndex, height };
+          }
+          return heightInfo;
+        });
+
+        // Add the height if it wasn't found
+        if (!foundSlide) {
+          newVisibleHeights = [...latestVisibleHeights, { slideIndex, height }];
+        }
       }
+
       setVisibleHeights(newVisibleHeights);
 
       if (

--- a/packages/nuka/src/slider-list.tsx
+++ b/packages/nuka/src/slider-list.tsx
@@ -44,6 +44,7 @@ interface SliderListProps
     | 'disableEdgeSwiping'
     | 'easing'
     | 'edgeEasing'
+    | 'listClassName'
     | 'scrollMode'
     | 'animation'
     | 'slidesToShow'
@@ -75,6 +76,7 @@ export const SliderList = React.forwardRef<HTMLDivElement, SliderListProps>(
       easing,
       edgeEasing,
       isDragging,
+      listClassName,
       scrollMode,
       slideCount,
       slidesToScroll,
@@ -168,7 +170,7 @@ export const SliderList = React.forwardRef<HTMLDivElement, SliderListProps>(
     return (
       <div
         ref={forwardedRef}
-        className="slider-list"
+        className={['slider-list', listClassName].filter(Boolean).join(' ')}
         style={{
           width: listVisibleWidth,
           textAlign: 'left',

--- a/packages/nuka/src/types.ts
+++ b/packages/nuka/src/types.ts
@@ -1,4 +1,4 @@
-import { ReactNode, CSSProperties } from 'react';
+import { ReactNode, CSSProperties, Ref } from 'react';
 
 export type CellAlign = 'center' | 'right' | 'left';
 
@@ -230,6 +230,9 @@ export interface InternalCarouselProps {
    */
   carouselId?: string;
 
+  /** Can be used to move to the next, previous, or a specific slide */
+  carouselRef?: Ref<CarouselRef>;
+
   /**
    * When displaying more than one slide,
    * sets which position to anchor the current slide to
@@ -309,6 +312,11 @@ export interface InternalCarouselProps {
    * Whether the carousel should be designated as a landmark region.
    */
   landmark: boolean;
+
+  /**
+   * Extra className to be added to the scrollable list that contains all slides
+   */
+  listClassName?: string;
 
   /**
    * optional callback function
@@ -402,6 +410,11 @@ export interface InternalCarouselProps {
   scrollMode: ScrollMode;
 
   /**
+   * Extra className to be added to the container for each slide
+   */
+  slideClassName?: string;
+
+  /**
    * Manually set the index of the initial slide to be shown
    */
   slideIndex?: number;
@@ -466,6 +479,26 @@ export interface InternalCarouselProps {
    * @default 0.85
    */
   zoomScale?: number;
+}
+
+export interface CarouselRef {
+  /**
+   * Moves to the specified slide index.
+   *
+   * @param targetSlideUnbounded can be negative or greater than the number of
+   *    slides or negative. The function will translate it to a bounded slide.
+   */
+  goToSlide: (targetSlideUnbounded: number) => void;
+
+  /**
+   * Go to the next slide
+   */
+  nextSlide: () => void;
+
+  /**
+   * Go to the previous slide
+   */
+  prevSlide: () => void;
 }
 
 /**

--- a/packages/nuka/stories/carousel.stories.tsx
+++ b/packages/nuka/stories/carousel.stories.tsx
@@ -1,10 +1,14 @@
-import React from 'react';
+import React, { useRef, useState } from 'react';
 import { ComponentMeta, Story } from '@storybook/react';
 import isChromatic from 'chromatic/isChromatic';
 import { renderToString } from 'react-dom/server';
 import { easeLinear, easeElasticOut } from 'd3-ease';
 
-import Carousel, { ControlProps, InternalCarouselProps } from '../src/index';
+import Carousel, {
+  CarouselRef,
+  ControlProps,
+  InternalCarouselProps,
+} from '../src/index';
 
 import { sampleSlideImageSources } from './sample-slide-images';
 
@@ -21,11 +25,13 @@ export default {
 interface StoryProps {
   storySlideCount: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14;
   slideHeights?: number[];
+  carouselRef?: React.Ref<CarouselRef>;
 }
 
 const Template: Story<InternalCarouselProps & StoryProps> = ({
   storySlideCount = 9,
   slideHeights,
+  carouselRef,
   ...args
 }) => {
   const slides = sampleSlideImageSources
@@ -56,7 +62,9 @@ const Template: Story<InternalCarouselProps & StoryProps> = ({
           margin: '0px auto',
         }}
       >
-        <Carousel {...args}>{slides}</Carousel>
+        <Carousel carouselRef={carouselRef} {...args}>
+          {slides}
+        </Carousel>
       </div>
     </div>
   );
@@ -76,6 +84,34 @@ const StaticTemplate: Story<InternalCarouselProps & StoryProps> = (args) => {
 /* Stories - add common combinations of props here! */
 export const Default = Template.bind({});
 Default.args = {};
+
+/** Template that lets us use a ref to change the slides */
+const RefControlsTemplate: Story<
+  Omit<InternalCarouselProps & StoryProps, 'carouselRef'>
+> = (args) => {
+  const carouselRef = useRef<CarouselRef>(null);
+
+  return (
+    <>
+      <div style={{ textAlign: 'center' }}>
+        Controls using ref:{' '}
+        <button onClick={() => carouselRef.current?.nextSlide()}>
+          Next slide
+        </button>
+        <button onClick={() => carouselRef.current?.prevSlide()}>
+          Previous slide
+        </button>
+        <button onClick={() => carouselRef.current?.goToSlide(0)}>
+          Move to first slide
+        </button>
+      </div>
+      <Template {...args} carouselRef={carouselRef} />
+    </>
+  );
+};
+
+export const WithRefControls = RefControlsTemplate.bind({});
+WithRefControls.args = {};
 
 export const Vertical = Template.bind({});
 Vertical.args = {
@@ -249,6 +285,36 @@ AdaptiveHeightThreeSlidesStatic.args = {
   slidesToShow: 3,
   slidesToScroll: 3,
   slideHeights: [210, 220, 230, 240, 250, 260, 270, 280, 290],
+};
+
+/** Template that lets us change the heights of the slides */
+const ChangeHeightsTemplate: Story<
+  Omit<InternalCarouselProps & StoryProps, 'slideHeights'>
+> = (args) => {
+  const [extraHeight, setExtraHeight] = useState(0);
+  const slideHeights = [210, 220, 230, 240, 250, 260, 270, 280, 290].map(
+    (height) => height + extraHeight
+  );
+
+  return (
+    <>
+      <div style={{ textAlign: 'center' }}>
+        Verify that the heights adapt when heights of children change:
+        <button onClick={() => setExtraHeight(extraHeight + 10)}>
+          Expand slides by 10px
+        </button>
+        <button onClick={() => setExtraHeight(extraHeight - 10)}>
+          Shrink slides by 10px
+        </button>
+      </div>
+      <Template {...args} slideHeights={slideHeights} />
+    </>
+  );
+};
+
+export const AdaptiveHeightChangeHeights = ChangeHeightsTemplate.bind({});
+AdaptiveHeightChangeHeights.args = {
+  adaptiveHeight: true,
 };
 
 export const KeyboardControls = Template.bind({});


### PR DESCRIPTION
### Description

1. We want to advance/change the current slide of the carousel from a parent outside the carousel.
2. To customize styling of the slider list and individual slides, we don't want to rely on the slider-list and similar classNames, as they're internal implementation details. Instead, we let users pass in their own classNames
3. Make Carousel height update when only the slide itself changes without any props changing by using ResizeObserver (when available)

#### Type of Change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

#### Refs

Added new Storybook story that also includes contains buttons to change slide via the new refs:

![Ref controls](https://github.com/FormidableLabs/nuka-carousel/assets/2937410/d2d9e7d2-cde6-438e-9f7d-38e5a117c0a2)

#### Resizing on children change

![Change heights](https://github.com/FormidableLabs/nuka-carousel/assets/2937410/8c381ae0-c02f-406b-ad90-b30ad210427e)

### Checklist: (Feel free to delete this section upon completion)

- [X] My code follows the style guidelines of this project (I have run `yarn lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules