### PR TITLE
fix: ignored attempt to cancel a touchmove event with cancelable=false

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -299,7 +299,7 @@ export default class Carousel extends React.Component {
         e.touches[0].pageY,
         this.props.vertical
       );
-      if (direction !== 0) {
+      if (direction !== 0 && e.cancelable) {
         e.preventDefault();
       }
     }


### PR DESCRIPTION
### Description

Fix the `[Intervention]Ignored attempt to cancel a touchmove event with cancelable=false, for example because scrolling is in progress and cannot be interrupted.` console error when scrolling with touch on mobile.

![ezgif-4-ce4c31bb0d](https://user-images.githubusercontent.com/43506490/173658912-e19d4e2f-b216-49be-9f6b-51e0b9ec4819.gif)


#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- Add `height: 200vh` and `align-items: center` to Drag Multiple Slides example in Storybook
- Scroll with the cursor over the slide card on the Surface Duo device in DevTools (It may not give an error in other device sizes in this example because of the buttons covering the slide).

![ezgif-4-ad5b34989d](https://user-images.githubusercontent.com/43506490/173659540-7ce6dba2-29bc-4c01-988d-8e30f98548a1.gif)



### Checklist: (Feel free to delete this section upon completion)

- [x] My code follows the style guidelines of this project (I have run `yarn lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] For any breaking API changes, I have updated the type definitions in [`index.d.ts`](../index.d.ts)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
