### PR TITLE
Fix deprecated defaultProps warning in React >18.2.0

### DIFF
--- a/.changeset/weak-kings-protect.md
+++ b/.changeset/weak-kings-protect.md
@@ -1,0 +1,5 @@
+---
+'nuka-carousel': patch
+---
+
+Do not set defaultProps on the Carousel component, as defaultProps are deprecated in React 18.3.0-canary

--- a/packages/nuka/src/carousel.tsx
+++ b/packages/nuka/src/carousel.tsx
@@ -24,16 +24,10 @@ import { useForwardRef } from './hooks/use-forward-ref';
 
 export const Carousel = React.forwardRef<HTMLDivElement, CarouselProps>(
   (rawProps, ref): React.ReactElement => {
-    /**
-     * We need this cast because we want the component's properties to seem
-     * optional to external users, but always-present for the internal
-     * implementation.
-     *
-     * This cast is safe due to the `Carousel.defaultProps = defaultProps;`
-     * statement below. That guarantees all the properties are present, since
-     * `defaultProps` has type `InternalCarouselProps`.
-     */
-    const props = rawProps as InternalCarouselProps;
+    const props: InternalCarouselProps = {
+      ...defaultProps,
+      ...rawProps,
+    };
 
     const {
       adaptiveHeight,
@@ -750,7 +744,6 @@ export const Carousel = React.forwardRef<HTMLDivElement, CarouselProps>(
   }
 );
 
-Carousel.defaultProps = defaultProps;
 Carousel.displayName = 'Carousel';
 
 export default Carousel;

--- a/packages/nuka/stories/carousel.stories.tsx
+++ b/packages/nuka/stories/carousel.stories.tsx
@@ -7,13 +7,14 @@ import { easeLinear, easeElasticOut } from 'd3-ease';
 import Carousel, { ControlProps, InternalCarouselProps } from '../src/index';
 
 import { sampleSlideImageSources } from './sample-slide-images';
+import defaultProps from '../src/default-carousel-props';
 
 export default {
   title: 'Nuka Carousel/Carousel',
   component: Carousel,
   args: {
     storySlideCount: 9,
-    ...Carousel.defaultProps,
+    ...defaultProps,
   },
 } as ComponentMeta<typeof Carousel>;
 


### PR DESCRIPTION
### Description



In React 18.3.0 (unreleased) and React-canary (used by NextJS 13.4 App Router stable), react throws console warnings for `defaultProps`

> Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.


Fixes #997

#### Type of Change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

<!-- (Feel free to delete this section upon completion) -->

- [ ] New and existing unit tests pass locally with my changes (I have run `pnpm run test:ci-with-server`/`pnpm run test`)

Could not run tests, they're broken on main branch.