### PR TITLE
fix: add slide-visible classes appropriately when slideIndex has fractional digits

### DIFF
--- a/.changeset/pink-apricots-pay.md
+++ b/.changeset/pink-apricots-pay.md
@@ -1,0 +1,5 @@
+---
+'nuka-carousel': patch
+---
+
+fix missing slide-visible classes when slideIndex has fractional digits

--- a/packages/nuka/src/slide.tsx
+++ b/packages/nuka/src/slide.tsx
@@ -1,5 +1,6 @@
 import React, { CSSProperties, ReactNode, useRef, useEffect } from 'react';
 import { Alignment } from './types';
+import { isSlideVisible } from './utils';
 
 const getSlideWidth = (count: number, wrapAround?: boolean): string =>
   `${wrapAround ? 100 / (3 * count) : 100 / count}%`;
@@ -50,34 +51,6 @@ const getSlideStyles = (
         : undefined,
     opacity: animation === 'fade' ? visibleSlideOpacity : 1
   };
-};
-
-const isVisibleSlide = (
-  currentSlide: number,
-  index: number,
-  slidesToShow: number,
-  cellAlign: Alignment
-) => {
-  if (slidesToShow === 1) {
-    return index === currentSlide;
-  }
-
-  if (cellAlign === Alignment.Left) {
-    return index < currentSlide + slidesToShow && index >= currentSlide;
-  }
-
-  if (cellAlign === Alignment.Center) {
-    return (
-      (index >= currentSlide - slidesToShow / 2 && index <= currentSlide) ||
-      (index > currentSlide && index <= currentSlide + slidesToShow / 2)
-    );
-  }
-
-  if (cellAlign === Alignment.Right) {
-    return index <= currentSlide && index > currentSlide - slidesToShow;
-  }
-
-  return false;
 };
 
 const generateIndex = (
@@ -138,7 +111,7 @@ const Slide = ({
   const customIndex = wrapAround
     ? generateIndex(index, count, typeOfSlide)
     : index;
-  const isVisible = isVisibleSlide(
+  const isVisible = isSlideVisible(
     currentSlide,
     customIndex,
     slidesToShow,

--- a/packages/nuka/src/utils.test.ts
+++ b/packages/nuka/src/utils.test.ts
@@ -1,0 +1,119 @@
+import { Alignment } from './types';
+import { isSlideVisible } from './utils';
+
+describe('isSlideVisible', () => {
+  it.each`
+    currentSlide | indexToCheck | slidesToShow | expected
+    ${1}         | ${0}         | ${2}         | ${false}
+    ${1}         | ${1}         | ${2}         | ${true}
+    ${1}         | ${2}         | ${2}         | ${true}
+    ${1}         | ${3}         | ${2}         | ${false}
+    ${1}         | ${0}         | ${1.5}       | ${false}
+    ${1}         | ${1}         | ${1.5}       | ${true}
+    ${1}         | ${2}         | ${1.5}       | ${true}
+    ${1}         | ${3}         | ${1.5}       | ${false}
+    ${1.5}       | ${0}         | ${2}         | ${false}
+    ${1.5}       | ${1}         | ${2}         | ${true}
+    ${1.5}       | ${2}         | ${2}         | ${true}
+    ${1.5}       | ${3}         | ${2}         | ${true}
+    ${1.5}       | ${4}         | ${2}         | ${false}
+    ${1}         | ${0}         | ${1}         | ${false}
+    ${1}         | ${1}         | ${1}         | ${true}
+    ${1}         | ${2}         | ${1}         | ${false}
+    ${1.5}       | ${0}         | ${1}         | ${false}
+    ${1.5}       | ${1}         | ${1}         | ${true}
+    ${1.5}       | ${2}         | ${1}         | ${true}
+    ${1.5}       | ${3}         | ${1}         | ${false}
+  `(
+    'works with left align (showing index $currentSlide, check index $indexToCheck, $slidesToShow slidesToShow)',
+    ({ currentSlide, indexToCheck, slidesToShow, expected }) => {
+      expect(
+        isSlideVisible(currentSlide, indexToCheck, slidesToShow, Alignment.Left)
+      ).toEqual(expected);
+    }
+  );
+
+  it.each`
+    currentSlide | indexToCheck | slidesToShow | expected
+    ${1}         | ${-1}        | ${2}         | ${false}
+    ${1}         | ${0}         | ${2}         | ${true}
+    ${1}         | ${1}         | ${2}         | ${true}
+    ${1}         | ${2}         | ${2}         | ${false}
+    ${1}         | ${-1}        | ${1.5}       | ${false}
+    ${1}         | ${0}         | ${1.5}       | ${true}
+    ${1}         | ${1}         | ${1.5}       | ${true}
+    ${1}         | ${2}         | ${1.5}       | ${false}
+    ${1.5}       | ${-1}        | ${2}         | ${false}
+    ${1.5}       | ${0}         | ${2}         | ${true}
+    ${1.5}       | ${1}         | ${2}         | ${true}
+    ${1.5}       | ${2}         | ${2}         | ${true}
+    ${1.5}       | ${3}         | ${2}         | ${false}
+    ${1}         | ${0}         | ${1}         | ${false}
+    ${1}         | ${1}         | ${1}         | ${true}
+    ${1}         | ${2}         | ${1}         | ${false}
+    ${1.5}       | ${0}         | ${1}         | ${false}
+    ${1.5}       | ${1}         | ${1}         | ${true}
+    ${1.5}       | ${2}         | ${1}         | ${true}
+    ${1.5}       | ${3}         | ${1}         | ${false}
+  `(
+    'works with right align (showing index $currentSlide, check index $indexToCheck, $slidesToShow slidesToShow)',
+    ({ currentSlide, indexToCheck, slidesToShow, expected }) => {
+      expect(
+        isSlideVisible(
+          currentSlide,
+          indexToCheck,
+          slidesToShow,
+          Alignment.Right
+        )
+      ).toEqual(expected);
+    }
+  );
+
+  it.each`
+    currentSlide | indexToCheck | slidesToShow | expected
+    ${1}         | ${-1}        | ${3}         | ${false}
+    ${1}         | ${0}         | ${3}         | ${true}
+    ${1}         | ${1}         | ${3}         | ${true}
+    ${1}         | ${2}         | ${3}         | ${true}
+    ${1}         | ${3}         | ${3}         | ${false}
+    ${1}         | ${-1}        | ${2.5}       | ${false}
+    ${1}         | ${0}         | ${2.5}       | ${true}
+    ${1}         | ${1}         | ${2.5}       | ${true}
+    ${1}         | ${2}         | ${2.5}       | ${true}
+    ${1}         | ${3}         | ${2.5}       | ${false}
+    ${1}         | ${-1}        | ${2}         | ${false}
+    ${1}         | ${0}         | ${2}         | ${true}
+    ${1}         | ${1}         | ${2}         | ${true}
+    ${1}         | ${2}         | ${2}         | ${true}
+    ${1}         | ${3}         | ${2}         | ${false}
+    ${1.2}       | ${-1}        | ${2}         | ${false}
+    ${1.2}       | ${0}         | ${2}         | ${true}
+    ${1.2}       | ${1}         | ${2}         | ${true}
+    ${1.2}       | ${2}         | ${2}         | ${true}
+    ${1.2}       | ${3}         | ${2}         | ${false}
+    ${1.7}       | ${0}         | ${2}         | ${false}
+    ${1.7}       | ${1}         | ${2}         | ${true}
+    ${1.7}       | ${2}         | ${2}         | ${true}
+    ${1.7}       | ${3}         | ${2}         | ${true}
+    ${1.7}       | ${4}         | ${2}         | ${false}
+    ${1}         | ${0}         | ${1}         | ${false}
+    ${1}         | ${1}         | ${1}         | ${true}
+    ${1}         | ${2}         | ${1}         | ${false}
+    ${1.5}       | ${0}         | ${1}         | ${false}
+    ${1.5}       | ${1}         | ${1}         | ${true}
+    ${1.5}       | ${2}         | ${1}         | ${true}
+    ${1.5}       | ${3}         | ${1}         | ${false}
+  `(
+    'works with center align (showing index $currentSlide, check index $indexToCheck, $slidesToShow slidesToShow)',
+    ({ currentSlide, indexToCheck, slidesToShow, expected }) => {
+      expect(
+        isSlideVisible(
+          currentSlide,
+          indexToCheck,
+          slidesToShow,
+          Alignment.Center
+        )
+      ).toEqual(expected);
+    }
+  );
+});

--- a/packages/nuka/src/utils.ts
+++ b/packages/nuka/src/utils.ts
@@ -1,4 +1,4 @@
-import { ScrollMode } from './types';
+import { Alignment, ScrollMode } from './types';
 
 export const getIndexes = (
   slide: number,
@@ -47,6 +47,40 @@ export const removeEvent = (
   if (elem.removeEventListener) {
     elem.removeEventListener(type, eventHandler, false);
   }
+};
+
+export const isSlideVisible = (
+  currentSlide: number,
+  indexToCheck: number,
+  slidesToShow: number,
+  cellAlign: Alignment
+) => {
+  if (slidesToShow === 1) {
+    return indexToCheck === currentSlide;
+  }
+
+  if (cellAlign === Alignment.Left) {
+    return (
+      indexToCheck < currentSlide + slidesToShow && indexToCheck >= currentSlide
+    );
+  }
+
+  if (cellAlign === Alignment.Center) {
+    return (
+      (indexToCheck >= currentSlide - slidesToShow / 2 &&
+        indexToCheck <= currentSlide) ||
+      (indexToCheck > currentSlide &&
+        indexToCheck <= currentSlide + slidesToShow / 2)
+    );
+  }
+
+  if (cellAlign === Alignment.Right) {
+    return (
+      indexToCheck <= currentSlide && indexToCheck > currentSlide - slidesToShow
+    );
+  }
+
+  return false;
 };
 
 export const getNextMoveIndex = (

--- a/packages/nuka/src/utils.ts
+++ b/packages/nuka/src/utils.ts
@@ -55,28 +55,34 @@ export const isSlideVisible = (
   slidesToShow: number,
   cellAlign: Alignment
 ) => {
-  if (slidesToShow === 1) {
-    return indexToCheck === currentSlide;
-  }
+  // The addition or subtraction of constants (1 , 0.5) in the following
+  // calculations are accounting for the fact that a slide will be visible even
+  // after the position associated with its index is off-screen. For example,
+  // with cellAlign="left", slidesToShow=1 and indexToCheck=0,
+  // if the currentSlide is set to 0.99, both (a sliver of) slide 0 and slide 1
+  // will be visible at the same time, even though the position we associate
+  // with index 0, its leftmost edge, is off-screen.
 
   if (cellAlign === Alignment.Left) {
     return (
-      indexToCheck < currentSlide + slidesToShow && indexToCheck >= currentSlide
+      indexToCheck < currentSlide + slidesToShow &&
+      indexToCheck > currentSlide - 1
     );
   }
 
   if (cellAlign === Alignment.Center) {
     return (
-      (indexToCheck >= currentSlide - slidesToShow / 2 &&
+      (indexToCheck > currentSlide - slidesToShow / 2 - 0.5 &&
         indexToCheck <= currentSlide) ||
       (indexToCheck > currentSlide &&
-        indexToCheck <= currentSlide + slidesToShow / 2)
+        indexToCheck < currentSlide + slidesToShow / 2 + 0.5)
     );
   }
 
   if (cellAlign === Alignment.Right) {
     return (
-      indexToCheck <= currentSlide && indexToCheck > currentSlide - slidesToShow
+      indexToCheck < currentSlide + 1 &&
+      indexToCheck > currentSlide - slidesToShow
     );
   }
 


### PR DESCRIPTION
### Description

When the slideIndex has fractional digits (e.g., 0.5, 1.2), `slide-visible` classes are not being applied correctly.

[Bug demo](https://nuka-carousel-next.vercel.app/?slides=5&params=%7B%22scrollMode%22:%22remainder%22,%22slidesToShow%22:2.5,%22slidesToScroll%22:1%7D): click on `next` until you reach the end of the carousel and check slide 3's classes. It is missing `slide-visible` even though it is visible.

This PR fixes that.


#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I added unit tests for the `isSlideVisible` function.
