### PR TITLE
Set draggable=false on only children of the SliderList, not the whole document

### DIFF
--- a/.changeset/metal-teachers-behave.md
+++ b/.changeset/metal-teachers-behave.md
@@ -1,0 +1,5 @@
+---
+'nuka-carousel': patch
+---
+
+Applies draggable=false only to children of sliderList, not entire document

--- a/packages/nuka/src/carousel.tsx
+++ b/packages/nuka/src/carousel.tsx
@@ -92,24 +92,26 @@ export const Carousel = (rawProps: CarouselProps): React.ReactElement => {
 
   const prevXPosition = useRef<number | null>(null);
   const preDragOffset = useRef<number>(0);
-  const sliderListRef = useRef<HTMLDivElement>(null);
+  const sliderListRef = useRef<HTMLDivElement | null>(null);
   const defaultCarouselRef = useRef<HTMLDivElement>(null);
   const autoplayTimeout = useRef<ReturnType<typeof setTimeout>>();
   const autoplayLastTriggeredRef = useRef<number | null>(null);
   const isMounted = useRef<boolean>(true);
+
+  const setSliderListRef = useCallback((node: HTMLDivElement) => {
+    if (node) {
+      node
+        .querySelectorAll('.slider-list img')
+        .forEach((el) => el.setAttribute('draggable', 'false'));
+    }
+    sliderListRef.current = node;
+  }, []);
 
   useEffect(() => {
     isMounted.current = true;
     return () => {
       isMounted.current = false;
     };
-  }, []);
-
-  useEffect(() => {
-    // disable img draggable attribute by default, this will improve the dragging
-    document
-      .querySelectorAll('.slider-list img')
-      .forEach((el) => el.setAttribute('draggable', 'false'));
   }, []);
 
   const carouselRef = innerRef || defaultCarouselRef;
@@ -662,7 +664,7 @@ export const Carousel = (rawProps: CarouselProps): React.ReactElement => {
           easing={props.easing}
           edgeEasing={props.edgeEasing}
           isDragging={isDragging}
-          ref={sliderListRef}
+          ref={setSliderListRef}
           scrollMode={scrollMode}
           animation={animation}
           slideCount={slideCount}

--- a/packages/nuka/src/carousel.tsx
+++ b/packages/nuka/src/carousel.tsx
@@ -100,6 +100,9 @@ export const Carousel = (rawProps: CarouselProps): React.ReactElement => {
 
   const setSliderListRef = useCallback((node: HTMLDivElement) => {
     if (node) {
+      // disable img draggable attribute by default, this will improve the dragging
+      // applying the querySelectorAll on just the descendants of the sliderList prevents
+      // impacting DOM elements outside our scope
       node
         .querySelectorAll('.slider-list img')
         .forEach((el) => el.setAttribute('draggable', 'false'));


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
Nuka Carousel currently applies its `.slider-list img` query selector to the entire document, rather than the narrower scope it ought to impact.
In case of conflicting class names, Nuka Carousel may impact elements beyond its own scope.

#### Another less common reason:
I intend to use Nuka Carousel inside a React portal which portals its content into an `<iframe />` element. Because my React code runs on the host window, libraries which access the global `window` & `document` end up impacting *only the content outside the iframe*. The motivation behind portaling into an iframe is to shelter my UI from undue influence from the host page it is embedded on (and shelter the host page from things my code may be doing). If I depend on libraries which access the global `window` or `document`, things will break ¯\_(ツ)_/¯

<!-- List any dependencies that are required for this change. -->

#### Type of Change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

I ran the whole test suite, and also verified that the `draggable=false` attribute was being set on the demo carousel images.

<!-- Please describe the tests that you ran to verify your changes. -->

<!-- Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

### Checklist

<!-- (Feel free to delete this section upon completion) -->

- [x] My code follows the style guidelines of this project (I have run `pnpm run lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (I have run `pnpm run test:ci-with-server`/`pnpm run test`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have recorded any user-facing fixes or changes with `pnpm changeset`.
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
