### PR TITLE
feat: provide page info on beforeSlide and afterSlide callbacks

### DIFF
--- a/.changeset/hot-berries-ring.md
+++ b/.changeset/hot-berries-ring.md
@@ -1,0 +1,5 @@
+---
+"nuka-carousel": minor
+---
+
+feat: provide page info on beforeSlide and afterSlide callbacks

--- a/docs/api/callbacks.mdx
+++ b/docs/api/callbacks.mdx
@@ -14,10 +14,10 @@ Functions that are invoked when the progression methods (goBack()/goForward()) a
 
 ### Details
 
-| Prop Name     | Type       | Default Value |
-| :------------ | :--------- | :------------ |
-| `beforeSlide` | () => void | `undefined`   |
-| `afterSlide`  | () => void | `undefined`   |
+| Prop Name     | Type                                                       | Default Value |
+| :------------ | :--------------------------------------------------------- | :------------ |
+| `beforeSlide` | (currentSlideIndex: number, endSlideIndex: number) => void | `undefined`   |
+| `afterSlide`  | (endSlideIndex: number) => void                            | `undefined`   |
 
 - `beforeSlide` - Runs a given function before scrolling when a progression method is called. It will also run right before the carousel registers that it has been scrolled on if manually scrolled.
 - `afterSlide` - Runs a given function after scrolling when a progression method is called or after manually scrolling.
@@ -25,13 +25,9 @@ Functions that are invoked when the progression methods (goBack()/goForward()) a
 ### Example
 
 ```tsx
-<Carousel beforeSlide={() => myCustomBeforeFunction()}>
-  {/* Cards */}
-</Carousel>
+<Carousel beforeSlide={() => myCustomBeforeFunction()}>{/* Cards */}</Carousel>
 ```
 
 ```tsx
-<Carousel afterSlide={() => myCustomAfterFunction()}>
-  {/* Cards */}
-</Carousel>
+<Carousel afterSlide={() => myCustomAfterFunction()}>{/* Cards */}</Carousel>
 ```

--- a/packages/nuka/src/Carousel/Carousel.stories.tsx
+++ b/packages/nuka/src/Carousel/Carousel.stories.tsx
@@ -171,8 +171,12 @@ export const GoToPage: Story = {
 
 export const BeforeSlide: Story = {
   args: {
-    beforeSlide: () =>
-      console.log('Function was called before scroll occurred '),
+    beforeSlide: (currentSlideIndex, endSlideIndex) =>
+      console.log(
+        'Function was called before scroll occurred ',
+        currentSlideIndex,
+        endSlideIndex,
+      ),
     children: (
       <>
         {[...Array(10)].map((_, index) => (
@@ -185,7 +189,8 @@ export const BeforeSlide: Story = {
 
 export const AfterSlide: Story = {
   args: {
-    afterSlide: () => console.log('Function was called after scroll occurred '),
+    afterSlide: (endSlideIndex) =>
+      console.log('Function was called after scroll occurred ', endSlideIndex),
     children: (
       <>
         {[...Array(10)].map((_, index) => (

--- a/packages/nuka/src/Carousel/Carousel.tsx
+++ b/packages/nuka/src/Carousel/Carousel.tsx
@@ -54,6 +54,7 @@ export const Carousel = forwardRef<SlideHandle, CarouselProps>(
 
     const carouselRef = useRef<HTMLDivElement | null>(null);
     const containerRef = useRef<HTMLDivElement | null>(null);
+    const previousPageRef = useRef<number>(-1);
 
     // -- update page count and scroll offset based on scroll distance
     const { totalPages, scrollOffset } = useMeasurement({
@@ -103,9 +104,12 @@ export const Carousel = forwardRef<SlideHandle, CarouselProps>(
     // -- scroll container when page index changes
     useEffect(() => {
       if (containerRef.current) {
-        beforeSlide && beforeSlide();
+        const currentSlideIndex = previousPageRef.current;
+        const endSlideIndex = currentPage;
+        beforeSlide && beforeSlide(currentSlideIndex, endSlideIndex);
         containerRef.current.scrollLeft = scrollOffset[currentPage];
-        afterSlide && setTimeout(() => afterSlide(), 0);
+        afterSlide && setTimeout(() => afterSlide(endSlideIndex), 0);
+        previousPageRef.current = currentPage;
       }
     }, [currentPage, scrollOffset, beforeSlide, afterSlide]);
 

--- a/packages/nuka/src/types.ts
+++ b/packages/nuka/src/types.ts
@@ -4,8 +4,8 @@ export type ShowArrowsOption = boolean | 'always' | 'hover';
 export type ScrollDistanceType = number | 'slide' | 'screen';
 
 export type CarouselCallbacks = {
-  beforeSlide?: () => void;
-  afterSlide?: () => void;
+  beforeSlide?: (currentSlideIndex: number, endSlideIndex: number) => void;
+  afterSlide?: (endSlideIndex: number) => void;
 };
 
 export type CarouselProps = CarouselCallbacks & {


### PR DESCRIPTION
### Description

Provide page information on beforeSlide and afterSlide callbacks. 
This was supported in previous nuka-carousel versions. For example - [codesandbox](https://codesandbox.io/p/sandbox/sweet-ioana-p7ky8d?file=%2Fsrc%2FApp.js%3A1%2C1-39%2C1).
It will be useful for developers to track user's interactions with the carousel.

#### Type of Change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### How Has This Been Tested?

- [x] Storybook
