### PR TITLE
pass dragThreshold as prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ You can play with `&params` url parameter to add or remove any carousel paramete
 | disableAnimation | `boolean` | When set to `true`, will disable animation. | `false` |
 | disableEdgeSwiping | `boolean` | When set to `true`, will disable swiping before first slide and after last slide. | `false` |
 | dragging | `boolean` | Enable mouse swipe/dragging. | `true` |
+| dragThreshold | `number` | The percentage (from 0 to 1) of a slide that the user needs to drag before a slide change is triggered. | `0.5` |
 | enableKeyboardControls | `boolean` | When set to `true` will enable keyboard controls when the carousel has focus. If the carousel does not have focus, keyboard controls will be ignored. | `false` |
 | frameAriaLabel | `string` | Customize the aria-label of the frame container of the carousel. This is useful when you have more than one carousel on the page. | `''` |
 | innerRef | `MutableRefObject<HTMLDivElement>` | React `ref` that should be set on the carousel element | |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuka-carousel",
-  "version": "5.0.16",
+  "version": "5.0.17",
   "description": "Pure React Carousel",
   "main": "index.js",
   "module": "es-v5/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuka-carousel",
-  "version": "5.0.17",
+  "version": "5.0.16",
   "description": "Pure React Carousel",
   "main": "index.js",
   "module": "es-v5/index.js",

--- a/src-v5/carousel.tsx
+++ b/src-v5/carousel.tsx
@@ -51,7 +51,8 @@ export const Carousel = (props: CarouselProps): React.ReactElement => {
 
   const slidesToScroll =
     props.animation === 'fade' ? props.slidesToShow : props.slidesToScroll;
-  const dragThreshold = (carouselWidth.current || 0) / props.slidesToShow / 2;
+  const dragThreshold =
+    ((carouselWidth.current || 0) / props.slidesToShow) * props.dragThreshold;
 
   const carouselRef = props.innerRef || carouselEl;
 

--- a/src-v5/default-carousel-props.tsx
+++ b/src-v5/default-carousel-props.tsx
@@ -1,14 +1,19 @@
 import React from 'react';
-import { Alignment, ControlProps, D3EasingFunctions } from './types';
+import {
+  Alignment,
+  ControlProps,
+  D3EasingFunctions,
+  ScrollMode,
+  CarouselProps
+} from './types';
 import { PagingDots, PreviousButton, NextButton } from './default-controls';
 import { defaultRenderAnnounceSlideMessage } from './announce-slide';
 
-const defaultProps = {
+const defaultProps: CarouselProps = {
   adaptiveHeight: false,
   afterSlide: () => {
     // do nothing
   },
-  autoGenerateStyleTag: true,
   autoplay: false,
   autoplayInterval: 3000,
   autoplayReverse: false,
@@ -21,6 +26,7 @@ const defaultProps = {
   disableAnimation: false,
   disableEdgeSwiping: false,
   dragging: true,
+  dragThreshold: 0.5,
   easing: D3EasingFunctions.EaseCircleOut,
   edgeEasing: D3EasingFunctions.EaseElasticOut,
   enableKeyboardControls: false,
@@ -50,7 +56,7 @@ const defaultProps = {
     <PreviousButton {...props} />
   ),
   renderCenterRightControls: (props: ControlProps) => <NextButton {...props} />,
-  scrollMode: 'page',
+  scrollMode: ScrollMode.page,
   slideIndex: 0,
   slidesToScroll: 1,
   slidesToShow: 1,

--- a/src-v5/types.ts
+++ b/src-v5/types.ts
@@ -191,6 +191,7 @@ export interface CarouselProps {
   disableAnimation: boolean;
   disableEdgeSwiping: boolean;
   dragging: boolean;
+  dragThreshold: number;
   easing: D3EasingFunctions; // not migrated yet
   edgeEasing: D3EasingFunctions; // not migrated yet
   enableKeyboardControls: boolean;


### PR DESCRIPTION
### Description

Resubmitting as a branch and not a fork

We've noticed in a client project that sometimes the drag threshold is too much on mobile. This PR adds a prop for the percentage of a slide which needs to be dragged.

#### Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

`yarn start:next`
Edit `index.tsx` to have a `dragThreshold` of 0.33. Play around with that on desktop, mobile, various browsers.

### Checklist: (Feel free to delete this section upon completion)

- [x] My code follows the style guidelines of this project (I have run `yarn lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] For any breaking API changes, I have updated the type definitions in [`index.d.ts`](../index.d.ts)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
