### PR TITLE
Feature: add default controls callbacks, onUserNavigation callback

### DIFF
--- a/.changeset/hot-ravens-explain.md
+++ b/.changeset/hot-ravens-explain.md
@@ -1,0 +1,5 @@
+---
+'nuka-carousel': minor
+---
+
+add onUserNavigation prop to listen for user-triggered navigation

--- a/.changeset/mighty-geckos-swim.md
+++ b/.changeset/mighty-geckos-swim.md
@@ -1,0 +1,5 @@
+---
+'nuka-carousel': minor
+---
+
+allow for any element or component in the nextButtonText and prevButtonText props, instead of just strings

--- a/.changeset/thick-buses-juggle.md
+++ b/.changeset/thick-buses-juggle.md
@@ -1,0 +1,5 @@
+---
+'nuka-carousel': patch
+---
+
+expands TypeScript type for innerRef to allow for the null (initial) case

--- a/.changeset/thick-buses-juggle.md
+++ b/.changeset/thick-buses-juggle.md
@@ -1,5 +1,0 @@
----
-'nuka-carousel': patch
----
-
-expands TypeScript type for innerRef to allow for the null (initial) case

--- a/.changeset/tricky-rocks-join.md
+++ b/.changeset/tricky-rocks-join.md
@@ -1,0 +1,5 @@
+---
+'nuka-carousel': minor
+---
+
+add props to enable users to hook into interactions with the default carousel controls

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ You can play with `&params` url parameter to add or remove any carousel paramete
 | cellAlign | `'left' \| 'center' \| 'right'` | When displaying more than one slide, sets which position to anchor the current slide to. | `left` |
 | cellSpacing | `number` | Space between slides, as an integer, but reflected as `px` | `0` |
 | className | `string` | Slider frame class name | `''` |
