### PR TITLE
fix: Use lib-v5/index.js instead of index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,0 @@
-module.exports = require('./lib-v5').default;
-module.exports.default = module.exports;
-module.exports.NextButton = require('./lib-v5').NextButton;
-module.exports.PreviousButton = require('./lib-v5').PreviousButton;
-module.exports.PagingDots = require('./lib-v5').PagingDots;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nuka-carousel",
   "version": "5.1.2",
   "description": "Pure React Carousel",
-  "main": "index.js",
+  "main": "lib-v5/index.js",
   "module": "es-v5/index.js",
   "jsnext:main": "es-v5/index.js",
   "types": "index.d.ts",

--- a/src-v5/index.tsx
+++ b/src-v5/index.tsx
@@ -1,2 +1,3 @@
 export { Carousel as default } from './carousel';
 export * from './types';
+export { NextButton, PreviousButton, PagingDots } from './default-controls';


### PR DESCRIPTION
### Description

We ran into a bug where the `index.js` didn't include some enums in `src-v5/types.ts`. It's annoying to maintain `index.js` to keep it up-to-date with `index.ts`, so I thought it'd be easier to just use the build output instead.

#### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Built the library and installed it in an existing user of nuka-carousel v5. Verified that everything works.

This is true because the build output now includes everything that the original `index.js` includes and more.

### Checklist: (Feel free to delete this section upon completion)

- [X] My code follows the style guidelines of this project (I have run `yarn lint`)
- **N/A** I have added tests that prove my fix is effective or that my feature works~
- [X] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [X] I have performed a self-review of my own code
- **N/A** I have commented my code, particularly in hard-to-understand areas
- **N/A** I have made corresponding changes to the documentation
- **N/A** For any breaking API changes, I have updated the type definitions in [`index.d.ts`](../index.d.ts)
- [X] My changes generate no new warnings
- **N/A** Any dependent changes have been merged and published in downstream modules