### PR TITLE
fix: only add tabIndex when keyboardControls enabled

### DIFF
--- a/.changeset/few-dodos-watch.md
+++ b/.changeset/few-dodos-watch.md
@@ -1,0 +1,5 @@
+---
+'nuka-carousel': patch
+---
+
+slider-frame is no longer a focus target if enableKeyboardControls is false

--- a/packages/nuka/src/carousel.tsx
+++ b/packages/nuka/src/carousel.tsx
@@ -646,7 +646,7 @@ export const Carousel = (rawProps: CarouselProps): React.ReactElement => {
         }}
         aria-label={frameAriaLabel}
         role="region"
-        tabIndex={enableKeyboardControls ? 0 : undefined}
+        tabIndex={enableKeyboardControls ? 0 : -1}
         onKeyDown={enableKeyboardControls ? onKeyDown : undefined}
         ref={carouselRef}
         onMouseUp={onMouseUp}

--- a/packages/nuka/src/carousel.tsx
+++ b/packages/nuka/src/carousel.tsx
@@ -646,7 +646,7 @@ export const Carousel = (rawProps: CarouselProps): React.ReactElement => {
         }}
         aria-label={frameAriaLabel}
         role="region"
-        tabIndex={0}
+        tabIndex={enableKeyboardControls ? 0 : undefined}
         onKeyDown={enableKeyboardControls ? onKeyDown : undefined}
         ref={carouselRef}
         onMouseUp={onMouseUp}


### PR DESCRIPTION
### Description

Prevents `tabIndex=0` being added to slider-frame when keyboard controls are not enabled. This fixes an accessibility issue whereby the slider-frame was previously focussable even though it was non-interactive when `enableKeyboardControls=false`.

Not sure if this requires additional tests?

Fixes #982

#### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Verified in nextJs sample app that the `tabindex=0` attribute is only present when `enableKeyboardControls=true`. 
