### PR TITLE
Fix the Alignment type so library users don't need to import an enum

### DIFF
--- a/.changeset/modern-falcons-tan.md
+++ b/.changeset/modern-falcons-tan.md
@@ -1,0 +1,5 @@
+---
+'nuka-carousel': patch
+---
+
+fix the Alignment type so library users don't need to import an enum for a simple value

--- a/packages/nuka/src/default-carousel-props.tsx
+++ b/packages/nuka/src/default-carousel-props.tsx
@@ -1,10 +1,5 @@
 import React from 'react';
-import {
-  Alignment,
-  InternalCarouselProps,
-  ControlProps,
-  ScrollMode,
-} from './types';
+import { InternalCarouselProps, ControlProps, ScrollMode } from './types';
 import { NextButton, PagingDots, PreviousButton } from './default-controls';
 import { defaultRenderAnnounceSlideMessage } from './announce-slide';
 
@@ -22,7 +17,7 @@ const defaultProps: InternalCarouselProps = {
   beforeSlide: () => {
     // do nothing
   },
-  cellAlign: Alignment.Left,
+  cellAlign: 'left',
   cellSpacing: 0,
   defaultControlsConfig: {},
   disableAnimation: false,

--- a/packages/nuka/src/default-controls.test.tsx
+++ b/packages/nuka/src/default-controls.test.tsx
@@ -1,4 +1,4 @@
-import { Alignment, ControlProps, ScrollMode } from './types';
+import { ControlProps, ScrollMode } from './types';
 import {
   getDotIndexes,
   nextButtonDisabled,
@@ -107,7 +107,7 @@ describe('getDotIndexes', () => {
           ScrollMode.page, // ignored
           slidesToShow,
           true,
-          Alignment.Left
+          'left'
         )
       ).toEqual(expected);
     }

--- a/packages/nuka/src/default-controls.tsx
+++ b/packages/nuka/src/default-controls.tsx
@@ -1,5 +1,5 @@
 import React, { CSSProperties, useCallback } from 'react';
-import { Alignment, ControlProps, ScrollMode } from './types';
+import { CellAlign, ControlProps, ScrollMode } from './types';
 import { getBoundedIndex } from './utils';
 
 const defaultButtonStyles = (disabled: boolean): CSSProperties => ({
@@ -152,7 +152,7 @@ export const getDotIndexes = (
   scrollMode: ScrollMode,
   slidesToShow: number,
   wrapAround: boolean,
-  cellAlign: Alignment
+  cellAlign: CellAlign
 ) => {
   const dotIndexes: number[] = [];
   const scrollSlides = slidesToScroll <= 0 ? 1 : slidesToScroll;

--- a/packages/nuka/src/default-controls.tsx
+++ b/packages/nuka/src/default-controls.tsx
@@ -32,7 +32,7 @@ export const prevButtonDisabled = ({
   }
 
   // remainder scroll mode
-  if (cellAlign === Alignment.Right && currentSlide <= slidesToShow - 1) {
+  if (cellAlign === 'right' && currentSlide <= slidesToShow - 1) {
     return true;
   }
 
@@ -98,10 +98,7 @@ export const nextButtonDisabled = ({
   }
 
   // remainder scroll mode
-  if (
-    cellAlign === Alignment.Left &&
-    currentSlide >= slideCount - slidesToShow
-  ) {
+  if (cellAlign === 'left' && currentSlide >= slideCount - slidesToShow) {
     return true;
   }
 
@@ -168,7 +165,7 @@ export const getDotIndexes = (
     return dotIndexes;
   }
 
-  if (cellAlign === Alignment.Center) {
+  if (cellAlign === 'center') {
     for (let i = 0; i < slideCount - 1; i += scrollSlides) {
       dotIndexes.push(i);
     }
@@ -180,7 +177,7 @@ export const getDotIndexes = (
     return dotIndexes;
   }
 
-  if (cellAlign === Alignment.Left) {
+  if (cellAlign === 'left') {
     if (slidesToShow >= slideCount) {
       return [0];
     }
@@ -200,7 +197,7 @@ export const getDotIndexes = (
     return dotIndexes;
   }
 
-  if (cellAlign === Alignment.Right) {
+  if (cellAlign === 'right') {
     if (slidesToShow >= slideCount) {
       return [slideCount - 1];
     }

--- a/packages/nuka/src/slide.tsx
+++ b/packages/nuka/src/slide.tsx
@@ -1,5 +1,5 @@
 import React, { CSSProperties, ReactNode, useRef, useEffect } from 'react';
-import { Alignment } from './types';
+import { CellAlign } from './types';
 import { isSlideVisible } from './utils';
 
 const getSlideWidth = (count: number, wrapAround?: boolean): string =>
@@ -99,7 +99,7 @@ const Slide = ({
   speed: number;
   slidesToShow: number;
   zoomScale: number | undefined;
-  cellAlign: Alignment;
+  cellAlign: CellAlign;
   /**
    * Called with `height` when slide becomes visible and `null` when it becomes
    * hidden.

--- a/packages/nuka/src/slider-list.tsx
+++ b/packages/nuka/src/slider-list.tsx
@@ -1,13 +1,13 @@
 import React, { ReactNode } from 'react';
 import { getDotIndexes } from './default-controls';
 import { useTween } from './hooks/use-tween';
-import { Alignment, InternalCarouselProps } from './types';
+import { CellAlign, InternalCarouselProps } from './types';
 
 export const getPercentOffsetForSlide = (
   currentSlide: number,
   slideCount: number,
   slidesToShow: number,
-  cellAlign: Alignment,
+  cellAlign: CellAlign,
   wrapAround: boolean
 ): number => {
   // When wrapAround is enabled, we show the slides 3 times

--- a/packages/nuka/src/slider-list.tsx
+++ b/packages/nuka/src/slider-list.tsx
@@ -19,12 +19,12 @@ export const getPercentOffsetForSlide = (
   // (the left and right sets are clones meant to avoid visual gaps)
   let slide0Offset = wrapAround ? -100 / 3 : 0;
 
-  if (cellAlign === Alignment.Right && slidesToShow > 1) {
+  if (cellAlign === 'right' && slidesToShow > 1) {
     const excessSlides = slidesToShow - 1;
     slide0Offset += singleSlidePercentOfWhole * excessSlides;
   }
 
-  if (cellAlign === Alignment.Center && slidesToShow > 1) {
+  if (cellAlign === 'center' && slidesToShow > 1) {
     const excessSlides = slidesToShow - 1;
     // Half of excess is on left and half is on right when centered
     const excessLeftSlides = excessSlides / 2;

--- a/packages/nuka/src/types.ts
+++ b/packages/nuka/src/types.ts
@@ -1,12 +1,6 @@
 import { ReactNode, CSSProperties, MutableRefObject } from 'react';
 
-/* eslint-disable no-shadow */
-
-export enum Alignment {
-  Center = 'center',
-  Right = 'right',
-  Left = 'left',
-}
+export type Alignment = 'center' | 'right' | 'left';
 
 export enum Directions {
   Next = 'next',

--- a/packages/nuka/src/types.ts
+++ b/packages/nuka/src/types.ts
@@ -1,6 +1,13 @@
 import { ReactNode, CSSProperties, MutableRefObject } from 'react';
 
-export type Alignment = 'center' | 'right' | 'left';
+export type CellAlign = 'center' | 'right' | 'left';
+
+/** @deprecated use string literals for the values instead */
+export enum Alignment {
+  Center = 'center',
+  Right = 'right',
+  Left = 'left',
+}
 
 export enum Directions {
   Next = 'next',
@@ -219,7 +226,7 @@ export interface InternalCarouselProps {
    * When displaying more than one slide,
    * sets which position to anchor the current slide to
    */
-  cellAlign: Alignment;
+  cellAlign: CellAlign;
 
   /**
    * Space between slides, as an integer, but reflected as px

--- a/packages/nuka/src/utils.test.ts
+++ b/packages/nuka/src/utils.test.ts
@@ -1,4 +1,4 @@
-import { Alignment, ScrollMode } from './types';
+import { ScrollMode } from './types';
 import {
   getBoundedIndex,
   getNextMoveIndex,
@@ -34,7 +34,7 @@ describe('isSlideVisible', () => {
       '(showing index $currentSlide, check index $indexToCheck, $slidesToShow slidesToShow)',
     ({ currentSlide, indexToCheck, slidesToShow, expected }) => {
       expect(
-        isSlideVisible(currentSlide, indexToCheck, slidesToShow, Alignment.Left)
+        isSlideVisible(currentSlide, indexToCheck, slidesToShow, 'left')
       ).toEqual(expected);
     }
   );
@@ -66,12 +66,7 @@ describe('isSlideVisible', () => {
       '(showing index $currentSlide, check index $indexToCheck, $slidesToShow slidesToShow)',
     ({ currentSlide, indexToCheck, slidesToShow, expected }) => {
       expect(
-        isSlideVisible(
-          currentSlide,
-          indexToCheck,
-          slidesToShow,
-          Alignment.Right
-        )
+        isSlideVisible(currentSlide, indexToCheck, slidesToShow, 'right')
       ).toEqual(expected);
     }
   );
@@ -115,12 +110,7 @@ describe('isSlideVisible', () => {
       '(showing index $currentSlide, check index $indexToCheck, $slidesToShow slidesToShow)',
     ({ currentSlide, indexToCheck, slidesToShow, expected }) => {
       expect(
-        isSlideVisible(
-          currentSlide,
-          indexToCheck,
-          slidesToShow,
-          Alignment.Center
-        )
+        isSlideVisible(currentSlide, indexToCheck, slidesToShow, 'center')
       ).toEqual(expected);
     }
   );
@@ -146,9 +136,9 @@ describe('getNextMoveIndex', () => {
         slidesToScroll,
         1,
       ] as const;
-      expect(getNextMoveIndex(...args, Alignment.Left)).toEqual(expected);
-      expect(getNextMoveIndex(...args, Alignment.Right)).toEqual(expected);
-      expect(getNextMoveIndex(...args, Alignment.Center)).toEqual(expected);
+      expect(getNextMoveIndex(...args, 'left')).toEqual(expected);
+      expect(getNextMoveIndex(...args, 'right')).toEqual(expected);
+      expect(getNextMoveIndex(...args, 'center')).toEqual(expected);
     }
   );
 
@@ -263,7 +253,7 @@ describe('getPrevMoveIndex', () => {
           currentSlide,
           slidesToScroll,
           1,
-          Alignment.Left
+          'left'
         )
       ).toEqual(expected);
     }

--- a/packages/nuka/src/utils.ts
+++ b/packages/nuka/src/utils.ts
@@ -15,14 +15,14 @@ export const isSlideVisible = (
   // will be visible at the same time, even though the position we associate
   // with index 0, its leftmost edge, is off-screen.
 
-  if (cellAlign === Alignment.Left) {
+  if (cellAlign === 'left') {
     return (
       indexToCheck < currentSlide + slidesToShow &&
       indexToCheck > currentSlide - 1
     );
   }
 
-  if (cellAlign === Alignment.Center) {
+  if (cellAlign === 'center') {
     return (
       (indexToCheck > currentSlide - slidesToShow / 2 - 0.5 &&
         indexToCheck <= currentSlide) ||
@@ -31,7 +31,7 @@ export const isSlideVisible = (
     );
   }
 
-  if (cellAlign === Alignment.Right) {
+  if (cellAlign === 'right') {
     return (
       indexToCheck < currentSlide + 1 &&
       indexToCheck > currentSlide - slidesToShow
@@ -56,12 +56,12 @@ export const getNextMoveIndex = (
   // Quit early if we're already as far right as we can go
   if (
     currentSlide >= slideCount - 1 ||
-    (cellAlign === Alignment.Left && currentSlide >= slideCount - slidesToShow)
+    (cellAlign === 'left' && currentSlide >= slideCount - slidesToShow)
   ) {
     return currentSlide;
   }
 
-  if (scrollMode === ScrollMode.remainder && cellAlign === Alignment.Left) {
+  if (scrollMode === ScrollMode.remainder && cellAlign === 'left') {
     return Math.min(currentSlide + slidesToScroll, slideCount - slidesToShow);
   }
 
@@ -83,12 +83,12 @@ export const getPrevMoveIndex = (
   // Quit early if we're already as far left as we can go
   if (
     currentSlide <= 0 ||
-    (cellAlign === Alignment.Right && currentSlide <= slidesToShow - 1)
+    (cellAlign === 'right' && currentSlide <= slidesToShow - 1)
   ) {
     return currentSlide;
   }
 
-  if (scrollMode === ScrollMode.remainder && cellAlign === Alignment.Right) {
+  if (scrollMode === ScrollMode.remainder && cellAlign === 'right') {
     return Math.max(currentSlide - slidesToScroll, slidesToShow - 1);
   }
 

--- a/packages/nuka/src/utils.ts
+++ b/packages/nuka/src/utils.ts
@@ -1,11 +1,11 @@
 import { getDotIndexes } from './default-controls';
-import { Alignment, ScrollMode } from './types';
+import { CellAlign, ScrollMode } from './types';
 
 export const isSlideVisible = (
   currentSlide: number,
   indexToCheck: number,
   slidesToShow: number,
-  cellAlign: Alignment
+  cellAlign: CellAlign
 ) => {
   // The addition or subtraction of constants (1 , 0.5) in the following
   // calculations are accounting for the fact that a slide will be visible even
@@ -48,7 +48,7 @@ export const getNextMoveIndex = (
   slideCount: number,
   slidesToScroll: number,
   slidesToShow: number,
-  cellAlign: Alignment
+  cellAlign: CellAlign
 ) => {
   if (wrapAround) {
     return currentSlide + slidesToScroll;
@@ -74,7 +74,7 @@ export const getPrevMoveIndex = (
   currentSlide: number,
   slidesToScroll: number,
   slidesToShow: number,
-  cellAlign: Alignment
+  cellAlign: CellAlign
 ) => {
   if (wrapAround) {
     return currentSlide - slidesToScroll;
@@ -100,7 +100,7 @@ export const getDefaultSlideIndex = (
   slideCount: number,
   slidesToShow: number,
   slidesToScroll: number,
-  cellAlign: Alignment,
+  cellAlign: CellAlign,
   autoplayReverse: boolean,
   scrollMode: ScrollMode
 ) => {

--- a/packages/nuka/stories/carousel.stories.tsx
+++ b/packages/nuka/stories/carousel.stories.tsx
@@ -4,11 +4,7 @@ import isChromatic from 'chromatic/isChromatic';
 import { renderToString } from 'react-dom/server';
 import { easeLinear, easeElasticOut } from 'd3-ease';
 
-import Carousel, {
-  Alignment,
-  ControlProps,
-  InternalCarouselProps,
-} from '../src/index';
+import Carousel, { ControlProps, InternalCarouselProps } from '../src/index';
 
 import { sampleSlideImageSources } from './sample-slide-images';
 
@@ -107,7 +103,7 @@ CustomEasing.args = {
 export const ZoomAnimation = Template.bind({});
 ZoomAnimation.args = {
   animation: 'zoom',
-  cellAlign: Alignment.Center,
+  cellAlign: 'center',
 };
 
 export const WrapAround = Template.bind({});
@@ -196,26 +192,26 @@ DragMultipleSlides.args = {
 export const CellAlignCenter = Template.bind({});
 CellAlignCenter.args = {
   slidesToShow: 2.5,
-  cellAlign: Alignment.Center,
+  cellAlign: 'center',
 };
 
 export const CellAlignCenterWrapAround = Template.bind({});
 CellAlignCenterWrapAround.args = {
   slidesToShow: 2.5,
-  cellAlign: Alignment.Center,
+  cellAlign: 'center',
   wrapAround: true,
 };
 
 export const CellAlignRight = Template.bind({});
 CellAlignRight.args = {
   slidesToShow: 2.5,
-  cellAlign: Alignment.Right,
+  cellAlign: 'right',
 };
 
 export const CellAlignRightWrapAround = Template.bind({});
 CellAlignRightWrapAround.args = {
   slidesToShow: 2.5,
-  cellAlign: Alignment.Right,
+  cellAlign: 'right',
   wrapAround: true,
 };
 


### PR DESCRIPTION
### Description

Changes the `Alignment` type used in `cellAlign` from an enum to a simple union of string literals so library users don't need to import the enum to use that prop.

I believe the original issue was a regression caused by some refactoring of the prop types I did, and the original user-facing type was a string literal union as well.

Fixes #973

#### Type of Change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Ensured the build worked normally.