### PR TITLE
docs: update ref documentation

### DIFF
--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -96,11 +96,6 @@ ___
 ### `frameAriaLabel`
 A `string` for the aria-label of the frame container of the carousel. This is useful when you have more than one carousel on the page. The default value is an empty string.
 
-___
-
-### `innerRef`
-A React ref object `MutableRefObject<HTMLDivElement>` for carousel element.
-
 ---
 
 ### `keyCodeConfig`
@@ -135,6 +130,11 @@ ___
 
 ### `onUserNavigation`
 A function `(props: Pick<CarouselState, 'currentSlide' | 'count'>) => string` to render the message in the ARIA live region that is announcing the current slide on slide change.
+
+___
+
+### `ref`
+A React ref object `MutableRefObject<HTMLDivElement>` for carousel element.
 
 ---
 


### PR DESCRIPTION
### Description

The `innerRef` prop was [updated](https://github.com/FormidableLabs/nuka-carousel/commit/5358e8f6d603f7c9e3ab8512acc5e566f48e984d) to `ref`. I've changed this in the documentation.

Fixes # (issue)

#### Type of Change

- [X] Documentation update

### How Has This Been Tested?

Check the documentation in the docs folder.

### Checklist

- [ ] My code follows the style guidelines of this project (I have run `pnpm run lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (I have run `pnpm run test:ci-with-server`/`pnpm run test`)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have recorded any user-facing fixes or changes with `pnpm changeset`.
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
