### PR TITLE
fix: Remove use of CSS transforms to prevent flickering

### DIFF
--- a/packages/nuka/src/control-styles.ts
+++ b/packages/nuka/src/control-styles.ts
@@ -3,95 +3,64 @@ import { Positions } from './types';
 
 const commonStyles: CSSProperties = {
   position: 'absolute',
-  zIndex: 1
+  display: 'flex',
+  zIndex: 1,
+  top: 0,
+  left: 0,
+  bottom: 0,
+  right: 0
 };
 
-export const getDecoratorStyles = (pos: Positions): CSSProperties => {
+/**
+ * Gets flexbox alignment and justify-content styles for a given position.
+ */
+const getControlContainerFlexStyles = (pos: Positions): CSSProperties => {
+  let alignItems: CSSProperties['alignItems'];
+
   switch (pos) {
-    case Positions.TopLeft: {
-      return {
-        ...commonStyles,
-        top: 0,
-        left: 0
-      };
-    }
-    case Positions.TopCenter: {
-      return {
-        ...commonStyles,
-        top: 0,
-        left: '50%',
-        transform: 'translateX(-50%)',
-        WebkitTransform: 'translateX(-50%)',
-        msTransform: 'translateX(-50%)'
-      };
-    }
-    case Positions.TopRight: {
-      return {
-        ...commonStyles,
-        top: 0,
-        right: 0
-      };
-    }
-    case Positions.CenterLeft: {
-      return {
-        ...commonStyles,
-        top: '50%',
-        left: 0,
-        transform: 'translateY(-50%)',
-        WebkitTransform: 'translateY(-50%)',
-        msTransform: 'translateY(-50%)'
-      };
-    }
-    case Positions.CenterCenter: {
-      return {
-        ...commonStyles,
-        top: '50%',
-        left: '50%',
-        transform: 'translate(-50%,-50%)',
-        WebkitTransform: 'translate(-50%, -50%)',
-        msTransform: 'translate(-50%, -50%)'
-      };
-    }
-    case Positions.CenterRight: {
-      return {
-        ...commonStyles,
-        top: '50%',
-        right: 0,
-        transform: 'translateY(-50%)',
-        WebkitTransform: 'translateY(-50%)',
-        msTransform: 'translateY(-50%)'
-      };
-    }
-    case Positions.BottomLeft: {
-      return {
-        ...commonStyles,
-        bottom: 0,
-        left: 0
-      };
-    }
-    case Positions.BottomCenter: {
-      return {
-        ...commonStyles,
-        bottom: 0,
-        left: '50%',
-        transform: 'translateX(-50%)',
-        WebkitTransform: 'translateX(-50%)',
-        msTransform: 'translateX(-50%)'
-      };
-    }
-    case Positions.BottomRight: {
-      return {
-        ...commonStyles,
-        bottom: 0,
-        right: 0
-      };
-    }
-    default: {
-      return {
-        ...commonStyles,
-        top: 0,
-        left: 0
-      };
-    }
+    case Positions.TopLeft:
+    case Positions.TopCenter:
+    case Positions.TopRight:
+      alignItems = 'flex-start';
+      break;
+    case Positions.CenterLeft:
+    case Positions.CenterCenter:
+    case Positions.CenterRight:
+      alignItems = 'center';
+      break;
+    case Positions.BottomLeft:
+    case Positions.BottomCenter:
+    case Positions.BottomRight:
+      alignItems = 'flex-end';
+      break;
   }
+
+  let justifyContent: CSSProperties['justifyContent'];
+  switch (pos) {
+    case Positions.TopLeft:
+    case Positions.CenterLeft:
+    case Positions.BottomLeft:
+      justifyContent = 'flex-start';
+      break;
+    case Positions.TopCenter:
+    case Positions.CenterCenter:
+    case Positions.BottomCenter:
+      justifyContent = 'center';
+      break;
+    case Positions.TopRight:
+    case Positions.CenterRight:
+    case Positions.BottomRight:
+      justifyContent = 'flex-end';
+      break;
+  }
+
+  return { alignItems, justifyContent };
+};
+
+/**
+ * Gets the styles for a back/forward control container to align the control
+ * properly within the parent.
+ */
+export const getControlContainerStyles = (pos: Positions): CSSProperties => {
+  return { ...getControlContainerFlexStyles(pos), ...commonStyles };
 };

--- a/packages/nuka/src/controls.tsx
+++ b/packages/nuka/src/controls.tsx
@@ -1,6 +1,5 @@
-/* eslint-disable @typescript-eslint/no-empty-function */
 import React, { Fragment } from 'react';
-import { getDecoratorStyles } from './control-styles';
+import { getControlContainerStyles } from './control-styles';
 import {
   InternalCarouselProps,
   Positions,
@@ -42,31 +41,38 @@ const renderControls = (
     return (
       <div
         key={control.funcName}
-        className={[
-          `slider-control-${control.key.toLowerCase()}`,
-          props.defaultControlsConfig.containerClassName || ''
-        ]
-          .join(' ')
-          .trim()}
         style={{
-          ...getDecoratorStyles(control.key)
+          ...getControlContainerStyles(control.key),
+          pointerEvents: 'none'
         }}
       >
-        {props[control.funcName]?.({
-          cellAlign: props.cellAlign,
-          cellSpacing: props.cellSpacing,
-          currentSlide,
-          defaultControlsConfig: props.defaultControlsConfig || {},
-          goToSlide: (index) => moveSlide(index),
-          nextSlide: () => nextSlide(),
-          previousSlide: () => prevSlide(),
-          scrollMode: props.scrollMode,
-          slideCount: count,
-          slidesToScroll,
-          slidesToShow: props.slidesToShow || 1,
-          vertical: props.vertical,
-          wrapAround: props.wrapAround
-        })}
+        <div
+          className={[
+            `slider-control-${control.key.toLowerCase()}`,
+            props.defaultControlsConfig.containerClassName || ''
+          ]
+            .join(' ')
+            .trim()}
+          // The container has `pointerEvents: 'none'` so we need to override
+          // that to make sure the controls are clickable.
+          style={{ pointerEvents: 'auto' }}
+        >
+          {props[control.funcName]?.({
+            cellAlign: props.cellAlign,
+            cellSpacing: props.cellSpacing,
+            currentSlide,
+            defaultControlsConfig: props.defaultControlsConfig || {},
+            goToSlide: (index) => moveSlide(index),
+            nextSlide: () => nextSlide(),
+            previousSlide: () => prevSlide(),
+            scrollMode: props.scrollMode,
+            slideCount: count,
+            slidesToScroll,
+            slidesToShow: props.slidesToShow || 1,
+            vertical: props.vertical,
+            wrapAround: props.wrapAround
+          })}
+        </div>
       </div>
     );
   });

--- a/packages/nuka/src/slide.tsx
+++ b/packages/nuka/src/slide.tsx
@@ -30,12 +30,11 @@ const getSlideStyles = (
     flex: 1,
     height: adaptiveHeight ? '100%' : 'auto',
     padding: `0 ${cellSpacing ? cellSpacing / 2 : 0}px`,
-    transition: animation ? `${speed || animationSpeed}ms ease 0s` : 'none',
-    transform: `${
+    transition: animation ? `${speed || animationSpeed}ms ease 0s` : undefined,
+    transform:
       animation === 'zoom'
         ? `scale(${isCurrentSlide ? 1 : zoomScale || 0.85})`
-        : 'initial'
-    }`,
+        : undefined,
     opacity: animation === 'fade' ? visibleSlideOpacity : 1
   };
 };

