### PR TITLE
Render controls before slides in the carousel DOM

### DIFF
--- a/src-v5/carousel.tsx
+++ b/src-v5/carousel.tsx
@@ -562,6 +562,16 @@ export const Carousel = (props: CarouselProps): React.ReactElement => {
         })}
       />
 
+      {renderControls(
+        props,
+        count,
+        currentSlide,
+        moveSlide,
+        nextSlide,
+        prevSlide,
+        slidesToScroll
+      )}
+
       <div
         className={['slider-frame', className || ''].join(' ').trim()}
         style={{
@@ -605,15 +615,6 @@ export const Carousel = (props: CarouselProps): React.ReactElement => {
           {wrapAround ? renderSlides('next-cloned') : null}
         </div>
       </div>
-      {renderControls(
-        props,
-        count,
-        currentSlide,
-        moveSlide,
-        nextSlide,
-        prevSlide,
-        slidesToScroll
-      )}
     </div>
   );
 };

--- a/src-v5/control-styles.ts
+++ b/src-v5/control-styles.ts
@@ -1,18 +1,23 @@
 import { CSSProperties } from 'react';
 import { Positions } from './types';
 
+const commonStyles: CSSProperties = {
+  position: 'absolute',
+  zIndex: 1
+};
+
 export const getDecoratorStyles = (pos: Positions): CSSProperties => {
   switch (pos) {
     case Positions.TopLeft: {
       return {
-        position: 'absolute',
+        ...commonStyles,
         top: 0,
         left: 0
       };
     }
     case Positions.TopCenter: {
       return {
-        position: 'absolute',
+        ...commonStyles,
         top: 0,
         left: '50%',
         transform: 'translateX(-50%)',
@@ -22,14 +27,14 @@ export const getDecoratorStyles = (pos: Positions): CSSProperties => {
     }
     case Positions.TopRight: {
       return {
-        position: 'absolute',
+        ...commonStyles,
         top: 0,
         right: 0
       };
     }
     case Positions.CenterLeft: {
       return {
-        position: 'absolute',
+        ...commonStyles,
         top: '50%',
         left: 0,
         transform: 'translateY(-50%)',
@@ -39,7 +44,7 @@ export const getDecoratorStyles = (pos: Positions): CSSProperties => {
     }
     case Positions.CenterCenter: {
       return {
-        position: 'absolute',
+        ...commonStyles,
         top: '50%',
         left: '50%',
         transform: 'translate(-50%,-50%)',
@@ -49,7 +54,7 @@ export const getDecoratorStyles = (pos: Positions): CSSProperties => {
     }
     case Positions.CenterRight: {
       return {
-        position: 'absolute',
+        ...commonStyles,
         top: '50%',
         right: 0,
         transform: 'translateY(-50%)',
@@ -59,14 +64,14 @@ export const getDecoratorStyles = (pos: Positions): CSSProperties => {
     }
     case Positions.BottomLeft: {
       return {
-        position: 'absolute',
+        ...commonStyles,
         bottom: 0,
         left: 0
       };
     }
     case Positions.BottomCenter: {
       return {
-        position: 'absolute',
+        ...commonStyles,
         bottom: 0,
         left: '50%',
         transform: 'translateX(-50%)',
@@ -76,14 +81,14 @@ export const getDecoratorStyles = (pos: Positions): CSSProperties => {
     }
     case Positions.BottomRight: {
       return {
-        position: 'absolute',
+        ...commonStyles,
         bottom: 0,
         right: 0
       };
     }
     default: {
       return {
-        position: 'absolute',
+        ...commonStyles,
         top: 0,
         left: 0
       };


### PR DESCRIPTION
### Description

This change adds a new `renderControlsBeforeSlides` prop on the main `<Carousel/>` component, which when set to `true`, renders the controls before the slide frame in the DOM.

This allows screen reader and other keyboard users to first access the slider controls before the slider frame and its possible focusable contents, when tabbing through the web page the carousel is displayed on.

I didn't manage to find a WCAG 2.0 rule associated to the carousel control focus order, but we were asked to do so for a11y reasons by a partner company.

Existing W3C WAI-ARIA carousel examples ([here](https://www.w3.org/WAI/ARIA/apg/example-index/carousel/carousel-1-prev-next.html) and [also here](https://www.w3.org/WAI/ARIA/apg/example-index/carousel/carousel-2-tablist.html)), and other accessible carousel we found on the web seem to always place the controls before the carousel frame and contents.

As there doesn't seem to be an actual official rule about it, I just added the prop and made it default to `false`.

#### Type of Change

- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

The non-e2e test suite doesn't seem to run for me, and when checking the code, it seems to call nuka-carousel v4 code (from the `src/` folder and not the `src-v5/` one).

So my tests where : 

```bash
$ yarn
$ yarn start:next
$ open http://localhost:3000/?params={"renderControlsBeforeSlides": true}
```

You can test it with the [PR Review APP](https://nuka-carousel-git-fork-respublica-conseil-243ed8-nuka-carousel.vercel.app/?params={%22renderControlsBeforeSlides%22:%20true})

Then tab through the page : the controls are focused first, the carousel frame after.

### Checklist: (Feel free to delete this section upon completion)

- [x] My code follows the style guidelines of this project (I have run `yarn lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

Note : I couldn't run the tests with `yarn run test`, so I didn't added tests, but updated the README. But the cypress tests seemed to all pass as green.
Plase let me know if there's any way to run the tests and if you'd like me to add some tests for the new prop.

Thanks !