### PR TITLE
Feature: Additional render*Controls helpers

### DIFF
--- a/.changeset/shiny-cats-smell.md
+++ b/.changeset/shiny-cats-smell.md
@@ -1,0 +1,5 @@
+---
+'nuka-carousel': minor
+---
+
+pass nextDisabled, previousDisabled, and dotNavigationIndices to render\*Controls callbacks to aid in the creation of custom controls

--- a/README.md
+++ b/README.md
@@ -130,15 +130,16 @@ A set of eight render props for rendering controls in different positions around
 
   Additionally, the following data and callbacks are provided to make creating controls easier:
 
-  | Name             | Type                            | Description                                             |
-  | :--------------- | ------------------------------- | :------------------------------------------------------ |
-  | currentSlide     | `number`                        | Current slide index                                     |
-  | goToSlide        | `(targetIndex: number) => void` | Go to a specific slide                                  |
-  | nextDisabled     | `boolean`                       | Whether the "next" button should be disabled or not     |
-  | nextSlide        | `() => void`                    | Go to the next slide                                    |
-  | previousDisabled | `boolean`                       | Whether the "previous" button should be disabled or not |
-  | previousSlide    | `() => void`                    | Go to the previous slide                                |
-  | slideCount       | `number`                        | Total number of slides                                  |
+  | Name                 | Type                            | Description                                             |
+  | :------------------- | ------------------------------- | :------------------------------------------------------ |
+  | currentSlide         | `number`                        | Current slide index                                     |
+  | dotNavigationIndices | `number[]`                      | The indices for the navigation dots                     |
+  | goToSlide            | `(targetIndex: number) => void` | Go to a specific slide                                  |
+  | nextDisabled         | `boolean`                       | Whether the "next" button should be disabled or not     |
+  | nextSlide            | `() => void`                    | Go to the next slide                                    |
+  | previousDisabled     | `boolean`                       | Whether the "previous" button should be disabled or not |
+  | previousSlide        | `() => void`                    | Go to the previous slide                                |
+  | slideCount           | `number`                        | Total number of slides                                  |
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -114,23 +114,53 @@ A set of eight render props for rendering controls in different positions around
 
 - The default props are set as `renderCenterLeftControls` for `Previous` button, `renderCenterRightControls` for the `Next` button and `renderBottomCenterControls` for the "Paging dots". To change the position or remove "Paging dots", the default positions need to be disabled by setting them to null.
 
+- You can remove all render controls using the `withoutControls` prop on `Carousel`.
+
+- The render functions receive a `ControlProps` argument containing the following props from the Carousel props, using default values if not originally defined: 
+
+  ```
+  cellAlign
+  cellSpacing
+  defaultControlsConfig
+  scrollMode
+  slidesToScroll
+  slidesToShow
+  wrapAround
+  ```
+
+  Additionally, the following data and callbacks are provided to make creating controls easier:
+
+  | Name             | Type                            | Description                                             |
+  | :--------------- | ------------------------------- | :------------------------------------------------------ |
+  | currentSlide     | `number`                        | Current slide index                                     |
+  | goToSlide        | `(targetIndex: number) => void` | Go to a specific slide                                  |
+  | nextDisabled     | `boolean`                       | Whether the "next" button should be disabled or not     |
+  | nextSlide        | `() => void`                    | Go to the next slide                                    |
+  | previousDisabled | `boolean`                       | Whether the "previous" button should be disabled or not |
+  | previousSlide    | `() => void`                    | Go to the previous slide                                |
+  | slideCount       | `number`                        | Total number of slides                                  |
+
+Example:
+
 ```jsx
 <Carousel
   renderTopCenterControls={({ currentSlide }) => (
     <div>Slide: {currentSlide}</div>
   )}
-  renderCenterLeftControls={({ previousSlide }) => (
-    <button onClick={previousSlide}>Previous</button>
+  renderCenterLeftControls={({ previousDisabled, previousSlide }) => (
+    <button onClick={previousSlide} disabled={previousDisabled}>
+      Previous
+    </button>
   )}
-  renderCenterRightControls={({ nextSlide }) => (
-    <button onClick={nextSlide}>Next</button>
+  renderCenterRightControls={({ nextDisabled, nextSlide }) => (
+    <button onClick={nextSlide} disabled={nextDisabled}>
+      Next
+    </button>
   )}
 >
   {/* Carousel Content */}
 </Carousel>
 ```
-
-- The function returns the props for `goToSlide`, `nextSlide` and `previousSlide` functions, in addition to `slideCount` and `currentSlide` values. You can also remove all render controls using `withoutControls`.
 
 - NOTE: The className `slide-visible` is added to the currently visible slide or slides (when `slidesToShow` > 1). The className `slide-current` is added to the currently "active" slide.
 

--- a/packages/nuka/src/controls.tsx
+++ b/packages/nuka/src/controls.tsx
@@ -1,5 +1,6 @@
 import React, { Fragment } from 'react';
 import { getControlContainerStyles } from './control-styles';
+import { nextButtonDisabled, prevButtonDisabled } from './default-controls';
 import {
   InternalCarouselProps,
   Positions,
@@ -31,6 +32,15 @@ const renderControls = (
   if (props.withoutControls) {
     return null;
   }
+
+  const disableCheckProps = {
+    ...props,
+    currentSlide,
+    slideCount,
+  };
+  const nextDisabled = nextButtonDisabled(disableCheckProps);
+  const previousDisabled = prevButtonDisabled(disableCheckProps);
+
   return controlsMap.map((control) => {
     if (
       !props[control.funcName] ||
@@ -63,7 +73,9 @@ const renderControls = (
             currentSlide,
             defaultControlsConfig: props.defaultControlsConfig || {},
             goToSlide,
+            nextDisabled,
             nextSlide,
+            previousDisabled,
             previousSlide: prevSlide,
             scrollMode: props.scrollMode,
             slideCount,

--- a/packages/nuka/src/controls.tsx
+++ b/packages/nuka/src/controls.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { getControlContainerStyles } from './control-styles';
-import { nextButtonDisabled, prevButtonDisabled } from './default-controls';
+import {
+  getDotIndexes,
+  nextButtonDisabled,
+  prevButtonDisabled,
+} from './default-controls';
 import {
   InternalCarouselProps,
   Positions,
@@ -40,6 +44,14 @@ const renderControls = (
   };
   const nextDisabled = nextButtonDisabled(disableCheckProps);
   const previousDisabled = prevButtonDisabled(disableCheckProps);
+  const dotNavigationIndices = getDotIndexes(
+    slideCount,
+    slidesToScroll,
+    props.scrollMode,
+    props.slidesToShow,
+    props.wrapAround,
+    props.cellAlign
+  );
 
   return controlsMap.map((control) => {
     if (
@@ -72,6 +84,7 @@ const renderControls = (
             cellSpacing: props.cellSpacing,
             currentSlide,
             defaultControlsConfig: props.defaultControlsConfig || {},
+            dotNavigationIndices,
             goToSlide,
             nextDisabled,
             nextSlide,

--- a/packages/nuka/src/default-controls.tsx
+++ b/packages/nuka/src/default-controls.tsx
@@ -13,11 +13,14 @@ const defaultButtonStyles = (disabled: boolean): CSSProperties => ({
 });
 
 export const prevButtonDisabled = ({
-  currentSlide,
-  wrapAround,
   cellAlign,
+  currentSlide,
   slidesToShow,
-}: ControlProps) => {
+  wrapAround,
+}: Pick<
+  ControlProps,
+  'cellAlign' | 'currentSlide' | 'slidesToShow' | 'wrapAround'
+>) => {
   // inifite carousel
   if (wrapAround) {
     return false;
@@ -36,19 +39,19 @@ export const prevButtonDisabled = ({
   return false;
 };
 
-export const PreviousButton = (props: ControlProps) => {
-  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
-    event.preventDefault();
-    props?.previousSlide();
-  };
-
-  const {
+export const PreviousButton = ({
+  previousSlide,
+  defaultControlsConfig: {
     prevButtonClassName,
     prevButtonStyle = {},
     prevButtonText,
-  } = props.defaultControlsConfig || {};
-
-  const disabled = prevButtonDisabled(props);
+  },
+  previousDisabled: disabled,
+}: ControlProps) => {
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    event.preventDefault();
+    previousSlide();
+  };
 
   return (
     <button
@@ -68,12 +71,15 @@ export const PreviousButton = (props: ControlProps) => {
 };
 
 export const nextButtonDisabled = ({
+  cellAlign,
   currentSlide,
   slideCount,
   slidesToShow,
   wrapAround,
-  cellAlign,
-}: ControlProps) => {
+}: Pick<
+  ControlProps,
+  'cellAlign' | 'currentSlide' | 'slideCount' | 'slidesToShow' | 'wrapAround'
+>) => {
   // inifite carousel
   if (wrapAround) {
     return false;
@@ -95,21 +101,19 @@ export const nextButtonDisabled = ({
   return false;
 };
 
-export const NextButton = (props: ControlProps) => {
-  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
-    event.preventDefault();
-    props.nextSlide();
-  };
-
-  const { defaultControlsConfig } = props;
-
-  const {
+export const NextButton = ({
+  nextSlide,
+  defaultControlsConfig: {
     nextButtonClassName,
     nextButtonStyle = {},
     nextButtonText,
-  } = defaultControlsConfig;
-
-  const disabled = nextButtonDisabled(props);
+  },
+  nextDisabled: disabled,
+}: ControlProps) => {
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    event.preventDefault();
+    nextSlide();
+  };
 
   return (
     <button

--- a/packages/nuka/src/default-controls.tsx
+++ b/packages/nuka/src/default-controls.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable complexity */
 import React, { CSSProperties, useCallback } from 'react';
 import { Alignment, ControlProps, ScrollMode } from './types';
 import { getBoundedIndex } from './utils';

--- a/packages/nuka/src/default-controls.tsx
+++ b/packages/nuka/src/default-controls.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable complexity */
 import React, { CSSProperties, useCallback } from 'react';
 import { Alignment, ControlProps, ScrollMode } from './types';
+import { getBoundedIndex } from './utils';
 
 const defaultButtonStyles = (disabled: boolean): CSSProperties => ({
   border: 0,
@@ -223,7 +224,17 @@ export const getDotIndexes = (
   return dotIndexes;
 };
 
-export const PagingDots = (props: ControlProps) => {
+export const PagingDots = ({
+  dotNavigationIndices,
+  defaultControlsConfig: {
+    pagingDotsContainerClassName,
+    pagingDotsClassName,
+    pagingDotsStyle = {},
+  },
+  currentSlide,
+  slideCount,
+  goToSlide,
+}: ControlProps) => {
   const listStyles: CSSProperties = {
     position: 'relative',
     top: -10,
@@ -243,37 +254,20 @@ export const PagingDots = (props: ControlProps) => {
     }),
     []
   );
-
-  const indexes = getDotIndexes(
-    props.slideCount,
-    props.slidesToScroll,
-    props.scrollMode,
-    props.slidesToShow,
-    props.wrapAround,
-    props.cellAlign
-  );
-
-  const {
-    pagingDotsContainerClassName,
-    pagingDotsClassName,
-    pagingDotsStyle = {},
-  } = props.defaultControlsConfig;
+  const currentSlideBounded = getBoundedIndex(currentSlide, slideCount);
 
   return (
     <ul className={pagingDotsContainerClassName} style={listStyles}>
-      {indexes.map((index, i) => {
-        let isActive =
-          props.currentSlide === index ||
-          props.currentSlide - props.slideCount === index ||
-          props.currentSlide + props.slideCount === index;
+      {dotNavigationIndices.map((slideIndex, i) => {
+        const isActive =
+          currentSlideBounded === slideIndex ||
+          // sets navigation dots active if the current slide falls in the current index range
+          (currentSlideBounded < slideIndex &&
+            (i === 0 || currentSlideBounded > dotNavigationIndices[i - 1]));
 
-        // the below condition checks and sets navigation dots active if the current slide falls in the current index range
-        if (props.currentSlide < index && props.currentSlide > indexes[i - 1]) {
-          isActive = true;
-        }
         return (
           <li
-            key={index}
+            key={slideIndex}
             className={isActive ? 'paging-item active' : 'paging-item'}
           >
             <button
@@ -283,8 +277,8 @@ export const PagingDots = (props: ControlProps) => {
                 ...getButtonStyles(isActive),
                 ...pagingDotsStyle,
               }}
-              onClick={props.goToSlide.bind(null, index)}
-              aria-label={`slide ${index + 1} bullet`}
+              onClick={() => goToSlide(slideIndex)}
+              aria-label={`slide ${slideIndex + 1} bullet`}
               aria-selected={isActive}
             >
               <svg

--- a/packages/nuka/src/types.ts
+++ b/packages/nuka/src/types.ts
@@ -129,69 +129,53 @@ type RenderAnnounceSlideMessage = (props: {
   count: number;
 }) => string;
 
-export interface ControlProps {
-  /**
-   * When displaying more than one slide, sets which position to anchor the current slide to.
-   */
-  cellAlign: Alignment;
-
-  /**
-   * Space between slides, as an integer, but reflected as px
-   */
-  cellSpacing: number;
-
+export interface ControlProps
+  extends Pick<
+    InternalCarouselProps,
+    | 'cellAlign'
+    | 'cellSpacing'
+    | 'defaultControlsConfig'
+    | 'scrollMode'
+    | 'slidesToScroll'
+    | 'slidesToShow'
+    | 'vertical'
+    | 'wrapAround'
+  > {
   /**
    * Current slide index
    */
   currentSlide: number;
 
   /**
-   * This prop lets you apply custom classes and styles to the default Next, Previous, and Paging Dots controls
+   * Go to a specific slide
+   * @param targetIndex Index to go to
    */
-  defaultControlsConfig: DefaultControlsConfig;
+  goToSlide: (targetIndex: number) => void;
 
   /**
-   * Go to X slide method
-   * @param index Slide's index to go
+   * Whether the "next" button should be disabled or not
    */
-  goToSlide: (index: number) => void;
+  nextDisabled: boolean;
 
   /**
-   * Go to the next slide method
+   * Go to the next slide
    */
   nextSlide: () => void;
 
   /**
-   * Go to the previous slide method
+   * Whether the "previous" button should be disabled or not
+   */
+  previousDisabled: boolean;
+
+  /**
+   * Go to the previous slide
    */
   previousSlide: () => void;
-  scrollMode: ScrollMode;
 
   /**
-   * Total amount of slides
+   * Total number of slides
    */
   slideCount: number;
-
-  /**
-   * Slides to scroll at once
-   */
-  slidesToScroll: number;
-
-  /**
-   * Slides to show at once
-   */
-  slidesToShow: number;
-
-  /**
-   * Enable the slides to transition vertically
-   */
-  vertical: boolean;
-
-  /**
-   * Sets infinite wrapAround mode
-   * @default false
-   */
-  wrapAround: boolean;
 }
 
 export type RenderControlFunctionNames =

--- a/packages/nuka/src/types.ts
+++ b/packages/nuka/src/types.ts
@@ -147,6 +147,11 @@ export interface ControlProps
   currentSlide: number;
 
   /**
+   * The indices for the navigation dots
+   */
+  dotNavigationIndices: number[];
+
+  /**
    * Go to a specific slide
    * @param targetIndex Index to go to
    */

--- a/packages/nuka/src/utils.test.ts
+++ b/packages/nuka/src/utils.test.ts
@@ -1,5 +1,10 @@
 import { Alignment, ScrollMode } from './types';
-import { getNextMoveIndex, getPrevMoveIndex, isSlideVisible } from './utils';
+import {
+  getBoundedIndex,
+  getNextMoveIndex,
+  getPrevMoveIndex,
+  isSlideVisible,
+} from './utils';
 
 describe('isSlideVisible', () => {
   it.each`
@@ -341,6 +346,30 @@ describe('getPrevMoveIndex', () => {
           cellAlign
         )
       ).toEqual(expected);
+    }
+  );
+});
+
+describe('getBoundedIndex', () => {
+  it.each`
+    rawIndex | slideCount | expected
+    ${0}     | ${1}       | ${0}
+    ${1}     | ${2}       | ${1}
+    ${2}     | ${2}       | ${0}
+    ${3}     | ${2}       | ${1}
+    ${4}     | ${2}       | ${0}
+    ${-1}    | ${2}       | ${1}
+    ${-2}    | ${2}       | ${0}
+    ${-2}    | ${3}       | ${1}
+    ${-3}    | ${3}       | ${0}
+    ${-6}    | ${3}       | ${0}
+    ${-7}    | ${3}       | ${2}
+    ${-7.5}  | ${3}       | ${1.5}
+  `(
+    'gets the right index when bounds applied ' +
+      '(rawIndex $rawIndex, slideCount $slideCount)',
+    ({ rawIndex, slideCount, expected }) => {
+      expect(getBoundedIndex(rawIndex, slideCount)).toEqual(expected);
     }
   );
 });

--- a/packages/nuka/src/utils.ts
+++ b/packages/nuka/src/utils.ts
@@ -1,29 +1,6 @@
 import { getDotIndexes } from './default-controls';
 import { Alignment, ScrollMode } from './types';
 
-export const getIndexes = (
-  slide: number,
-  endSlide: number,
-  slideCount: number
-): [number, number] => {
-  let slideIndex = slide;
-  let endSlideIndex = endSlide;
-
-  if (slideIndex < 0) {
-    slideIndex += slideCount;
-  } else if (slideIndex > slideCount - 1) {
-    slideIndex -= slideCount;
-  }
-
-  if (endSlideIndex < 0) {
-    endSlideIndex += slideCount;
-  } else if (endSlideIndex > slideCount - 1) {
-    endSlideIndex -= slideCount;
-  }
-
-  return [slideIndex, endSlideIndex];
-};
-
 export const isSlideVisible = (
   currentSlide: number,
   indexToCheck: number,
@@ -141,4 +118,12 @@ export const getDefaultSlideIndex = (
   );
 
   return autoplayReverse ? dotIndexes[dotIndexes.length - 1] : dotIndexes[0];
+};
+
+/**
+ * Boils down an unbounded index (-Infinity < index < Infinity) to a bounded one
+ * (0 ≤ index < slideCount)
+ */
+export const getBoundedIndex = (rawIndex: number, slideCount: number) => {
+  return ((rawIndex % slideCount) + slideCount) % slideCount;
 };

--- a/packages/nuka/stories/carousel.stories.tsx
+++ b/packages/nuka/stories/carousel.stories.tsx
@@ -22,7 +22,7 @@ export default {
 
 /* Set up story template */
 interface StoryProps {
-  storySlideCount: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
+  storySlideCount: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14;
   slideHeights?: number[];
 }
 
@@ -253,12 +253,12 @@ KeyboardControls.args = {
 
 export const CustomControls = Template.bind({});
 CustomControls.args = {
-  wrapAround: true,
+  slidesToShow: 3,
   renderCenterLeftControls: (props: ControlProps) => (
     <button
       type="button"
-      // eslint-disable-next-line react/jsx-handler-names
       onClick={props.previousSlide}
+      disabled={props.previousDisabled}
       aria-label="Previous slide"
       style={{ background: 'none', border: 0, fontSize: '32px' }}
     >
@@ -268,8 +268,8 @@ CustomControls.args = {
   renderCenterRightControls: (props: ControlProps) => (
     <button
       type="button"
-      // eslint-disable-next-line react/jsx-handler-names
       onClick={props.nextSlide}
+      disabled={props.nextDisabled}
       aria-label="Next slide"
       style={{ background: 'none', border: 0, fontSize: '32px' }}
     >
@@ -278,7 +278,7 @@ CustomControls.args = {
   ),
   renderBottomCenterControls: (props: ControlProps) => (
     <ul style={{ display: 'flex', gap: 10, listStyle: 'none', padding: 0 }}>
-      {[...new Array(props.slideCount)].map((_, i) => (
+      {props.dotNavigationIndices.map((i) => (
         <li key={i}>
           <button
             type="button"


### PR DESCRIPTION
### Description

Adds `nextDisabled`, `previousDisabled`, and `dotNavigationIndices` to `render*Controls` callbacks to aid in the creation of custom controls.

Previously, library users would have to recreate the logic we already have inside the library for detecting when a next/prev button should be disabled, or for recreating the indices of the dots used for navigation. The logic for each of those is actually quite complex, with many edge cases, so it's very likely a library user would unintentionally introduce bugs into their program. By providing the values we use internally, they don't have to worry about recreating that logic.

#### Type of Change

- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

I used the newly provided values in the logic for rendering the default controls, so our existing test suite should catch any unexpected changes.
