### PR TITLE
Fix keyboard interactions

### DIFF
--- a/.changeset/four-olives-hope.md
+++ b/.changeset/four-olives-hope.md
@@ -1,0 +1,5 @@
+---
+'nuka-carousel': patch
+---
+
+keyboard-triggered "firstSlide" or "lastSlide" actions are now animated, and now take cellAlign into account

--- a/.changeset/strong-ads-heal.md
+++ b/.changeset/strong-ads-heal.md
@@ -1,0 +1,5 @@
+---
+'nuka-carousel': patch
+---
+
+keyboard interactions when focused on the carousel are now kept from bubbling up and triggering other listeners

--- a/packages/nuka/src/carousel.test.tsx
+++ b/packages/nuka/src/carousel.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import React from 'react';
-import { act, render } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import Carousel from './carousel';
 import { CarouselProps } from './types';
 
@@ -86,5 +86,46 @@ describe('Carousel', () => {
     checkTimingCycle(1);
     checkTimingCycle(2);
     checkTimingCycle(3);
+  });
+
+  it('can be controlled with the keyboard', () => {
+    const beforeSlide = jest.fn();
+    const keyCodeConfig = {
+      nextSlide: [39],
+      previousSlide: [37],
+      firstSlide: [81],
+      lastSlide: [69],
+      pause: [32],
+    };
+    renderCarousel({
+      enableKeyboardControls: true,
+      keyCodeConfig,
+      slideCount: 8,
+      beforeSlide,
+    });
+
+    const carouselFrame = screen.getByRole('region');
+
+    fireEvent.keyDown(carouselFrame, { keyCode: keyCodeConfig.nextSlide[0] });
+    expect(beforeSlide).toHaveBeenLastCalledWith(0, 1);
+
+    fireEvent.keyDown(carouselFrame, { keyCode: keyCodeConfig.nextSlide[0] });
+    expect(beforeSlide).toHaveBeenLastCalledWith(1, 2);
+
+    fireEvent.keyDown(carouselFrame, {
+      keyCode: keyCodeConfig.previousSlide[0],
+    });
+    expect(beforeSlide).toHaveBeenLastCalledWith(2, 1);
+
+    fireEvent.keyDown(carouselFrame, {
+      keyCode: keyCodeConfig.previousSlide[0],
+    });
+    expect(beforeSlide).toHaveBeenLastCalledWith(1, 0);
+
+    fireEvent.keyDown(carouselFrame, { keyCode: keyCodeConfig.lastSlide[0] });
+    expect(beforeSlide).toHaveBeenLastCalledWith(0, 7);
+
+    fireEvent.keyDown(carouselFrame, { keyCode: keyCodeConfig.firstSlide[0] });
+    expect(beforeSlide).toHaveBeenLastCalledWith(7, 0);
   });
 });

--- a/packages/nuka/src/carousel.tsx
+++ b/packages/nuka/src/carousel.tsx
@@ -18,6 +18,7 @@ import { useFrameHeight } from './hooks/use-frame-height';
 interface KeyboardEvent {
   keyCode: number;
 }
