### PR TITLE
fix: add type for dragThreshold

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -188,7 +188,7 @@ export interface CarouselProps {
    * Enable mouse swipe/dragging
    */
   dragging?: boolean;
-  
+
   /**
    * The percentage (from 0 to 1) of a slide that the user needs to drag before a slide change is triggered.
    */

--- a/index.d.ts
+++ b/index.d.ts
@@ -188,6 +188,11 @@ export interface CarouselProps {
    * Enable mouse swipe/dragging
    */
   dragging?: boolean;
+  
+  /**
+   * The percentage (from 0 to 1) of a slide that the user needs to drag before a slide change is triggered.
+   */
+  dragThreshold?: number;
 
   /**
    * Animation easing function


### PR DESCRIPTION
### Description

The dragTreshold type was not specified and gave an error on build. This PR updates the type definitions.

#### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

None, all tests should still pass.

### Checklist: (Feel free to delete this section upon completion)

- [ ] My code follows the style guidelines of this project (I have run `yarn lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] For any breaking API changes, I have updated the type definitions in [`index.d.ts`](../index.d.ts)
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
