### PR TITLE
fix(inert): only include inert property when it is true

### DIFF
--- a/packages/nuka/src/slide.tsx
+++ b/packages/nuka/src/slide.tsx
@@ -152,7 +152,7 @@ const Slide = ({
   return (
     <div
       ref={slideRef}
-      {...{ inert: (!isFullyVisible).toString() }}
+      {...{ inert: isFullyVisible ? undefined : 'true' }}
       className={`slide${currentSlideClass}${
         typeOfSlide ? ` ${typeOfSlide}` : ''
       }${isFullyVisible ? ' slide-visible' : ''}`}


### PR DESCRIPTION
### Description

Currently, `inert` is applied to every slide, which is causing issues if slides have interact-able elements on them. When a slide is in view, we are setting `inert="false"` which is basically still applying the inert property.

Instead we need to not have the `inert` property at all when the slide is in view.

Fixes #999

#### Type of Change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Verified in Storybook that the active slide does not have inert set 
![Screen Shot 2023-03-13 at 5 37 37 PM](https://user-images.githubusercontent.com/1761730/224848041-15028e7d-641b-4821-879b-bd938d714299.png)

### Checklist

<!-- (Feel free to delete this section upon completion) -->

- [ ] My code follows the style guidelines of this project (I have run `pnpm run lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (I have run `pnpm run test:ci-with-server`/`pnpm run test`)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have recorded any user-facing fixes or changes with `pnpm changeset`.
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
