### PR TITLE
fix: scale only the current and visible slide

### DIFF
--- a/packages/nuka/src/slide.tsx
+++ b/packages/nuka/src/slide.tsx
@@ -46,7 +46,7 @@ const getSlideStyles = (
     transition: animation ? `${speed || animationSpeed}ms ease 0s` : undefined,
     transform:
       animation === 'zoom'
-        ? `scale(${isCurrentSlide ? 1 : zoomScale || 0.85})`
+        ? `scale(${isCurrentSlide && isVisibleSlide ? 1 : zoomScale || 0.85})`
         : undefined,
     opacity: animation === 'fade' ? visibleSlideOpacity : 1
   };


### PR DESCRIPTION
### Description
Scale only the current and visible slide when animation zoom is enabled

Fixes #928

#### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

manual testing

### Checklist: (Feel free to delete this section upon completion)

- [ ] My code follows the style guidelines of this project (I have run `yarn lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (I have run `yarn test` and `yarn test-e2e`)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