--- a/packages/nuka/src/slider-list.ts
+++ b/packages/nuka/src/slider-list.ts
@@ -58,7 +58,6 @@ const getTransition = (
   return initialValue;
 };
 
-// eslint-disable-next-line complexity
 const getPositioning = (
   cellAlign: 'left' | 'right' | 'center',
   slidesToShow: number,
@@ -66,7 +65,7 @@ const getPositioning = (
   currentSlide: number,
   wrapAround?: boolean,
   move?: number
-): string => {
+): string | undefined => {
   // When wrapAround is enabled, we show the slides 3 times
   const totalCount = wrapAround ? 3 * count : count;
   const slideSize = 100 / totalCount;
@@ -91,6 +90,12 @@ const getPositioning = (
     cellAlign,
     wrapAround
   );
+
+  // Special-case this. It's better to return undefined rather than a
+  // transform of 0 pixels since transforms can cause flickering in chrome.
+  if (move === 0 && horizontalMove === 0) {
+    return undefined;
+  }
 
   const draggableMove = move
     ? `calc(${horizontalMove}% - ${move}px)`
@@ -127,7 +132,7 @@ export const getSliderListStyles = (
     transition:
       animation && slideAnimation !== 'fade'
         ? `${speed || 500}ms ease 0s`
-        : 'none',
+        : undefined,
     transform: positioning,
     display: 'flex'
   };


### PR DESCRIPTION
### Description

In our Storybook screenshot test suites, the carousels occasionally showed up as empty, causing many of our screenshot tests to be flaky.

![image](https://user-images.githubusercontent.com/2937410/178237438-43a21cbe-595b-47fa-84a9-1fabe988bcd4.png)

After debugging, I realized that this was because Chrome renders elements that have CSS transforms in a way that can cause them to flicker.

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Tested the changes by running Storybook stories with custom controls, since most of the changes relate to that:

![Remove transforms](https://user-images.githubusercontent.com/2937410/178237572-b2296261-1d99-4e85-b232-1593b1d3f3b0.gif)

### Checklist: (Feel free to delete this section upon completion)

- [X] My code follows the style guidelines of this project (I have run `yarn lint`)
- **N/A:** I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- **N/A:** I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- **N/A:** Any dependent changes have been merged and published in downstream modules