-| defaultControlsConfig | <pre>interface DefaultControlsConfig  { &#13; containerClassName?: string; &#13; nextButtonClassName?: string; &#13; nextButtonStyle?: CSSProperties; &#13; nextButtonText?: string; &#13; pagingDotsClassName?: string; &#13; pagingDotsContainerClassName?: string; &#13; pagingDotsStyle?: CSSProperties; &#13; prevButtonClassName?: string; &#13; prevButtonStyle?: CSSProperties; &#13; prevButtonText?: string; &#13;}</pre> | This prop lets you apply custom classes and styles to the default `Container`. `Next`, `Previous`, and `Paging Dots` controls. More information on how to customize these controls can be found below.| `{}` |
+| defaultControlsConfig | <pre>interface DefaultControlsConfig  { &#13; containerClassName?: string; &#13; nextButtonClassName?: string; &#13; nextButtonStyle?: CSSProperties; &#13; nextButtonText?: React.ReactNode; &#13; pagingDotsClassName?: string; &#13; pagingDotsContainerClassName?: string; &#13; pagingDotsStyle?: CSSProperties; &#13; prevButtonClassName?: string; &#13; prevButtonStyle?: CSSProperties; &#13; prevButtonText?: React.ReactNode; &#13;}</pre> | This prop lets you apply custom classes and styles to the default `Container`. `Next`, `Previous`, and `Paging Dots` controls. More information on how to customize these controls can be found below.| `{}` |
 | disableAnimation | `boolean` | When set to `true`, will disable animation. | `false` |
 | disableEdgeSwiping | `boolean` | When set to `true`, will disable swiping before first slide and after last slide. | `false` |
 | dragging | `boolean` | Enable mouse swipe/dragging. | `true` |
@@ -89,7 +89,7 @@ You can play with `&params` url parameter to add or remove any carousel paramete
 | keyCodeConfig | <pre>interface KeyCodeConfig { &#13;  firstSlide?: number[]; &#13;  lastSlide?: number[];&#13;  nextSlide?: number[]; &#13;  pause?: number[]; &#13;  previousSlide?: number[]; &#13;}</pre> | If `enableKeyboardControls` prop is true, you can pass configuration for the keyCode so you can override the default keyboard keys configured. | `{ nextSlide: [39, 68, 38, 87], previousSlide: [37, 65, 40, 83], firstSlide: [81], lastSlide: [69], pause: [32] }` |
 | onDragStart | `(e?: React.TouchEvent<HTMLDivElement> \| React.MouseEvent<HTMLDivElement>) => void;` | Adds a callback to capture event at the start of swiping/dragging slides | |
 | onDrag | `(e?: React.TouchEvent<HTMLDivElement> \| React.MouseEvent<HTMLDivElement>) => void;` | Adds a callback to capture swiping/dragging event on slides | |
-| onDragEnd | `(e?: React.TouchEvent<HTMLDivElement> \| React.MouseEvent<HTMLDivElement>) => void;` | Adds a callback to capture event at the ent of swiping/dragging slides | |
+| onDragEnd | `(e?: React.TouchEvent<HTMLDivElement> \| React.MouseEvent<HTMLDivElement>) => void;` | Adds a callback to capture event at the end of swiping/dragging slides | |
 | pauseOnHover | `boolean` | Pause autoPlay when mouse is over carousel. | `true` |
 | renderAnnounceSlideMessage | `(props: Pick<CarouselState, 'currentSlide' \| 'count'>) => string` | Renders message in the ARIA live region that is announcing the current slide on slide change | Render function that returns `"Slide {currentSlide + 1} of {slideCount}"` |
 | scrollMode | `'page' \| 'remainder'` | Set `scrollMode="remainder"` if you don't want to see the white space when you scroll to the end of a non-infinite carousel. scrollMode property is ignored when wrapAround is enabled | `'page'` |
@@ -188,13 +188,13 @@ interface DefaultControlsConfig {
   containerClassName?: string;
   nextButtonClassName?: string;
   nextButtonStyle?: CSSProperties;
-  nextButtonText?: string;
+  nextButtonText?: React.ReactNode;
   pagingDotsClassName?: string;
   pagingDotsContainerClassName?: string;
   pagingDotsStyle?: CSSProperties;
   prevButtonClassName?: string;
   prevButtonStyle?: CSSProperties;
-  prevButtonText?: string;
+  prevButtonText?: React.ReactNode;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ You can play with `&params` url parameter to add or remove any carousel paramete
 | cellAlign | `'left' \| 'center' \| 'right'` | When displaying more than one slide, sets which position to anchor the current slide to. | `left` |
 | cellSpacing | `number` | Space between slides, as an integer, but reflected as `px` | `0` |
 | className | `string` | Slider frame class name | `''` |
-| defaultControlsConfig | <pre>interface DefaultControlsConfig  { &#13; containerClassName?: string; &#13; nextButtonClassName?: string; &#13; nextButtonStyle?: CSSProperties; &#13; nextButtonText?: React.ReactNode; &#13; pagingDotsClassName?: string; &#13; pagingDotsContainerClassName?: string; &#13; pagingDotsStyle?: CSSProperties; &#13; prevButtonClassName?: string; &#13; prevButtonStyle?: CSSProperties; &#13; prevButtonText?: React.ReactNode; &#13;}</pre> | This prop lets you apply custom classes and styles to the default `Container`. `Next`, `Previous`, and `Paging Dots` controls. More information on how to customize these controls can be found below.| `{}` |
+| defaultControlsConfig | <pre>interface DefaultControlsConfig  { &#13; containerClassName?: string; &#13; nextButtonClassName?: string; &#13; nextButtonOnClick?: (event: React.MouseEvent) => void; &#13; nextButtonStyle?: CSSProperties; &#13; nextButtonText?: React.ReactNode; &#13; pagingDotsClassName?: string; &#13; pagingDotsContainerClassName?: string; &#13; pagingDotsOnClick?: (event: React.MouseEvent) => void; &#13; pagingDotsStyle?: CSSProperties; &#13; prevButtonClassName?: string; &#13; prevButtonOnClick?: (event: React.MouseEvent) => void; &#13; prevButtonStyle?: CSSProperties; &#13; prevButtonText?: React.ReactNode; &#13;}</pre> | This prop lets you apply custom classes and styles to the default `Container`. `Next`, `Previous`, and `Paging Dots` controls. More information on how to customize these controls can be found below.| `{}` |
 | disableAnimation | `boolean` | When set to `true`, will disable animation. | `false` |
 | disableEdgeSwiping | `boolean` | When set to `true`, will disable swiping before first slide and after last slide. | `false` |
 | dragging | `boolean` | Enable mouse swipe/dragging. | `true` |
@@ -187,12 +187,15 @@ Example:
 interface DefaultControlsConfig {
   containerClassName?: string;
   nextButtonClassName?: string;
+  nextButtonOnClick?: (event: React.MouseEvent) => void;
   nextButtonStyle?: CSSProperties;
   nextButtonText?: React.ReactNode;
   pagingDotsClassName?: string;
   pagingDotsContainerClassName?: string;
+  pagingDotsOnClick?: (event: React.MouseEvent) => void;
   pagingDotsStyle?: CSSProperties;
   prevButtonClassName?: string;
+  prevButtonOnClick?: (event: React.MouseEvent) => void;
   prevButtonStyle?: CSSProperties;
   prevButtonText?: React.ReactNode;
 }
@@ -202,6 +205,7 @@ The default controls used by Nuka are the `Previous` button, `Next` button, and 
 
 - The props ending with `ClassName` let you apply a custom css class to its respective control.
 - The props ending with `Style` let you apply inline styles to its respective control.
+- The props ending with `OnClick` let you listen for user interaction with the controls.
 - The text label for the `Previous` button and `Next` button can be customized using `prevButtonText` and `nextButtonText`, respectively.
 
 For example, you can change the text of the `Previous` and `Next` buttons, and change the paging dots to red by passing in the following configuration:

--- a/README.md
+++ b/README.md
@@ -87,9 +87,10 @@ You can play with `&params` url parameter to add or remove any carousel paramete
 | frameAriaLabel | `string` | Customize the aria-label of the frame container of the carousel. This is useful when you have more than one carousel on the page. | `''` |
 | innerRef | `MutableRefObject<HTMLDivElement>` | React `ref` that should be set on the carousel element | |
 | keyCodeConfig | <pre>interface KeyCodeConfig { &#13;  firstSlide?: number[]; &#13;  lastSlide?: number[];&#13;  nextSlide?: number[]; &#13;  pause?: number[]; &#13;  previousSlide?: number[]; &#13;}</pre> | If `enableKeyboardControls` prop is true, you can pass configuration for the keyCode so you can override the default keyboard keys configured. | `{ nextSlide: [39, 68, 38, 87], previousSlide: [37, 65, 40, 83], firstSlide: [81], lastSlide: [69], pause: [32] }` |
-| onDragStart | `(e?: React.TouchEvent<HTMLDivElement> \| React.MouseEvent<HTMLDivElement>) => void;` | Adds a callback to capture event at the start of swiping/dragging slides | |
-| onDrag | `(e?: React.TouchEvent<HTMLDivElement> \| React.MouseEvent<HTMLDivElement>) => void;` | Adds a callback to capture swiping/dragging event on slides | |
-| onDragEnd | `(e?: React.TouchEvent<HTMLDivElement> \| React.MouseEvent<HTMLDivElement>) => void;` | Adds a callback to capture event at the end of swiping/dragging slides | |
+| onDragStart | `(e: React.TouchEvent<HTMLDivElement> \| React.MouseEvent<HTMLDivElement>) => void;` | Adds a callback to capture event at the start of swiping/dragging slides | |
+| onDrag | `(e: React.TouchEvent<HTMLDivElement> \| React.MouseEvent<HTMLDivElement>) => void;` | Adds a callback to capture swiping/dragging event on slides | |
+| onDragEnd | `(e: React.TouchEvent<HTMLDivElement> \| React.MouseEvent<HTMLDivElement>) => void;` | Adds a callback to capture event at the end of swiping/dragging slides | |
+| onUserNavigation | `(e: React.TouchEvent \| React.MouseEvent \| React.KeyboardEvent) => void;` | Callback called when user-triggered navigation occurs: dragging/swiping, clicking one of the controls (custom controls not included), or using a keyboard shortcut | |
 | pauseOnHover | `boolean` | Pause autoPlay when mouse is over carousel. | `true` |
 | renderAnnounceSlideMessage | `(props: Pick<CarouselState, 'currentSlide' \| 'count'>) => string` | Renders message in the ARIA live region that is announcing the current slide on slide change | Render function that returns `"Slide {currentSlide + 1} of {slideCount}"` |
 | scrollMode | `'page' \| 'remainder'` | Set `scrollMode="remainder"` if you don't want to see the white space when you scroll to the end of a non-infinite carousel. scrollMode property is ignored when wrapAround is enabled | `'page'` |
@@ -122,6 +123,7 @@ A set of eight render props for rendering controls in different positions around
   cellAlign
   cellSpacing
   defaultControlsConfig
+  onUserNavigation
   scrollMode
   slidesToScroll
   slidesToShow

--- a/packages/nuka/src/carousel.test.tsx
+++ b/packages/nuka/src/carousel.test.tsx
@@ -26,23 +26,22 @@ const createCarouselRefWithMockedDimensions = ({ defaultWidth = 600 } = {}) => {
   let refValue: HTMLDivElement | null = null;
   const widthGetterMock = jest.fn(() => defaultWidth);
 
-  const carouselRef: React.MutableRefObject<HTMLDivElement | null> =
-    Object.create(
-      {},
-      {
-        current: {
-          get: () => refValue,
-          set(newValue) {
-            refValue = newValue;
-            if (refValue) {
-              Object.defineProperty(refValue, 'offsetWidth', {
-                get: widthGetterMock,
-              });
-            }
-          },
+  const carouselRef: React.MutableRefObject<HTMLDivElement> = Object.create(
+    {},
+    {
+      current: {
+        get: () => refValue,
+        set(newValue) {
+          refValue = newValue;
+          if (refValue) {
+            Object.defineProperty(refValue, 'offsetWidth', {
+              get: widthGetterMock,
+            });
+          }
         },
-      }
-    );
+      },
+    }
+  );
 
   return { ref: carouselRef, widthGetterMock };
 };

--- a/packages/nuka/src/carousel.test.tsx
+++ b/packages/nuka/src/carousel.test.tsx
@@ -111,10 +111,11 @@ describe('Carousel', () => {
       lastSlide: [69],
       pause: [32],
     };
+    const slideCount = 8;
     renderCarousel({
       enableKeyboardControls: true,
       keyCodeConfig,
-      slideCount: 8,
+      slideCount,
       beforeSlide,
     });
 
@@ -137,9 +138,129 @@ describe('Carousel', () => {
     expect(beforeSlide).toHaveBeenLastCalledWith(1, 0);
 
     fireEvent.keyDown(carouselFrame, { keyCode: keyCodeConfig.lastSlide[0] });
-    expect(beforeSlide).toHaveBeenLastCalledWith(0, 7);
+    expect(beforeSlide).toHaveBeenLastCalledWith(0, slideCount - 1);
 
     fireEvent.keyDown(carouselFrame, { keyCode: keyCodeConfig.firstSlide[0] });
-    expect(beforeSlide).toHaveBeenLastCalledWith(7, 0);
+    expect(beforeSlide).toHaveBeenLastCalledWith(slideCount - 1, 0);
+  });
+
+  it('detects user-triggered navigation', () => {
+    const beforeSlide = jest.fn();
+    const onUserNavigation = jest.fn();
+    const keyCodeConfig = {
+      nextSlide: [39],
+      previousSlide: [37],
+      firstSlide: [81],
+      lastSlide: [69],
+      pause: [32],
+    };
+    const autoplayInterval = 3000;
+    const slideCount = 8;
+    renderCarousel({
+      enableKeyboardControls: true,
+      autoplay: true,
+      autoplayInterval,
+      keyCodeConfig,
+      slideCount,
+      beforeSlide,
+      onUserNavigation,
+    });
+
+    expect(onUserNavigation).toHaveBeenCalledTimes(0);
+
+    // Let enough time pass that autoplay triggers navigation
+    act(() => {
+      jest.advanceTimersByTime(autoplayInterval);
+    });
+
+    // Make sure the navigation happened, but did not trigger the
+    // `onUserNavigation` callback (because it wasn't user-initiated)
+    expect(onUserNavigation).toHaveBeenCalledTimes(0);
+    expect(beforeSlide).toHaveBeenLastCalledWith(0, 1);
+
+    const carouselFrame = screen.getByRole('region');
+
+    // Simulating keyboard shortcut use to navigate
+    fireEvent.keyDown(carouselFrame, { keyCode: keyCodeConfig.nextSlide[0] });
+    expect(beforeSlide).toHaveBeenLastCalledWith(1, 2);
+    expect(onUserNavigation).toHaveBeenCalledTimes(1);
+
+    fireEvent.keyDown(carouselFrame, {
+      keyCode: keyCodeConfig.previousSlide[0],
+    });
+    expect(onUserNavigation).toHaveBeenCalledTimes(2);
+
+    fireEvent.keyDown(carouselFrame, { keyCode: keyCodeConfig.lastSlide[0] });
+    expect(onUserNavigation).toHaveBeenCalledTimes(3);
+
+    fireEvent.keyDown(carouselFrame, { keyCode: keyCodeConfig.firstSlide[0] });
+    expect(onUserNavigation).toHaveBeenCalledTimes(4);
+
+    // Simulating clicks on default controls to navigate
+    fireEvent.click(screen.getByRole('button', { name: /next/ }));
+    expect(onUserNavigation).toHaveBeenCalledTimes(5);
+
+    fireEvent.click(screen.getByRole('button', { name: /prev/ }));
+    expect(onUserNavigation).toHaveBeenCalledTimes(6);
+
+    fireEvent.click(screen.getByRole('button', { name: /slide 2/ }));
+    expect(onUserNavigation).toHaveBeenCalledTimes(7);
+
+    // Simulating drag to navigate
+    fireEvent.mouseDown(carouselFrame, { clientX: 100 });
+    fireEvent.mouseMove(carouselFrame, { clientX: 100 });
+    jest.advanceTimersByTime(100);
+    fireEvent.mouseUp(carouselFrame, { clientX: 700 });
+    expect(onUserNavigation).toHaveBeenCalledTimes(8);
+
+    // Simulating swipe to navigate
+    fireEvent.touchStart(carouselFrame, { touches: [{ pageX: 700 }] });
+    fireEvent.touchMove(carouselFrame, { touches: [{ pageX: 700 }] });
+    jest.advanceTimersByTime(100);
+    fireEvent.touchEnd(carouselFrame, { touches: [{ pageX: 100 }] });
+    expect(onUserNavigation).toHaveBeenCalledTimes(9);
+  });
+
+  it('calls default control callbacks when interacted with', () => {
+    const beforeSlide = jest.fn();
+    const nextButtonOnClick = jest.fn();
+    const prevButtonOnClick = jest.fn();
+    const pagingDotsOnClick = jest.fn();
+    const slideCount = 8;
+    renderCarousel({
+      slideCount,
+      beforeSlide,
+      defaultControlsConfig: {
+        nextButtonOnClick,
+        prevButtonOnClick,
+        pagingDotsOnClick,
+      },
+    });
+
+    // Simulating clicks on default controls to navigate
+    expect(nextButtonOnClick).toHaveBeenCalledTimes(0);
+    fireEvent.click(screen.getByRole('button', { name: /next/ }));
+    expect(nextButtonOnClick).toHaveBeenCalledTimes(1);
+
+    expect(prevButtonOnClick).toHaveBeenCalledTimes(0);
+    fireEvent.click(screen.getByRole('button', { name: /prev/ }));
+    expect(prevButtonOnClick).toHaveBeenCalledTimes(1);
+
+    expect(pagingDotsOnClick).toHaveBeenCalledTimes(0);
+    fireEvent.click(screen.getByRole('button', { name: /slide 2/ }));
+    expect(pagingDotsOnClick).toHaveBeenCalledTimes(1);
+
+    // Check that calling preventDefault in the custom callback will stop the
+    // default behavior (navigation) before it happens
+    const preventDefault = (event: React.FormEvent) => event.preventDefault();
+    nextButtonOnClick.mockImplementation(preventDefault);
+    prevButtonOnClick.mockImplementation(preventDefault);
+    pagingDotsOnClick.mockImplementation(preventDefault);
+
+    expect(beforeSlide).toHaveBeenCalledTimes(3);
+    fireEvent.click(screen.getByRole('button', { name: /next/ }));
+    fireEvent.click(screen.getByRole('button', { name: /prev/ }));
+    fireEvent.click(screen.getByRole('button', { name: /slide 2/ }));
+    expect(beforeSlide).toHaveBeenCalledTimes(3);
   });
 });

--- a/packages/nuka/src/carousel.test.tsx
+++ b/packages/nuka/src/carousel.test.tsx
@@ -255,8 +255,8 @@ describe('Carousel', () => {
     fireEvent.mouseDown(carouselFrame, { clientX: 100 });
     fireEvent.mouseMove(carouselFrame, { clientX: 100 });
     jest.advanceTimersByTime(10);
-    fireEvent.mouseMove(carouselFrame, { clientX: 100 });
-    fireEvent.mouseUp(carouselFrame, { clientX: 100 });
+    fireEvent.mouseMove(carouselFrame, { clientX: 105 });
+    fireEvent.mouseUp(carouselFrame, { clientX: 105 });
     expect(onUserNavigation).toHaveBeenCalledTimes(9);
   });
 

--- a/packages/nuka/src/carousel.tsx
+++ b/packages/nuka/src/carousel.tsx
@@ -393,7 +393,6 @@ export const Carousel = (rawProps: CarouselProps): React.ReactElement => {
       Math.abs(dragDistance) + Math.abs(distanceFromInertia);
 
     onDragEnd(e);
-    onUserNavigation(e);
 
     prevXPosition.current = null;
     setDragDistance(0);
@@ -442,6 +441,10 @@ export const Carousel = (rawProps: CarouselProps): React.ReactElement => {
           cellAlign
         );
       }
+    }
+
+    if (nextSlideIndex !== currentSlide) {
+      onUserNavigation(e);
     }
 
     goToSlide(nextSlideIndex);

--- a/packages/nuka/src/carousel.tsx
+++ b/packages/nuka/src/carousel.tsx
@@ -56,6 +56,7 @@ export const Carousel = (rawProps: CarouselProps): React.ReactElement => {
     onDrag,
     onDragEnd,
     onDragStart,
+    onUserNavigation,
     pauseOnHover,
     renderAnnounceSlideMessage,
     scrollMode,
@@ -323,13 +324,17 @@ export const Carousel = (rawProps: CarouselProps): React.ReactElement => {
 
     switch (keyCommand) {
       case 'nextSlide':
+        onUserNavigation(event);
         nextSlide();
         break;
       case 'previousSlide':
+        onUserNavigation(event);
         prevSlide();
         break;
       case 'firstSlide':
       case 'lastSlide': {
+        onUserNavigation(event);
+
         const dotIndices = getDotIndexes(
           slideCount,
           slidesToScroll,
@@ -338,6 +343,7 @@ export const Carousel = (rawProps: CarouselProps): React.ReactElement => {
           wrapAround,
           cellAlign
         );
+
         if (keyCommand === 'firstSlide') {
           goToSlide(dotIndices[0]);
         } else {
@@ -387,6 +393,7 @@ export const Carousel = (rawProps: CarouselProps): React.ReactElement => {
       Math.abs(dragDistance) + Math.abs(distanceFromInertia);
 
     onDragEnd(e);
+    onUserNavigation(e);
 
     prevXPosition.current = null;
     setDragDistance(0);
@@ -441,7 +448,7 @@ export const Carousel = (rawProps: CarouselProps): React.ReactElement => {
   };
 
   const onTouchStart = useCallback(
-    (e?: React.TouchEvent<HTMLDivElement>) => {
+    (e: React.TouchEvent<HTMLDivElement>) => {
       if (
         !mobileDraggingEnabled ||
         !sliderListRef.current ||

--- a/packages/nuka/src/controls.tsx
+++ b/packages/nuka/src/controls.tsx
@@ -88,6 +88,7 @@ const renderControls = (
             goToSlide,
             nextDisabled,
             nextSlide,
+            onUserNavigation: props.onUserNavigation,
             previousDisabled,
             previousSlide: prevSlide,
             scrollMode: props.scrollMode,

--- a/packages/nuka/src/default-carousel-props.tsx
+++ b/packages/nuka/src/default-carousel-props.tsx
@@ -48,6 +48,9 @@ const defaultProps: InternalCarouselProps = {
   onDragEnd: () => {
     // do nothing
   },
+  onUserNavigation: () => {
+    // do nothing
+  },
   pauseOnHover: true,
   renderAnnounceSlideMessage: defaultRenderAnnounceSlideMessage,
   renderBottomCenterControls: (props: ControlProps) => (

--- a/packages/nuka/src/default-controls.tsx
+++ b/packages/nuka/src/default-controls.tsx
@@ -45,10 +45,14 @@ export const PreviousButton = ({
     prevButtonClassName,
     prevButtonStyle = {},
     prevButtonText,
+    prevButtonOnClick,
   },
   previousDisabled: disabled,
 }: ControlProps) => {
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    prevButtonOnClick?.(event);
+    if (event.defaultPrevented) return;
+
     event.preventDefault();
     previousSlide();
   };
@@ -107,10 +111,14 @@ export const NextButton = ({
     nextButtonClassName,
     nextButtonStyle = {},
     nextButtonText,
+    nextButtonOnClick,
   },
   nextDisabled: disabled,
 }: ControlProps) => {
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    nextButtonOnClick?.(event);
+    if (event.defaultPrevented) return;
+
     event.preventDefault();
     nextSlide();
   };
@@ -229,6 +237,7 @@ export const PagingDots = ({
     pagingDotsContainerClassName,
     pagingDotsClassName,
     pagingDotsStyle = {},
+    pagingDotsOnClick,
   },
   currentSlide,
   slideCount,
@@ -276,7 +285,12 @@ export const PagingDots = ({
                 ...getButtonStyles(isActive),
                 ...pagingDotsStyle,
               }}
-              onClick={() => goToSlide(slideIndex)}
+              onClick={(event) => {
+                pagingDotsOnClick?.(event);
+                if (event.defaultPrevented) return;
+
+                goToSlide(slideIndex);
+              }}
               aria-label={`slide ${slideIndex + 1} bullet`}
               aria-selected={isActive}
             >

--- a/packages/nuka/src/default-controls.tsx
+++ b/packages/nuka/src/default-controls.tsx
@@ -47,11 +47,14 @@ export const PreviousButton = ({
     prevButtonText,
     prevButtonOnClick,
   },
+  onUserNavigation,
   previousDisabled: disabled,
 }: ControlProps) => {
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
     prevButtonOnClick?.(event);
     if (event.defaultPrevented) return;
+
+    onUserNavigation(event);
 
     event.preventDefault();
     previousSlide();
@@ -114,10 +117,13 @@ export const NextButton = ({
     nextButtonOnClick,
   },
   nextDisabled: disabled,
+  onUserNavigation,
 }: ControlProps) => {
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
     nextButtonOnClick?.(event);
     if (event.defaultPrevented) return;
+
+    onUserNavigation(event);
 
     event.preventDefault();
     nextSlide();
@@ -240,6 +246,7 @@ export const PagingDots = ({
     pagingDotsOnClick,
   },
   currentSlide,
+  onUserNavigation,
   slideCount,
   goToSlide,
 }: ControlProps) => {
@@ -288,6 +295,8 @@ export const PagingDots = ({
               onClick={(event) => {
                 pagingDotsOnClick?.(event);
                 if (event.defaultPrevented) return;
+
+                onUserNavigation(event);
 
                 goToSlide(slideIndex);
               }}

--- a/packages/nuka/src/types.ts
+++ b/packages/nuka/src/types.ts
@@ -331,7 +331,7 @@ export interface InternalCarouselProps {
   /**
    * Ref to pass to carousel element
    */
-  innerRef?: MutableRefObject<HTMLDivElement | null>;
+  innerRef?: MutableRefObject<HTMLDivElement>;
 
   /**
    * When enableKeyboardControls is enabled, Configure keyCodes for corresponding slide actions as array of keyCodes

--- a/packages/nuka/src/types.ts
+++ b/packages/nuka/src/types.ts
@@ -90,13 +90,13 @@ interface DefaultControlsConfig {
   containerClassName?: string;
   nextButtonClassName?: string;
   nextButtonStyle?: CSSProperties;
-  nextButtonText?: string;
+  nextButtonText?: ReactNode;
   pagingDotsClassName?: string;
   pagingDotsContainerClassName?: string;
   pagingDotsStyle?: CSSProperties;
   prevButtonClassName?: string;
   prevButtonStyle?: CSSProperties;
-  prevButtonText?: string;
+  prevButtonText?: ReactNode;
 }
 
 export interface KeyCodeConfig {

--- a/packages/nuka/src/types.ts
+++ b/packages/nuka/src/types.ts
@@ -89,12 +89,15 @@ export enum D3EasingFunctions {
 interface DefaultControlsConfig {
   containerClassName?: string;
   nextButtonClassName?: string;
+  nextButtonOnClick?: React.MouseEventHandler;
   nextButtonStyle?: CSSProperties;
   nextButtonText?: ReactNode;
   pagingDotsClassName?: string;
   pagingDotsContainerClassName?: string;
+  pagingDotsOnClick?: React.MouseEventHandler;
   pagingDotsStyle?: CSSProperties;
   prevButtonClassName?: string;
+  prevButtonOnClick?: React.MouseEventHandler;
   prevButtonStyle?: CSSProperties;
   prevButtonText?: ReactNode;
 }

--- a/packages/nuka/src/types.ts
+++ b/packages/nuka/src/types.ts
@@ -138,6 +138,7 @@ export interface ControlProps
     | 'cellAlign'
     | 'cellSpacing'
     | 'defaultControlsConfig'
+    | 'onUserNavigation'
     | 'scrollMode'
     | 'slidesToScroll'
     | 'slidesToShow'
@@ -341,21 +342,30 @@ export interface InternalCarouselProps {
    * optional callback function
    */
   onDragStart: (
-    e?: React.TouchEvent<HTMLDivElement> | React.MouseEvent<HTMLDivElement>
+    e: React.TouchEvent<HTMLDivElement> | React.MouseEvent<HTMLDivElement>
   ) => void;
 
   /**
    * optional callback function
    */
   onDrag: (
-    e?: React.TouchEvent<HTMLDivElement> | React.MouseEvent<HTMLDivElement>
+    e: React.TouchEvent<HTMLDivElement> | React.MouseEvent<HTMLDivElement>
   ) => void;
 
   /**
    * optional callback function
    */
   onDragEnd: (
-    e?: React.TouchEvent<HTMLDivElement> | React.MouseEvent<HTMLDivElement>
+    e: React.TouchEvent<HTMLDivElement> | React.MouseEvent<HTMLDivElement>
+  ) => void;
+
+  /**
+   * Callback called when user-triggered navigation occurs: dragging/swiping,
+   * clicking one of the controls (custom controls not included), or using a
+   * keyboard shortcut
+   */
+  onUserNavigation: (
+    e: React.TouchEvent | React.MouseEvent | React.KeyboardEvent
   ) => void;
 
   /**

--- a/packages/nuka/src/types.ts
+++ b/packages/nuka/src/types.ts
@@ -331,7 +331,7 @@ export interface InternalCarouselProps {
   /**
    * Ref to pass to carousel element
    */
-  innerRef?: MutableRefObject<HTMLDivElement>;
+  innerRef?: MutableRefObject<HTMLDivElement | null>;
 
   /**
    * When enableKeyboardControls is enabled, Configure keyCodes for corresponding slide actions as array of keyCodes


### PR DESCRIPTION
### Description

Adds:

* Three new callbacks for the default controls: `nextButtonOnClick`, `prevButtonOnClick`, `pagingDotsOnClick`
* A new callback,`onUserNavigation`, called whenever a user interaction triggered carousel navigation.
* An expanded type to `nextButtonText` and `prevButtonText` props, allowing for any element instead of just strings

The `onUserNavigation` callback in particular will provide a simple fix for a couple existing issues that want to pause autoplay following user interaction:
Fixes #918 
Fixes #499 

#### Type of Change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

New unit tests