### PR TITLE
fix: make the control dots change in size when dimensions changed via CSS

### DIFF
--- a/.changeset/hot-swans-rest.md
+++ b/.changeset/hot-swans-rest.md
@@ -1,0 +1,5 @@
+---
+'nuka-carousel': patch
+---
+
+make the control dots change in size when dimensions changed via CSS

--- a/packages/nuka/src/default-controls.tsx
+++ b/packages/nuka/src/default-controls.tsx
@@ -289,6 +289,7 @@ export const PagingDots = (props: ControlProps) => {
                 height="6"
                 aria-hidden="true"
                 focusable="false"
+                viewBox="0 0 6 6"
               >
                 <circle cx="3" cy="3" r="3" />
               </svg>


### PR DESCRIPTION
### Description

By giving the paging dot SVG a `viewBox`, it can respond to changes in CSS width. e.g., the following CSS could be used to increase the size of the dots from 6x6px to 20x20px:
```css
.paging-dot {
  height: 20px;
  width: 20px;
}
```

Before:
<img width="619" alt="image" src="https://user-images.githubusercontent.com/4413963/188685379-71b52457-5271-4fdb-857c-ea53bf4372f6.png">


After:
<img width="623" alt="image" src="https://user-images.githubusercontent.com/4413963/188684964-32c3ec4a-a9fc-4cce-bc12-e3b23c2c257a.png">


Fixes #962

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Manually