### PR TITLE
Alternate easing api and `edgeEasing` prop

### DIFF
--- a/.changeset/tall-ghosts-act.md
+++ b/.changeset/tall-ghosts-act.md
@@ -2,4 +2,4 @@
 'nuka-carousel': minor
 ---
 
-adds d3-ease transitions to carousel
+adds the ability to use custom easing functions for the animations via `easing` and `edgeEasing`

--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ You can play with `&params` url parameter to add or remove any carousel paramete
 | disableEdgeSwiping | `boolean` | When set to `true`, will disable swiping before first slide and after last slide. | `false` |
 | dragging | `boolean` | Enable mouse swipe/dragging. | `true` |
 | dragThreshold | `number` | The percentage (from 0 to 1) of a slide that the user needs to drag before a slide change is triggered. | `0.5` |
-| easing | `(normalizedTime: number) => number` | An easing function. See the [Easing section](#easing) for more details | A cubic easeInOut function |
+| easing | `(normalizedTime: number) => number` | Animation easing function. See the [Easing section](#easing-and-edgeeasing) for more details | A cubic easeOut function |
+| edgeEasing | `(normalizedTime: number) => number` | Animation easing function when swipe exceeds edge. See the [Easing section](#easing-and-edgeeasing) for more details | A cubic easeOut function |
 | enableKeyboardControls | `boolean` | When set to `true` will enable keyboard controls when the carousel has focus. If the carousel does not have focus, keyboard controls will be ignored. | `false` |
 | frameAriaLabel | `string` | Customize the aria-label of the frame container of the carousel. This is useful when you have more than one carousel on the page. | `''` |
 | innerRef | `MutableRefObject<HTMLDivElement>` | React `ref` that should be set on the carousel element | |
@@ -168,20 +169,22 @@ Example:
 
 - NOTE: The className `slide-visible` is added to the currently visible slide or slides (when `slidesToShow` > 1). The className `slide-current` is added to the currently "active" slide.
 
-#### easing
+#### easing and edgeEasing
 
 `(normalizedTime: number) => number`
 
 A function accepting a normalized time between 0 and 1, inclusive, and returning an eased time, which equals 0 at normalizedTime==0 and equals 1 at normalizedTime==1. You can plug in your own custom easing function (e.g., `(t) => t` for a linear transition), or import functions from a different library, like [`d3-ease`](https://github.com/d3/d3-ease).
 ```jsx
-import { easeElasticOut } from 'd3-ease';
+import { easeCircleOut, easeElasticOut } from 'd3-ease';
 
 // ...
 
-<Carousel easing={easeElasticOut}>
+<Carousel easing={easeCircleOut} edgeEasing={easeElasticOut}>
   {/* Carousel Content */}
 </Carousel>
 ```
+
+Please note that using a function for `easing` with "In" in it (ease**In**Out, easeElastic**In**, etc.) will make swiping transitions feel a bit clunky, as the velocity at the end of the swipe will suddenly drop to follow the slow startup speed of the "In" easing function. In general, when using custom easing functions, try out both swiping and clicking on the navigation buttons to see how the transitions feel.
 
 #### renderAnnounceSlideMessage
 

--- a/README.md
+++ b/README.md
@@ -78,11 +78,12 @@ You can play with `&params` url parameter to add or remove any carousel paramete
 | cellAlign | `'left' \| 'center' \| 'right'` | When displaying more than one slide, sets which position to anchor the current slide to. | `left` |
 | cellSpacing | `number` | Space between slides, as an integer, but reflected as `px` | `0` |
 | className | `string` | Slider frame class name | `''` |
-| defaultControlsConfig | <pre>interface DefaultControlsConfig  { &#13; containerClassName?: string; &#13; nextButtonClassName?: string; &#13; nextButtonOnClick?: (event: React.MouseEvent) => void; &#13; nextButtonStyle?: CSSProperties; &#13; nextButtonText?: React.ReactNode; &#13; pagingDotsClassName?: string; &#13; pagingDotsContainerClassName?: string; &#13; pagingDotsOnClick?: (event: React.MouseEvent) => void; &#13; pagingDotsStyle?: CSSProperties; &#13; prevButtonClassName?: string; &#13; prevButtonOnClick?: (event: React.MouseEvent) => void; &#13; prevButtonStyle?: CSSProperties; &#13; prevButtonText?: React.ReactNode; &#13;}</pre> | This prop lets you apply custom classes and styles to the default `Container`. `Next`, `Previous`, and `Paging Dots` controls. More information on how to customize these controls can be found below.| `{}` |
+| defaultControlsConfig | <pre>interface DefaultControlsConfig  { &#13; containerClassName?: string; &#13; nextButtonClassName?: string; &#13; nextButtonOnClick?: (event: React.MouseEvent) => void; &#13; nextButtonStyle?: CSSProperties; &#13; nextButtonText?: React.ReactNode; &#13; pagingDotsClassName?: string; &#13; pagingDotsContainerClassName?: string; &#13; pagingDotsOnClick?: (event: React.MouseEvent) => void; &#13; pagingDotsStyle?: CSSProperties; &#13; prevButtonClassName?: string; &#13; prevButtonOnClick?: (event: React.MouseEvent) => void; &#13; prevButtonStyle?: CSSProperties; &#13; prevButtonText?: React.ReactNode; &#13;}</pre> | This prop lets you apply custom classes and styles to the default `Container`. `Next`, `Previous`, and `Paging Dots` controls. More information on how to customize these controls can be found in the [defaultControlsConfig section](#defaultcontrolsconfig).| `{}` |
 | disableAnimation | `boolean` | When set to `true`, will disable animation. | `false` |
 | disableEdgeSwiping | `boolean` | When set to `true`, will disable swiping before first slide and after last slide. | `false` |
 | dragging | `boolean` | Enable mouse swipe/dragging. | `true` |
 | dragThreshold | `number` | The percentage (from 0 to 1) of a slide that the user needs to drag before a slide change is triggered. | `0.5` |
+| easing | `(normalizedTime: number) => number` | An easing function. See the [Easing section](#easing) for more details | A cubic easeInOut function |
 | enableKeyboardControls | `boolean` | When set to `true` will enable keyboard controls when the carousel has focus. If the carousel does not have focus, keyboard controls will be ignored. | `false` |
 | frameAriaLabel | `string` | Customize the aria-label of the frame container of the carousel. This is useful when you have more than one carousel on the page. | `''` |
 | innerRef | `MutableRefObject<HTMLDivElement>` | React `ref` that should be set on the carousel element | |
@@ -166,6 +167,21 @@ Example:
 ```
 
 - NOTE: The className `slide-visible` is added to the currently visible slide or slides (when `slidesToShow` > 1). The className `slide-current` is added to the currently "active" slide.
+
+#### easing
+
+`(normalizedTime: number) => number`
+
+A function accepting a normalized time between 0 and 1, inclusive, and returning an eased time, which equals 0 at normalizedTime==0 and equals 1 at normalizedTime==1. You can plug in your own custom easing function (e.g., `(t) => t` for a linear transition), or import functions from a different library, like [`d3-ease`](https://github.com/d3/d3-ease).
+```jsx
+import { easeElasticOut } from 'd3-ease';
+
+// ...
+
+<Carousel easing={easeElasticOut}>
+  {/* Carousel Content */}
+</Carousel>
+```
 
 #### renderAnnounceSlideMessage
 

--- a/packages/nuka/package.json
+++ b/packages/nuka/package.json
@@ -47,6 +47,7 @@
     "@storybook/react": "^6.5.9",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.3.0",
+    "@types/d3-ease": "^3.0.0",
     "@types/exenv": "^1.2.0",
     "@types/node": "^18.7.5",
     "@types/react": "^18.0.0",

--- a/packages/nuka/package.json
+++ b/packages/nuka/package.json
@@ -54,6 +54,7 @@
     "@types/testing-library__jest-dom": "^5.14.5",
     "babel-loader": "8.1.0",
     "chromatic": "^6.2.0",
+    "d3-ease": "^3.0.1",
     "exenv": "^1.2.0",
     "jest-environment-jsdom": "^28.1.3",
     "prop-types": "^15.6.0",

--- a/packages/nuka/package.json
+++ b/packages/nuka/package.json
@@ -63,7 +63,6 @@
     "require-from-string": "^2.0.2",
     "typescript": "^4.5.2",
     "url-loader": "^4.1.1",
-    "victory-vendor": "^36.6.3",
     "webpack": "5.61.0",
     "webpack-cli": "^4.9.1",
     "webpack-dev-server": "^4.6.0"

--- a/packages/nuka/src/carousel.tsx
+++ b/packages/nuka/src/carousel.tsx
@@ -45,10 +45,8 @@ export const Carousel = (rawProps: CarouselProps): React.ReactElement => {
     children,
     className,
     disableAnimation,
-    disableEdgeSwiping,
     dragging: desktopDraggingEnabled,
     dragThreshold: propsDragThreshold,
-    easing,
     enableKeyboardControls,
     frameAriaLabel,
     innerRef,
@@ -63,7 +61,7 @@ export const Carousel = (rawProps: CarouselProps): React.ReactElement => {
     slideIndex,
     slidesToScroll: propsSlidesToScroll,
     slidesToShow,
-    speed: propsSpeed,
+    speed,
     style,
     swiping: mobileDraggingEnabled,
     wrapAround,
@@ -168,7 +166,7 @@ export const Carousel = (rawProps: CarouselProps): React.ReactElement => {
         setCurrentSlide(targetSlideBounded);
 
         // if animation is disabled decrease the speed to 40
-        const msToEndOfAnimation = !disableAnimation ? propsSpeed || 500 : 40;
+        const msToEndOfAnimation = !disableAnimation ? speed || 500 : 40;
         setTimeout(() => {
           if (!isMounted.current) return;
           afterSlide(targetSlideBounded);
@@ -182,7 +180,7 @@ export const Carousel = (rawProps: CarouselProps): React.ReactElement => {
       cellAlign,
       currentSlide,
       disableAnimation,
-      propsSpeed,
+      speed,
       slideCount,
       slidesToShow,
       wrapAround,
@@ -584,7 +582,7 @@ export const Carousel = (rawProps: CarouselProps): React.ReactElement => {
           cellSpacing={cellSpacing}
           animation={animation}
           slidesToShow={slidesToShow}
-          speed={propsSpeed}
+          speed={speed}
           zoomScale={zoomScale}
           cellAlign={cellAlign}
           onVisibleSlideHeightChange={handleVisibleSlideHeightChange}
@@ -658,18 +656,19 @@ export const Carousel = (rawProps: CarouselProps): React.ReactElement => {
           animationDistance={animationDistance}
           cellAlign={cellAlign}
           currentSlide={currentSlide}
-          disableEdgeSwiping={disableEdgeSwiping}
+          disableEdgeSwiping={props.disableEdgeSwiping}
           draggedOffset={preDragOffset.current - dragDistance}
           disableAnimation={disableAnimation}
-          easing={easing}
+          easing={props.easing}
+          edgeEasing={props.edgeEasing}
           isDragging={isDragging}
           ref={sliderListRef}
           scrollMode={scrollMode}
-          slideAnimation={animation}
+          animation={animation}
           slideCount={slideCount}
           slidesToScroll={slidesToScroll}
           slidesToShow={slidesToShow}
-          speed={propsSpeed}
+          speed={speed}
           wrapAround={wrapAround}
         >
           {wrapAround ? renderSlides('prev-cloned') : null}

--- a/packages/nuka/src/default-carousel-props.tsx
+++ b/packages/nuka/src/default-carousel-props.tsx
@@ -3,11 +3,13 @@ import {
   Alignment,
   InternalCarouselProps,
   ControlProps,
-  D3EasingFunctions,
   ScrollMode,
 } from './types';
 import { NextButton, PagingDots, PreviousButton } from './default-controls';
 import { defaultRenderAnnounceSlideMessage } from './announce-slide';
+
+const easeInOut = (t: number) =>
+  t < 0.5 ? 4 * t * t * t : (t - 1) * (2 * t - 2) * (2 * t - 2) + 1;
 
 const defaultProps: InternalCarouselProps = {
   adaptiveHeight: false,
@@ -28,8 +30,8 @@ const defaultProps: InternalCarouselProps = {
   disableEdgeSwiping: false,
   dragging: true,
   dragThreshold: 0.5,
-  easing: D3EasingFunctions.EaseCircleOut,
-  edgeEasing: D3EasingFunctions.EaseElasticOut,
+  easing: easeInOut,
+  edgeEasing: easeInOut,
   enableKeyboardControls: false,
   frameAriaLabel: 'carousel-slider',
   keyCodeConfig: {

--- a/packages/nuka/src/default-carousel-props.tsx
+++ b/packages/nuka/src/default-carousel-props.tsx
@@ -8,8 +8,7 @@ import {
 import { NextButton, PagingDots, PreviousButton } from './default-controls';
 import { defaultRenderAnnounceSlideMessage } from './announce-slide';
 
-const easeInOut = (t: number) =>
-  t < 0.5 ? 4 * t * t * t : (t - 1) * (2 * t - 2) * (2 * t - 2) + 1;
+const easeOut = (t: number) => --t * t * t + 1;
 
 const defaultProps: InternalCarouselProps = {
   adaptiveHeight: false,
@@ -30,8 +29,8 @@ const defaultProps: InternalCarouselProps = {
   disableEdgeSwiping: false,
   dragging: true,
   dragThreshold: 0.5,
-  easing: easeInOut,
-  edgeEasing: easeInOut,
+  easing: easeOut,
+  edgeEasing: easeOut,
   enableKeyboardControls: false,
   frameAriaLabel: 'carousel-slider',
   keyCodeConfig: {

--- a/packages/nuka/src/hooks/use-tween.ts
+++ b/packages/nuka/src/hooks/use-tween.ts
@@ -1,14 +1,13 @@
 import { useEffect, useState, useRef } from 'react';
-import { D3EasingFunctions } from 'src/types';
-import * as d3Ease from 'victory-vendor/d3-ease';
+import { EasingFunction } from 'src/types';
 
 /**
  * Provides an interpolated value, beginning at 0 and ending at 1, based on a
- * provided duration and d3-ease animation timing function name.
+ * provided duration and animation timing function.
  */
 export const useTween = (
-  duration: number, // in milliseconds
-  animationTimingFunction: D3EasingFunctions,
+  durationMs: number,
+  easingFunction: EasingFunction,
   currentSlide: number,
   shouldInterrupt: boolean
 ) => {
@@ -52,7 +51,7 @@ export const useTween = (
         const currentTime = Date.now();
         const normalizedTime = Math.min(
           1,
-          (currentTime - startTime.current) / duration
+          (currentTime - startTime.current) / durationMs
         );
         setNormalizedTime(normalizedTime);
 
@@ -75,10 +74,10 @@ export const useTween = (
         setNormalizedTime(1);
       }
     };
-  }, [currentSlide, duration, shouldInterrupt]);
+  }, [currentSlide, durationMs, shouldInterrupt]);
 
   return {
     isAnimating: normalizedTime !== 1,
-    value: d3Ease[animationTimingFunction](normalizedTime),
+    value: easingFunction(normalizedTime),
   };
 };

--- a/packages/nuka/src/hooks/use-tween.ts
+++ b/packages/nuka/src/hooks/use-tween.ts
@@ -8,29 +8,33 @@ import { EasingFunction } from 'src/types';
 export const useTween = (
   durationMs: number,
   easingFunction: EasingFunction,
-  currentSlide: number,
+  // navigationNum is an combination of numbers that are stable when the
+  // animation should not be running or should continue running, but change when
+  // the animation should start running. In practice, this is a combination of
+  // the animation distance and slide index.
+  navigationNum: number,
   shouldInterrupt: boolean
 ) => {
   const [normalizedTimeRaw, setNormalizedTime] = useState(1);
   const startTime = useRef(Date.now());
   const rAF = useRef<number | undefined>();
   const isFirstRender = useRef(true);
-  const lastSlide = useRef<number | null>(null);
+  const lastNavigationNum = useRef<number | null>(null);
 
-  // Detect on the first render following a slide change if the animation should
+  // Detect on the first render following navigation if the animation should
   // be running. If we wait for the useEffect, the first render will flash with
   // the slide in its destination position, before the animation triggers,
   // sending it back to the position of the first frame of the animation. This
   // approach is done in place of a useLayoutEffect, which has issues with SSR.
   const normalizedTime =
-    lastSlide.current === null ||
-    lastSlide.current === currentSlide ||
+    lastNavigationNum.current === null ||
+    lastNavigationNum.current === navigationNum ||
     shouldInterrupt
       ? normalizedTimeRaw
       : 0; // 0 here indicates the animation has begun
 
   useEffect(() => {
-    lastSlide.current = currentSlide;
+    lastNavigationNum.current = navigationNum;
 
     // Skip the first render as we don't want to trigger the animation right off
     // the bat
@@ -74,7 +78,7 @@ export const useTween = (
         setNormalizedTime(1);
       }
     };
-  }, [currentSlide, durationMs, shouldInterrupt]);
+  }, [navigationNum, durationMs, shouldInterrupt]);
 
   return {
     isAnimating: normalizedTime !== 1,

--- a/packages/nuka/src/slider-list.tsx
+++ b/packages/nuka/src/slider-list.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode } from 'react';
 import { getDotIndexes } from './default-controls';
 import { useTween } from './hooks/use-tween';
-import { Alignment, D3EasingFunctions, ScrollMode } from './types';
+import { Alignment, EasingFunction, ScrollMode } from './types';
 
 export const getPercentOffsetForSlide = (
   currentSlide: number,
@@ -44,7 +44,7 @@ interface SliderListProps {
   disableAnimation: boolean;
   disableEdgeSwiping: boolean;
   draggedOffset: number;
-  easing: D3EasingFunctions;
+  easing: EasingFunction;
   isDragging: boolean;
   scrollMode: ScrollMode;
   slideAnimation?: 'fade' | 'zoom';

--- a/packages/nuka/src/slider-list.tsx
+++ b/packages/nuka/src/slider-list.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode } from 'react';
 import { getDotIndexes } from './default-controls';
 import { useTween } from './hooks/use-tween';
-import { Alignment, EasingFunction, ScrollMode } from './types';
+import { Alignment, InternalCarouselProps } from './types';
 
 export const getPercentOffsetForSlide = (
   currentSlide: number,
@@ -36,28 +36,33 @@ export const getPercentOffsetForSlide = (
   return slide0Offset - currentSlideOffsetFrom0;
 };
 
-interface SliderListProps {
+interface SliderListProps
+  extends Pick<
+    InternalCarouselProps,
+    | 'cellAlign'
+    | 'disableAnimation'
+    | 'disableEdgeSwiping'
+    | 'easing'
+    | 'edgeEasing'
+    | 'scrollMode'
+    | 'animation'
+    | 'slidesToScroll'
+    | 'slidesToShow'
+    | 'speed'
+    | 'wrapAround'
+  > {
   animationDistance: number;
-  cellAlign: Alignment;
   children: ReactNode;
   currentSlide: number;
-  disableAnimation: boolean;
-  disableEdgeSwiping: boolean;
   draggedOffset: number;
-  easing: EasingFunction;
   isDragging: boolean;
-  scrollMode: ScrollMode;
-  slideAnimation?: 'fade' | 'zoom';
   slideCount: number;
-  slidesToScroll: number;
-  slidesToShow: number;
-  speed: number;
-  wrapAround: boolean;
 }
 
 export const SliderList = React.forwardRef<HTMLDivElement, SliderListProps>(
   (
     {
+      animation,
       animationDistance,
       cellAlign,
       children,
@@ -66,9 +71,9 @@ export const SliderList = React.forwardRef<HTMLDivElement, SliderListProps>(
       disableEdgeSwiping,
       draggedOffset,
       easing,
+      edgeEasing,
       isDragging,
       scrollMode,
-      slideAnimation,
       slideCount,
       slidesToScroll,
       slidesToShow,
@@ -77,13 +82,6 @@ export const SliderList = React.forwardRef<HTMLDivElement, SliderListProps>(
     },
     forwardedRef
   ) => {
-    const { value: transition, isAnimating } = useTween(
-      speed,
-      easing,
-      currentSlide,
-      isDragging || disableAnimation || slideAnimation === 'fade'
-    );
-
     // When wrapAround is enabled, we show the slides 3 times
     const renderedSlideCount = wrapAround ? 3 * slideCount : slideCount;
 
@@ -96,19 +94,20 @@ export const SliderList = React.forwardRef<HTMLDivElement, SliderListProps>(
       wrapAround,
     ] as const;
 
-    // When disableEdgeSwiping=true, we recycle dot index generation to determine
-    // the leftmost and rightmost indices used, to be used in calculating the
-    // x-translation values we need to limit to.
+    // We recycle dot index generation to determine the leftmost and rightmost
+    // indices used, to be used in calculating the x-translation values we need
+    // to limit to or when edgeEasing should be used.
+    const dotIndexes = getDotIndexes(
+      slideCount,
+      slidesToScroll,
+      scrollMode,
+      slidesToShow,
+      wrapAround,
+      cellAlign
+    );
+
     let clampedDraggedOffset = `${draggedOffset}px`;
     if (isDragging && disableEdgeSwiping && !wrapAround) {
-      const dotIndexes = getDotIndexes(
-        slideCount,
-        slidesToScroll,
-        scrollMode,
-        slidesToShow,
-        wrapAround,
-        cellAlign
-      );
       const clampOffsets = [
         dotIndexes[0],
         dotIndexes[dotIndexes.length - 1],
@@ -123,6 +122,19 @@ export const SliderList = React.forwardRef<HTMLDivElement, SliderListProps>(
     const slideBasedOffset = getPercentOffsetForSlide(
       currentSlide,
       ...percentOffsetForSlideProps
+    );
+
+    const isEdgeEasing =
+      !disableEdgeSwiping &&
+      !wrapAround &&
+      ((currentSlide === dotIndexes[0] && animationDistance < 0) ||
+        (currentSlide === dotIndexes[dotIndexes.length - 1] &&
+          animationDistance > 0));
+    const { value: transition, isAnimating } = useTween(
+      speed,
+      !isEdgeEasing ? easing : edgeEasing,
+      currentSlide,
+      isDragging || disableAnimation || animation === 'fade'
     );
 
     // Return undefined if the transform would be 0 pixels since transforms can

--- a/packages/nuka/src/slider-list.tsx
+++ b/packages/nuka/src/slider-list.tsx
@@ -133,7 +133,11 @@ export const SliderList = React.forwardRef<HTMLDivElement, SliderListProps>(
     const { value: transition, isAnimating } = useTween(
       speed,
       !isEdgeEasing ? easing : edgeEasing,
-      currentSlide,
+      // animationDistance is assumed to be unique enough that it can be used to
+      // detect when a new animation should start. This is used in addition to
+      // currentSlide because some animations, such as those with edgeEasing, do
+      // not occur due to a change in value of currentSlide
+      currentSlide + animationDistance,
       isDragging || disableAnimation || animation === 'fade'
     );
 

--- a/packages/nuka/src/types.ts
+++ b/packages/nuka/src/types.ts
@@ -276,8 +276,6 @@ export interface InternalCarouselProps {
   easing: EasingFunction;
 
   /**
-   * Not migrated yet
-   *
    * Animation easing function when swipe exceeds edge
    */
   edgeEasing: EasingFunction;

--- a/packages/nuka/src/types.ts
+++ b/packages/nuka/src/types.ts
@@ -46,46 +46,6 @@ export enum ScrollMode {
   remainder = 'remainder',
 }
 
-export enum D3EasingFunctions {
-  EaseLinear = 'easeLinear',
-  EaseQuad = 'easeQuad',
-  EaseQuadIn = 'easeQuadIn',
-  EaseQuadOut = 'easeQuadOut',
-  EaseQuadInOut = 'easeQuadInOut',
-  EaseCubic = 'easeCubic',
-  EaseCubicIn = 'easeCubicIn',
-  EaseCubicOut = 'easeCubicOut',
-  EaseCubicInOut = 'easeCubicInOut',
-  EasePoly = 'easePoly',
-  EasePolyIn = 'easePolyIn',
-  EasePolyOut = 'easePolyOut',
-  EasePolyInOut = 'easePolyInOut',
-  EaseSin = 'easeSin',
-  EaseSinIn = 'easeSinIn',
-  EaseSinOut = 'easeSinOut',
-  EaseSinInOut = 'easeSinInOut',
-  EaseExp = 'easeExp',
-  EaseExpIn = 'easeExpIn',
-  EaseExpOut = 'easeExpOut',
-  EaseExpInOut = 'easeExpInOut',
-  EaseCircle = 'easeCircle',
-  EaseCircleIn = 'easeCircleIn',
-  EaseCircleOut = 'easeCircleOut',
-  EaseCircleInOut = 'easeCircleInOut',
-  EaseBack = 'easeBack',
-  EaseBackIn = 'easeBackIn',
-  EaseBackOut = 'easeBackOut',
-  EaseBackInOut = 'easeBackInOut',
-  EaseBounce = 'easeBounce',
-  EaseBounceIn = 'easeBounceIn',
-  EaseBounceOut = 'easeBounceOut',
-  EaseBounceInOut = 'easeBounceInOut',
-  EaseElastic = 'easeElastic',
-  EaseElasticIn = 'easeElasticIn',
-  EaseElasticOut = 'easeElasticOut',
-  EaseElasticInOut = 'easeElasticInOut',
-}
-
 interface DefaultControlsConfig {
   containerClassName?: string;
   nextButtonClassName?: string;
@@ -205,6 +165,13 @@ export type RenderControlFunctionNames =
  */
 type RenderControls = ((props: ControlProps) => ReactNode) | null;
 
+/**
+ * Animation easing function accepting a normalized time between 0 and 1,
+ * inclusive, and returning an eased time, which equals 0 at normalizedTime==0
+ * and equals 1 at normalizedTime==1
+ */
+export type EasingFunction = (normalizedTime: number) => number;
+
 export interface InternalCarouselProps {
   /**
    * If it's set to true, the carousel will adapt its height to the visible slides.
@@ -305,17 +272,15 @@ export interface InternalCarouselProps {
 
   /**
    * Animation easing function
-   * @see https://github.com/d3/d3-ease
    */
-  easing: D3EasingFunctions;
+  easing: EasingFunction;
 
   /**
    * Not migrated yet
    *
    * Animation easing function when swipe exceeds edge
-   * @see https://github.com/d3/d3-ease
    */
-  edgeEasing: D3EasingFunctions;
+  edgeEasing: EasingFunction;
 
   /**
    * When set to true, disable keyboard controls

--- a/packages/nuka/stories/carousel.stories.tsx
+++ b/packages/nuka/stories/carousel.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { ComponentMeta, Story } from '@storybook/react';
 import isChromatic from 'chromatic/isChromatic';
 import { renderToString } from 'react-dom/server';
+import { easeElasticOut } from 'd3-ease';
 
 import Carousel, {
   Alignment,
@@ -87,7 +88,7 @@ Vertical.args = {
 
 export const CustomEasing = Template.bind({});
 CustomEasing.args = {
-  easing: 'easeElasticOut',
+  easing: easeElasticOut,
   speed: 1000,
   wrapAround: true,
   slidesToShow: 3,

--- a/packages/nuka/stories/carousel.stories.tsx
+++ b/packages/nuka/stories/carousel.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ComponentMeta, Story } from '@storybook/react';
 import isChromatic from 'chromatic/isChromatic';
 import { renderToString } from 'react-dom/server';
-import { easeElasticOut } from 'd3-ease';
+import { easeLinear, easeElasticOut } from 'd3-ease';
 
 import Carousel, {
   Alignment,
@@ -88,9 +88,9 @@ Vertical.args = {
 
 export const CustomEasing = Template.bind({});
 CustomEasing.args = {
-  easing: easeElasticOut,
-  speed: 1000,
-  wrapAround: true,
+  easing: easeLinear,
+  edgeEasing: easeElasticOut,
+  speed: 500,
   slidesToShow: 3,
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,7 @@ importers:
       '@types/testing-library__jest-dom': ^5.14.5
       babel-loader: 8.1.0
       chromatic: ^6.2.0
+      d3-ease: ^3.0.1
       exenv: ^1.2.0
       jest-environment-jsdom: ^28.1.3
       prop-types: ^15.6.0
@@ -134,6 +135,7 @@ importers:
       '@types/testing-library__jest-dom': 5.14.5
       babel-loader: 8.1.0_jfosicmxnsybihywoftrtwahny
       chromatic: 6.7.0
+      d3-ease: 3.0.1
       exenv: 1.2.2
       jest-environment-jsdom: 28.1.3
       prop-types: 15.8.1
@@ -6827,6 +6829,11 @@ packages:
       tmp: 0.2.1
       untildify: 4.0.0
       yauzl: 2.10.0
+    dev: true
+
+  /d3-ease/3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
     dev: true
 
   /d3-timer/1.0.10:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,7 +114,6 @@ importers:
       require-from-string: ^2.0.2
       typescript: ^4.5.2
       url-loader: ^4.1.1
-      victory-vendor: ^36.6.3
       webpack: 5.61.0
       webpack-cli: ^4.9.1
       webpack-dev-server: ^4.6.0
@@ -144,7 +143,6 @@ importers:
       require-from-string: 2.0.2
       typescript: 4.7.4
       url-loader: 4.1.1_webpack@5.61.0
-      victory-vendor: 36.6.3
       webpack: 5.61.0_webpack-cli@4.10.0
       webpack-cli: 4.10.0_mqvvxh2zrpv77lcdiwl6knu6ra
       webpack-dev-server: 4.9.3_gsf3kbl7lkd67oqwp76ivzgfha
@@ -4070,48 +4068,6 @@ packages:
       '@types/node': 18.7.5
     dev: true
 
-  /@types/d3-array/3.0.3:
-    resolution: {integrity: sha512-Reoy+pKnvsksN0lQUlcH6dOGjRZ/3WRwXR//m+/8lt1BXeI4xyaUZoqULNjyXXRuh0Mj4LNpkCvhUpQlY3X5xQ==}
-    dev: true
-
-  /@types/d3-color/3.1.0:
-    resolution: {integrity: sha512-HKuicPHJuvPgCD+np6Se9MQvS6OCbJmOjGvylzMJRlDwUXjKTTXs6Pwgk79O09Vj/ho3u1ofXnhFOaEWWPrlwA==}
-    dev: true
-
-  /@types/d3-ease/3.0.0:
-    resolution: {integrity: sha512-aMo4eaAOijJjA6uU+GIeW018dvy9+oH5Y2VPPzjjfxevvGQ/oRDs+tfYC9b50Q4BygRR8yE2QCLsrT0WtAVseA==}
-    dev: true
-
-  /@types/d3-interpolate/3.0.1:
-    resolution: {integrity: sha512-jx5leotSeac3jr0RePOH1KdR9rISG91QIE4Q2PYTu4OymLTZfA3SrnURSLzKH48HmXVUru50b8nje4E79oQSQw==}
-    dependencies:
-      '@types/d3-color': 3.1.0
-    dev: true
-
-  /@types/d3-path/3.0.0:
-    resolution: {integrity: sha512-0g/A+mZXgFkQxN3HniRDbXMN79K3CdTpLsevj+PXiTcb2hVyvkZUBg37StmgCQkaD84cUJ4uaDAWq7UJOQy2Tg==}
-    dev: true
-
-  /@types/d3-scale/4.0.2:
-    resolution: {integrity: sha512-Yk4htunhPAwN0XGlIwArRomOjdoBFXC3+kCxK2Ubg7I9shQlVSJy/pG/Ht5ASN+gdMIalpk8TJ5xV74jFsetLA==}
-    dependencies:
-      '@types/d3-time': 3.0.0
-    dev: true
-
-  /@types/d3-shape/3.1.0:
-    resolution: {integrity: sha512-jYIYxFFA9vrJ8Hd4Se83YI6XF+gzDL1aC5DCsldai4XYYiVNdhtpGbA/GM6iyQ8ayhSp3a148LY34hy7A4TxZA==}
-    dependencies:
-      '@types/d3-path': 3.0.0
-    dev: true
-
-  /@types/d3-time/3.0.0:
-    resolution: {integrity: sha512-sZLCdHvBUcNby1cB6Fd3ZBrABbjz3v1Vm90nysCQ6Vt7vd6e/h9Lt7SiJUoEX0l4Dzc7P5llKyhqSi1ycSf1Hg==}
-    dev: true
-
-  /@types/d3-timer/3.0.0:
-    resolution: {integrity: sha512-HNB/9GHqu7Fo8AQiugyJbv6ZxYz58wef0esl4Mv828w1ZKpAshw/uFWVDUcIB9KKFeFKoxS3cHY07FFgtTRZ1g==}
-    dev: true
-
   /@types/eslint-scope/3.7.4:
     resolution: {integrity: sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==}
     dependencies:
@@ -6873,79 +6829,8 @@ packages:
       yauzl: 2.10.0
     dev: true
 
-  /d3-array/3.2.0:
-    resolution: {integrity: sha512-3yXFQo0oG3QCxbF06rMPFyGRMGJNS7NvsV1+2joOjbBE+9xvWQ8+GcMJAjRCzw06zQ3/arXeJgbPYcjUCuC+3g==}
-    engines: {node: '>=12'}
-    dependencies:
-      internmap: 2.0.3
-    dev: true
-
-  /d3-color/3.1.0:
-    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
-    engines: {node: '>=12'}
-    dev: true
-
-  /d3-ease/3.0.1:
-    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
-    engines: {node: '>=12'}
-    dev: true
-
-  /d3-format/3.1.0:
-    resolution: {integrity: sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==}
-    engines: {node: '>=12'}
-    dev: true
-
-  /d3-interpolate/3.0.1:
-    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
-    engines: {node: '>=12'}
-    dependencies:
-      d3-color: 3.1.0
-    dev: true
-
-  /d3-path/3.0.1:
-    resolution: {integrity: sha512-gq6gZom9AFZby0YLduxT1qmrp4xpBA1YZr19OI717WIdKE2OM5ETq5qrHLb301IgxhLwcuxvGZVLeeWc/k1I6w==}
-    engines: {node: '>=12'}
-    dev: true
-
-  /d3-scale/4.0.2:
-    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
-    engines: {node: '>=12'}
-    dependencies:
-      d3-array: 3.2.0
-      d3-format: 3.1.0
-      d3-interpolate: 3.0.1
-      d3-time: 3.0.0
-      d3-time-format: 4.1.0
-    dev: true
-
-  /d3-shape/3.1.0:
-    resolution: {integrity: sha512-tGDh1Muf8kWjEDT/LswZJ8WF85yDZLvVJpYU9Nq+8+yW1Z5enxrmXOhTArlkaElU+CTn0OTVNli+/i+HP45QEQ==}
-    engines: {node: '>=12'}
-    dependencies:
-      d3-path: 3.0.1
-    dev: true
-
-  /d3-time-format/4.1.0:
-    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
-    engines: {node: '>=12'}
-    dependencies:
-      d3-time: 3.0.0
-    dev: true
-
-  /d3-time/3.0.0:
-    resolution: {integrity: sha512-zmV3lRnlaLI08y9IMRXSDshQb5Nj77smnfpnd2LrBa/2K281Jijactokeak14QacHs/kKq0AQ121nidNYlarbQ==}
-    engines: {node: '>=12'}
-    dependencies:
-      d3-array: 3.2.0
-    dev: true
-
   /d3-timer/1.0.10:
     resolution: {integrity: sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==}
-    dev: true
-
-  /d3-timer/3.0.1:
-    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
-    engines: {node: '>=12'}
     dev: true
 
   /damerau-levenshtein/1.0.8:
@@ -9468,11 +9353,6 @@ packages:
       get-intrinsic: 1.1.2
       has: 1.0.3
       side-channel: 1.0.4
-    dev: true
-
-  /internmap/2.0.3:
-    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
-    engines: {node: '>=12'}
     dev: true
 
   /interpret/1.4.0:
@@ -14961,25 +14841,6 @@ packages:
       is-buffer: 2.0.5
       unist-util-stringify-position: 2.0.3
       vfile-message: 2.0.4
-    dev: true
-
-  /victory-vendor/36.6.3:
-    resolution: {integrity: sha512-iXr0si2zuKUqLI+AXNT8/tk8ySugek4qZCy6s02CFcoBoYgM5kb15HPda5aPNT53XRXKzWlIsoHUxMZ4u/sz+w==}
-    dependencies:
-      '@types/d3-array': 3.0.3
-      '@types/d3-ease': 3.0.0
-      '@types/d3-interpolate': 3.0.1
-      '@types/d3-scale': 4.0.2
-      '@types/d3-shape': 3.1.0
-      '@types/d3-time': 3.0.0
-      '@types/d3-timer': 3.0.0
-      d3-array: 3.2.0
-      d3-ease: 3.0.1
-      d3-interpolate: 3.0.1
-      d3-scale: 4.0.2
-      d3-shape: 3.1.0
-      d3-time: 3.0.0
-      d3-timer: 3.0.1
     dev: true
 
   /vm-browserify/1.1.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,7 @@ importers:
       '@storybook/react': ^6.5.9
       '@testing-library/jest-dom': ^5.16.5
       '@testing-library/react': ^13.3.0
+      '@types/d3-ease': ^3.0.0
       '@types/exenv': ^1.2.0
       '@types/node': ^18.7.5
       '@types/react': ^18.0.0
@@ -128,6 +129,7 @@ importers:
       '@storybook/react': 6.5.9_vegu647ne3vytk4lqkmtxbp7hu
       '@testing-library/jest-dom': 5.16.5
       '@testing-library/react': 13.3.0_biqbaboplfbrettd7655fr4n2y
+      '@types/d3-ease': 3.0.0
       '@types/exenv': 1.2.0
       '@types/node': 18.7.5
       '@types/react': 18.0.15
@@ -4068,6 +4070,10 @@ packages:
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
     dependencies:
       '@types/node': 18.7.5
+    dev: true
+
+  /@types/d3-ease/3.0.0:
+    resolution: {integrity: sha512-aMo4eaAOijJjA6uU+GIeW018dvy9+oH5Y2VPPzjjfxevvGQ/oRDs+tfYC9b50Q4BygRR8yE2QCLsrT0WtAVseA==}
     dev: true
 
   /@types/eslint-scope/3.7.4:


### PR DESCRIPTION
### Description

Instead of bundling in the d3-ease functions, the easing prop now accepts a callback that accepts functions of a form identical to [d3-ease’s ease functions](https://github.com/d3/d3-ease). That way those who want to customize their easing function can, those who want to use d3-ease’s functions can (and benefit from tree-shaking of the ones they don't use), and those who are happy with the default don't have to bear the extra weight of added d3 ease functions. And we get to sidestep all the d3 ESM mess. The README now includes a code snippet showing how users might use the new API.

As I was working on that, I noticed there was an old easing prop, `edgeEasing` that hadn't been addressed yet, so I added that in, too.

And as I was working on that, I noticed that there's a bit of an animation bug in that edge swipes result in the carousel flashing into its final position for one frame before starting the animation, so I added a kind of rough workaround for that.

#### Type of Change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [?] Breaking change (fix or feature that would cause existing functionality to not work as expected) **It would be a breaking change, save for the fact that we haven't released a version with `easing` available yet**
- [x] This change requires a documentation update

### How Has This Been Tested?

Manually