+import { getDotIndexes } from './default-controls';
 
 export const Carousel = (rawProps: CarouselProps): React.ReactElement => {
   /**
@@ -307,11 +308,22 @@ export const Carousel = (rawProps: CarouselProps): React.ReactElement => {
           prevSlide();
           break;
         case 'firstSlide':
-          setCurrentSlide(0);
+        case 'lastSlide': {
+          const dotIndices = getDotIndexes(
+            slideCount,
+            slidesToScroll,
+            scrollMode,
+            slidesToShow,
+            wrapAround,
+            cellAlign
+          );
+          if (keyboardMove === 'firstSlide') {
+            goToSlide(dotIndices[0]);
+          } else {
+            goToSlide(dotIndices[dotIndices.length - 1]);
+          }
           break;
-        case 'lastSlide':
-          setCurrentSlide(slideCount - slidesToShow);
-          break;
+        }
         case 'pause':
           if (pause && autoplay) {
             setPause(false);

--- a/packages/nuka/src/carousel.tsx
+++ b/packages/nuka/src/carousel.tsx
@@ -2,22 +2,21 @@ import React, { useEffect, useState, useRef, useCallback } from 'react';
 import Slide from './slide';
 import AnnounceSlide from './announce-slide';
 import { getSliderListStyles } from './slider-list';
-import { CarouselProps, InternalCarouselProps, KeyCodeFunction } from './types';
+import {
+  CarouselProps,
+  InternalCarouselProps,
+  KeyCodeConfig,
+  KeyCodeFunction,
+} from './types';
 import renderControls from './controls';
 import defaultProps from './default-carousel-props';
 import {
   getIndexes,
-  addEvent,
-  removeEvent,
   getNextMoveIndex,
   getPrevMoveIndex,
   getDefaultSlideIndex,
 } from './utils';
 import { useFrameHeight } from './hooks/use-frame-height';
-
-interface KeyboardEvent {
-  keyCode: number;
-}
 import { getDotIndexes } from './default-controls';
 
 export const Carousel = (rawProps: CarouselProps): React.ReactElement => {
@@ -88,9 +87,7 @@ export const Carousel = (rawProps: CarouselProps): React.ReactElement => {
   const [pause, setPause] = useState<boolean>(false);
   const [isDragging, setIsDragging] = useState<boolean>(false);
   const [dragDistance, setDragDistance] = useState<number>(0);
-  const [keyboardMove, setKeyboardMove] = useState<KeyCodeFunction>(null);
 
-  const focus = useRef<boolean>(false);
   const prevXPosition = useRef<number | null>(null);
   const preDragOffset = useRef<number>(0);
   const sliderListRef = useRef<HTMLDivElement>(null);
@@ -298,86 +295,53 @@ export const Carousel = (rawProps: CarouselProps): React.ReactElement => {
     wrapAround,
   ]);
 
-  useEffect(() => {
-    if (enableKeyboardControls && keyboardMove && focus.current) {
-      switch (keyboardMove) {
-        case 'nextSlide':
-          nextSlide();
-          break;
-        case 'previousSlide':
-          prevSlide();
-          break;
-        case 'firstSlide':
-        case 'lastSlide': {
-          const dotIndices = getDotIndexes(
-            slideCount,
-            slidesToScroll,
-            scrollMode,
-            slidesToShow,
-            wrapAround,
-            cellAlign
-          );
-          if (keyboardMove === 'firstSlide') {
-            goToSlide(dotIndices[0]);
-          } else {
-            goToSlide(dotIndices[dotIndices.length - 1]);
-          }
-          break;
-        }
-        case 'pause':
-          if (pause && autoplay) {
-            setPause(false);
-            break;
-          } else if (autoplay) {
-            setPause(true);
-            break;
-          }
-          break;
-      }
-      setKeyboardMove(null);
-    }
-  }, [
-    keyboardMove,
-    enableKeyboardControls,
-    slideCount,
-    slidesToShow,
-    pause,
-    autoplay,
-    nextSlide,
-    prevSlide,
-  ]);
-
-  const onKeyPress = useCallback(
-    (e: Event) => {
-      if (
-        enableKeyboardControls &&
-        focus.current &&
-        (e as unknown as KeyboardEvent).keyCode
-      ) {
-        const keyConfig = keyCodeConfig;
-        for (const func in keyConfig) {
-          if (
-            keyConfig[func as keyof typeof keyConfig]?.includes(
-              (e as unknown as KeyboardEvent).keyCode
-            )
-          ) {
-            setKeyboardMove(func as KeyCodeFunction);
-          }
+  const onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    let keyCommand: KeyCodeFunction = null;
+    (Object.keys(keyCodeConfig) as (keyof KeyCodeConfig)[]).forEach(
+      (command) => {
+        if (keyCodeConfig[command]?.includes(event.keyCode)) {
+          keyCommand = command;
         }
       }
-    },
-    [enableKeyboardControls, keyCodeConfig]
-  );
+    );
 
-  useEffect(() => {
-    if (enableKeyboardControls) {
-      addEvent(document, 'keydown', onKeyPress);
+    if (keyCommand === null) return;
+
+    // At this point we know some action is going to be triggered, so we
+    // preventDefault to avoid the browser interpreting the key event and
+    // stopPropagation to avoid any higher-up handlers from interpreting it.
+    event.preventDefault();
+    event.stopPropagation();
+
+    switch (keyCommand) {
+      case 'nextSlide':
+        nextSlide();
+        break;
+      case 'previousSlide':
+        prevSlide();
+        break;
+      case 'firstSlide':
+      case 'lastSlide': {
+        const dotIndices = getDotIndexes(
+          slideCount,
+          slidesToScroll,
+          scrollMode,
+          slidesToShow,
+          wrapAround,
+          cellAlign
+        );
+        if (keyCommand === 'firstSlide') {
+          goToSlide(dotIndices[0]);
+        } else {
+          goToSlide(dotIndices[dotIndices.length - 1]);
+        }
+        break;
+      }
+      case 'pause':
+        setPause((p) => !p);
+        break;
     }
-
-    return () => {
-      removeEvent(document, 'keydown', onKeyPress);
-    };
-  }, [enableKeyboardControls, carouselRef, onKeyPress]);
+  };
 
   const dragPositions = useRef<{ pos: number; time: number }[]>([]);
 
@@ -539,8 +503,6 @@ export const Carousel = (rawProps: CarouselProps): React.ReactElement => {
       )
         return;
 
-      carouselRef.current.focus();
-
       setIsDragging(true);
 
       preDragOffset.current =
@@ -670,8 +632,7 @@ export const Carousel = (rawProps: CarouselProps): React.ReactElement => {
         aria-label={frameAriaLabel}
         role="region"
         tabIndex={0}
-        onFocus={() => (focus.current = true)}
-        onBlur={() => (focus.current = false)}
+        onKeyDown={enableKeyboardControls ? onKeyDown : undefined}
         ref={carouselRef}
         onMouseUp={onMouseUp}
         onMouseDown={onMouseDown}

--- a/packages/nuka/src/utils.ts
+++ b/packages/nuka/src/utils.ts
@@ -24,32 +24,6 @@ export const getIndexes = (
   return [slideIndex, endSlideIndex];
 };
 
-export const addEvent = (
-  elem: Window | Document,
-  type: string,
-  eventHandler: EventListener
-): void => {
-  if (elem === null || typeof elem === 'undefined') {
-    return;
-  }
-  if (elem.addEventListener) {
-    elem.addEventListener(type, eventHandler, false);
-  }
-};
-
-export const removeEvent = (
-  elem: Window | Document,
-  type: string,
-  eventHandler: EventListener
-): void => {
-  if (elem === null || typeof elem === 'undefined') {
-    return;
-  }
-  if (elem.removeEventListener) {
-    elem.removeEventListener(type, eventHandler, false);
-  }
-};
-
 export const isSlideVisible = (
   currentSlide: number,
   indexToCheck: number,


### PR DESCRIPTION
### Description

The carousel did not animate when the keys corresponding to "firstSlide" or "lastSlide" were pressed. It also stopped at the wrong slide for certain `cellAlign` values. Click on the carousel and press the "Q" and "E" keys on [this repro demo](https://nuka-carousel-next.vercel.app/?slides=8&params=%7B%22slidesToScroll%22:3,%22enableKeyboardControls%22:true,%22cellAlign%22:%22center%22,%22slidesToShow%22:3%7D) to try for yourself. One more thing fixed was that key presses that were registered with the handler did not cause `preventDefault`/`stopPropagation` to be called, so both the carousel and the browser would respond to the same key event. To experience that, open the demo linked above, make the browser window short enough that you get a vertical scroll bar, click on the carousel, and then press the up and down arrow keys.

This PR fixes the behavior described above and simplifies the logic of the keyboard handler.

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I added a simple integration test for the basic keyboard functionality. I also confirmed the behavior manually in storybook.