### PR TITLE
fix: make cellAlign Center work correctly

### DIFF
--- a/src-v5/slider-list.ts
+++ b/src-v5/slider-list.ts
@@ -103,21 +103,31 @@ const getPositioning = (
     return `translate3d(${draggableMove}, 0, 0)`;
   }
   if (cellAlign === Alignment.Center) {
-    const center =
-      slidesToShow > 1 ? (100 / count) * Math.floor(slidesToShow / 2) : 0;
-
-    const validatedCenter =
-      slidesToShow % 2 === 0 ? center - 100 / count / 2 : center;
-    // if wrapAround is enabled
-    const centerAlignedFirstSlide =
-      -(count * (100 / (3 * count))) +
-      Math.floor(slidesToShow / 2) * (100 / (3 * count));
-
-    const wrapAroundCenter =
-      slidesToShow % 2 === 0
-        ? centerAlignedFirstSlide - 100 / (3 * count) / 2
-        : centerAlignedFirstSlide;
-    const initialValue = wrapAround ? wrapAroundCenter : validatedCenter;
+    let initialValue: number;
+    if (wrapAround) {
+      // Logic for the `wrapAround` branch hasn't been tested for v5, and may
+      // need work
+      const centerAlignedFirstSlide =
+        -(count * (100 / (3 * count))) +
+        Math.floor(slidesToShow / 2) * (100 / (3 * count));
+      initialValue =
+        slidesToShow % 2 === 0
+          ? centerAlignedFirstSlide - 100 / (3 * count) / 2
+          : centerAlignedFirstSlide;
+    } else {
+      // If slidesToShow is 1.5, we need 0.25 of a slide of margin.
+      // If slidesToShow is 2.6, we need 0.3 of a slide of margin.
+      //
+      // eslint-disable-next-line no-lonely-if
+      if (slidesToShow <= 1) {
+        initialValue = 0;
+      } else {
+        const slideSize = 100 / count;
+        const excessSlides = slidesToShow - Math.floor(slidesToShow);
+        const excessLeftSlides = excessSlides / 2;
+        initialValue = excessLeftSlides * slideSize;
+      }
+    }
 
     const horizontalMove = getTransition(
       count,

--- a/src-v5/slider-list.ts
+++ b/src-v5/slider-list.ts
@@ -67,83 +67,35 @@ const getPositioning = (
   wrapAround?: boolean,
   move?: number
 ): string => {
-  if (!cellAlign || cellAlign === Alignment.Left) {
-    const initialValue = wrapAround ? -(count * (100 / (3 * count))) : 0;
-    const horizontalMove = getTransition(
-      count,
-      initialValue,
-      currentSlide,
-      cellAlign,
-      wrapAround
-    );
-    const draggableMove = move
-      ? `calc(${horizontalMove}% - ${move}px)`
-      : `${horizontalMove}%`;
-    return `translate3d(${draggableMove}, 0, 0)`;
-  }
-  if (cellAlign === Alignment.Right) {
-    const right = slidesToShow > 1 ? (100 / count) * (slidesToShow - 1) : 0;
+  // When wrapAround is enabled, we show the slides 3 times
+  const totalCount = wrapAround ? 3 * count : count;
+  const slideSize = 100 / totalCount;
+  let initialValue = wrapAround ? -count * slideSize : 0;
 
-    // if wrapAround is enabled
-    const rightAlignedFirstSlide =
-      -(count * (100 / (3 * count))) + (slidesToShow - 1) * (100 / (3 * count));
-
-    const initialValue = wrapAround ? rightAlignedFirstSlide : right;
-
-    const horizontalMove = getTransition(
-      count,
-      initialValue,
-      currentSlide,
-      cellAlign,
-      wrapAround
-    );
-    const draggableMove = move
-      ? `calc(${horizontalMove}% - ${move}px)`
-      : `${horizontalMove}%`;
-    return `translate3d(${draggableMove}, 0, 0)`;
-  }
-  if (cellAlign === Alignment.Center) {
-    let initialValue: number;
-    if (wrapAround) {
-      // Logic for the `wrapAround` branch hasn't been tested for v5, and may
-      // need work
-      const centerAlignedFirstSlide =
-        -(count * (100 / (3 * count))) +
-        Math.floor(slidesToShow / 2) * (100 / (3 * count));
-      initialValue =
-        slidesToShow % 2 === 0
-          ? centerAlignedFirstSlide - 100 / (3 * count) / 2
-          : centerAlignedFirstSlide;
-    } else {
-      // If slidesToShow is 1.5, we need 0.25 of a slide of margin.
-      // If slidesToShow is 2.6, we need 0.3 of a slide of margin.
-      //
-      // eslint-disable-next-line no-lonely-if
-      if (slidesToShow <= 1) {
-        initialValue = 0;
-      } else {
-        const slideSize = 100 / count;
-        const excessSlides = slidesToShow - Math.floor(slidesToShow);
-        const excessLeftSlides = excessSlides / 2;
-        initialValue = excessLeftSlides * slideSize;
-      }
-    }
-
-    const horizontalMove = getTransition(
-      count,
-      initialValue,
-      currentSlide,
-      cellAlign,
-      wrapAround
-    );
-
-    const draggableMove = move
-      ? `calc(${horizontalMove}% - ${move}px)`
-      : `${horizontalMove}%`;
-    return `translate3d(${draggableMove}, 0, 0)`;
+  if (cellAlign === Alignment.Right && slidesToShow > 1) {
+    const excessSlides = slidesToShow - 1;
+    initialValue += slideSize * excessSlides;
   }
 
-  return 'translate3d(0, 0, 0)';
+  if (cellAlign === Alignment.Center && slidesToShow > 1) {
+    const excessSlides = slidesToShow - 1;
+    // Half of excess is on left and half is on right when centered
+    const excessLeftSlides = excessSlides / 2;
+    initialValue += slideSize * excessLeftSlides;
+  }
+
+  const horizontalMove = getTransition(
+    count,
+    initialValue,
+    currentSlide,
+    cellAlign,
+    wrapAround
+  );
+
+  const draggableMove = move
+    ? `calc(${horizontalMove}% - ${move}px)`
+    : `${horizontalMove}%`;
+  return `translate3d(${draggableMove}, 0, 0)`;
 };
 
 export const getSliderListStyles = (

--- a/stories/carousel.stories.tsx
+++ b/stories/carousel.stories.tsx
@@ -187,8 +187,27 @@ DragMultipleSlides.args = {
 
 export const CellAlignCenter = Template.bind({});
 CellAlignCenter.args = {
-  slidesToShow: 1.5,
+  slidesToShow: 2.5,
+  cellAlign: 'center'
+};
+
+export const CellAlignCenterWrapAround = Template.bind({});
+CellAlignCenterWrapAround.args = {
+  slidesToShow: 2.5,
   cellAlign: 'center',
+  wrapAround: true
+};
+
+export const CellAlignRight = Template.bind({});
+CellAlignRight.args = {
+  slidesToShow: 2.5,
+  cellAlign: 'right'
+};
+
+export const CellAlignRightWrapAround = Template.bind({});
+CellAlignRightWrapAround.args = {
+  slidesToShow: 2.5,
+  cellAlign: 'right',
   wrapAround: true
 };
 


### PR DESCRIPTION
### Description

The logic for `cellAlign={Alignment.Center}` was incorrect, and was leading to slides not being centered. The most common case is to center-align the slides when we display 1.5 or 2.5 slides. In that case, the left margin should be just 0.25 of a slide to make sure the slides are centered.

#### Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

This was tested with the new Storybook stories:

![Alignment](https://user-images.githubusercontent.com/2937410/172027640-fabf5a40-1b57-4adb-a130-bf0b9c4515c8.gif)

### Checklist: (Feel free to delete this section upon completion)

- [X] My code follows the style guidelines of this project (I have run `yarn lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules