### PR TITLE
Rename dotNavigationIndices -> pagingDotsIndices to be more consistent with existing prop naming

### DIFF
--- a/.changeset/shiny-cats-smell.md
+++ b/.changeset/shiny-cats-smell.md
@@ -2,4 +2,4 @@
 'nuka-carousel': minor
 ---
 
-pass nextDisabled, previousDisabled, and dotNavigationIndices to render\*Controls callbacks to aid in the creation of custom controls
+pass nextDisabled, previousDisabled, and pagingDotsIndices to render\*Controls callbacks to aid in the creation of custom controls

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ A set of eight render props for rendering controls in different positions around
   | Name                 | Type                            | Description                                             |
   | :------------------- | ------------------------------- | :------------------------------------------------------ |
   | currentSlide         | `number`                        | Current slide index                                     |
-  | dotNavigationIndices | `number[]`                      | The indices for the navigation dots                     |
+  | pagingDotsIndices    | `number[]`                      | The indices for the paging dots                         |
   | goToSlide            | `(targetIndex: number) => void` | Go to a specific slide                                  |
   | nextDisabled         | `boolean`                       | Whether the "next" button should be disabled or not     |
   | nextSlide            | `() => void`                    | Go to the next slide                                    |

--- a/packages/nuka/src/controls.tsx
+++ b/packages/nuka/src/controls.tsx
@@ -44,7 +44,7 @@ const renderControls = (
   };
   const nextDisabled = nextButtonDisabled(disableCheckProps);
   const previousDisabled = prevButtonDisabled(disableCheckProps);
-  const dotNavigationIndices = getDotIndexes(
+  const pagingDotsIndices = getDotIndexes(
     slideCount,
     slidesToScroll,
     props.scrollMode,
@@ -84,7 +84,7 @@ const renderControls = (
             cellSpacing: props.cellSpacing,
             currentSlide,
             defaultControlsConfig: props.defaultControlsConfig || {},
-            dotNavigationIndices,
+            pagingDotsIndices,
             goToSlide,
             nextDisabled,
             nextSlide,

--- a/packages/nuka/src/default-controls.tsx
+++ b/packages/nuka/src/default-controls.tsx
@@ -224,7 +224,7 @@ export const getDotIndexes = (
 };
 
 export const PagingDots = ({
-  dotNavigationIndices,
+  pagingDotsIndices,
   defaultControlsConfig: {
     pagingDotsContainerClassName,
     pagingDotsClassName,
@@ -257,12 +257,12 @@ export const PagingDots = ({
 
   return (
     <ul className={pagingDotsContainerClassName} style={listStyles}>
-      {dotNavigationIndices.map((slideIndex, i) => {
+      {pagingDotsIndices.map((slideIndex, i) => {
         const isActive =
           currentSlideBounded === slideIndex ||
           // sets navigation dots active if the current slide falls in the current index range
           (currentSlideBounded < slideIndex &&
-            (i === 0 || currentSlideBounded > dotNavigationIndices[i - 1]));
+            (i === 0 || currentSlideBounded > pagingDotsIndices[i - 1]));
 
         return (
           <li

--- a/packages/nuka/src/types.ts
+++ b/packages/nuka/src/types.ts
@@ -147,9 +147,9 @@ export interface ControlProps
   currentSlide: number;
 
   /**
-   * The indices for the navigation dots
+   * The indices for the paging dots
    */
-  dotNavigationIndices: number[];
+  pagingDotsIndices: number[];
 
   /**
    * Go to a specific slide

--- a/packages/nuka/stories/carousel.stories.tsx
+++ b/packages/nuka/stories/carousel.stories.tsx
@@ -278,7 +278,7 @@ CustomControls.args = {
   ),
   renderBottomCenterControls: (props: ControlProps) => (
     <ul style={{ display: 'flex', gap: 10, listStyle: 'none', padding: 0 }}>
-      {props.dotNavigationIndices.map((i) => (
+      {props.pagingDotsIndices.map((i) => (
         <li key={i}>
           <button
             type="button"


### PR DESCRIPTION
### Description

I overlooked the existing naming of some props when I made the name for `dotNavigationIndices`. 
```ts
DefaultControlsConfig {
  // ...
  pagingDotsClassName?: string;
  pagingDotsContainerClassName?: string;
  pagingDotsStyle?: CSSProperties;
```
so I have renamed it to `pagingDotsIndices` for better consistency.

#### Type of Change

Refactoring; the code with the `dotNavigationIndices` feature was not yet released, so it is not a breaking change.

### How Has This Been Tested?

The default components use the `pagingDotsIndices` internally, so it should be covered by our existing suite.