### PR TITLE
[Feature] Initial page index

### DIFF
--- a/docs/api/autoplay.mdx
+++ b/docs/api/autoplay.mdx
@@ -25,9 +25,35 @@ For accessibility, the carousel will pause when the user is interacting with it.
 #### Code
 
 ```tsx
-<Carousel autoplay={true} autoplayInterval={1000}  wrapMode="wrap">
+<Carousel autoplay={true} autoplayInterval={1000} wrapMode="wrap">
   <img src="pexels-01.jpg" />
   <img src="pexels-02.jpg" />
   <img src="pexels-03.jpg" />
+</Carousel>
+```
+
+## Initial page
+
+The carousel can start on any index within bounds of its length. Anything out of bounds will default back to `0` for its index. This list is `0` indexed.
+
+| Prop Name     | Type   | Default Value |
+| :------------ | :----- | :------------ |
+| `initialPage` | number | `0`           |
+
+### Example
+
+<Carousel initialPage={1}>
+  <img src="/open-source/nuka-carousel/img/pexels-01.jpg" />
+  <img src="/open-source/nuka-carousel/img/pexels-02.jpg" />
+  <img src="/open-source/nuka-carousel/img/pexels-03.jpg" />
+</Carousel>
+
+#### Code
+
+```tsx
+<Carousel initialPage={1}>
+  <img src="/open-source/nuka-carousel/img/pexels-01.jpg" />
+  <img src="/open-source/nuka-carousel/img/pexels-02.jpg" />
+  <img src="/open-source/nuka-carousel/img/pexels-03.jpg" />
 </Carousel>
 ```

--- a/docs/api/autoplay.mdx
+++ b/docs/api/autoplay.mdx
@@ -31,29 +31,3 @@ For accessibility, the carousel will pause when the user is interacting with it.
   <img src="pexels-03.jpg" />
 </Carousel>
 ```
-
-## Initial page
-
-The carousel can start on any index within bounds of its length. Anything out of bounds will default back to `0` for its index. This list is `0` indexed.
-
-| Prop Name     | Type   | Default Value |
-| :------------ | :----- | :------------ |
-| `initialPage` | number | `0`           |
-
-### Example
-
-<Carousel initialPage={1}>
-  <img src="/open-source/nuka-carousel/img/pexels-01.jpg" />
-  <img src="/open-source/nuka-carousel/img/pexels-02.jpg" />
-  <img src="/open-source/nuka-carousel/img/pexels-03.jpg" />
-</Carousel>
-
-#### Code
-
-```tsx
-<Carousel initialPage={1}>
-  <img src="/open-source/nuka-carousel/img/pexels-01.jpg" />
-  <img src="/open-source/nuka-carousel/img/pexels-02.jpg" />
-  <img src="/open-source/nuka-carousel/img/pexels-03.jpg" />
-</Carousel>
-```

--- a/docs/api/index.mdx
+++ b/docs/api/index.mdx
@@ -78,11 +78,11 @@ Feel free to mix React components and HTML elements as children. Nuka Carousel w
 
 :::caution
 
-Nuka Carousel uses a flex container for its magic
-
-:::
+### Nuka Carousel uses a flex container to hold its contents.
 
 In order for Nuka to measure your slides, they must have a width that can be calculated.
+
+:::
 
 ### Images
 
@@ -113,6 +113,12 @@ However, it's recommended to set the width and height of the image in the HTML t
 ### HTML Block Elements
 
 When using HTML block elements, such as `div`, you must set the min width in the HTML.
+
+:::info
+
+Most of the examples use <a href="https://tailwindcss.com/" target="_blank">Tailwind</a> classes for styling
+
+:::
 
 ```jsx
 .demo-slide {
@@ -145,5 +151,5 @@ function CarouselImage() {
   <CarouselImage />
   <CarouselImage />
   <CarouselImage />
-</Carousel>
+</Carousel>;
 ```

--- a/docs/api/initial-page.mdx
+++ b/docs/api/initial-page.mdx
@@ -1,0 +1,31 @@
+---
+sidebar_position: 4
+---
+
+import { Carousel } from 'nuka-carousel';
+
+# Initial Page
+
+The carousel can start on any index within bounds of its length. Anything out of bounds will default back to `0` for its index. This list is `0` indexed.
+
+| Prop Name     | Type   | Default Value |
+| :------------ | :----- | :------------ |
+| `initialPage` | number | `0`           |
+
+### Example
+
+<Carousel initialPage={1}>
+  <img src="/open-source/nuka-carousel/img/pexels-01.jpg" />
+  <img src="/open-source/nuka-carousel/img/pexels-02.jpg" />
+  <img src="/open-source/nuka-carousel/img/pexels-03.jpg" />
+</Carousel>
+
+#### Code
+
+```tsx
+<Carousel initialPage={1}>
+  <img src="/open-source/nuka-carousel/img/pexels-01.jpg" />
+  <img src="/open-source/nuka-carousel/img/pexels-02.jpg" />
+  <img src="/open-source/nuka-carousel/img/pexels-03.jpg" />
+</Carousel>
+```

--- a/docs/v8-upgrade-guide.mdx
+++ b/docs/v8-upgrade-guide.mdx
@@ -45,7 +45,7 @@ The following props were removed becuase they are no longer valid or replaced by
 - `pauseOnHover` - Enabled by default. See the <Link to="/docs/api/autoplay">autoplay</Link> docs.
 - `renderTop{direction}Controls`
 - `scrollMode` - Defaults to `remainder`.
-- `slideIndex` - Use <Link to="/docs/api/autoplay#initial-page">initialPage</Link> to start on a certain page, use <Link to="/docs/api/methods#progression">goToPage</Link> to change indices on command.
+- `slideIndex` - Use <Link to="/docs/api/initial-page">initialPage</Link> to start on a certain page, use <Link to="/docs/api/methods#progression">goToPage</Link> to change indices on command.
 - `slidesToShow` - Now based on media queries and how large the slides are.
 - `speed` - Controlled by native browser settings.
 - `style` - See the <Link to="/docs/api">style guide</Link>.

--- a/docs/v8-upgrade-guide.mdx
+++ b/docs/v8-upgrade-guide.mdx
@@ -45,7 +45,7 @@ The following props were removed becuase they are no longer valid or replaced by
 - `pauseOnHover` - Enabled by default. See the <Link to="/docs/api/autoplay">autoplay</Link> docs.
 - `renderTop{direction}Controls`
 - `scrollMode` - Defaults to `remainder`.
-- `slideIndex`
+- `slideIndex` - Use <Link to="/docs/api/autoplay#initial-page">initialPage</Link> to start on a certain page, use <Link to="/docs/api/methods#progression">goToPage</Link> to change indices on command.
 - `slidesToShow` - Now based on media queries and how large the slides are.
 - `speed` - Controlled by native browser settings.
 - `style` - See the <Link to="/docs/api">style guide</Link>.

--- a/packages/nuka/src/Carousel/Carousel.css
+++ b/packages/nuka/src/Carousel/Carousel.css
@@ -17,9 +17,14 @@
 }
 .nuka-overflow {
   overflow: scroll;
-  scroll-behavior: smooth;
   -ms-overflow-style: none; /* IE and Edge */
   scrollbar-width: none; /* Firefox */
+}
+.nuka-overflow.scroll-smooth {
+  scroll-behavior: smooth;
+}
+.nuka-overflow.scroll-auto {
+  scroll-behavior: auto;
 }
 .nuka-overflow::-webkit-scrollbar {
   display: none;

--- a/packages/nuka/src/Carousel/Carousel.stories.tsx
+++ b/packages/nuka/src/Carousel/Carousel.stories.tsx
@@ -169,6 +169,20 @@ export const GoToPage: Story = {
   },
 };
 
+export const InitialSlide: Story = {
+  args: {
+    initialPage: 2,
+    scrollDistance: 'slide',
+    children: (
+      <>
+        {[...Array(10)].map((_, index) => (
+          <ExampleSlide key={index} index={index} />
+        ))}
+      </>
+    ),
+  },
+};
+
 export const BeforeSlide: Story = {
   args: {
     beforeSlide: (currentSlideIndex, endSlideIndex) =>

--- a/packages/nuka/src/Carousel/Carousel.stories.tsx
+++ b/packages/nuka/src/Carousel/Carousel.stories.tsx
@@ -169,7 +169,7 @@ export const GoToPage: Story = {
   },
 };
 
-export const InitialSlide: Story = {
+export const InitialPage: Story = {
   args: {
     initialPage: 2,
     scrollDistance: 'slide',

--- a/packages/nuka/src/Carousel/Carousel.tsx
+++ b/packages/nuka/src/Carousel/Carousel.tsx
@@ -76,7 +76,7 @@ export const Carousel = forwardRef<SlideHandle, CarouselProps>(
     const { currentPage, goBack, goForward, goToPage } = usePaging({
       totalPages,
       wrapMode,
-      initialPage
+      initialPage,
     });
 
     // -- handle touch scroll events

--- a/packages/nuka/src/Carousel/Carousel.tsx
+++ b/packages/nuka/src/Carousel/Carousel.tsx
@@ -146,7 +146,7 @@ export const Carousel = forwardRef<SlideHandle, CarouselProps>(
           containerRef.current.classList.add('scroll-smooth');
         }
       }
-    }, [currentPage, scrollOffset, beforeSlide, afterSlide]);
+    }, [currentPage, scrollOffset, beforeSlide, afterSlide, initialPage]);
 
     const containerClassName = cls(
       'nuka-container',

--- a/packages/nuka/src/Carousel/Carousel.tsx
+++ b/packages/nuka/src/Carousel/Carousel.tsx
@@ -79,16 +79,6 @@ export const Carousel = forwardRef<SlideHandle, CarouselProps>(
       initialPage,
     });
 
-    // -- remove initial smooth scroll when given initialPage prop
-    const [currentReachedInitialPage, setCurrentReachedInitialPage] =
-      useState(!initialPage);
-
-    useEffect(() => {
-      if (!currentReachedInitialPage && initialPage !== undefined) {
-        setCurrentReachedInitialPage(initialPage === currentPage);
-      }
-    }, [initialPage, currentPage, currentReachedInitialPage]);
-
     // -- handle touch scroll events
     const [touchStart, setTouchStart] = useState<null | number>(null);
     const [touchEnd, setTouchEnd] = useState<null | number>(null);
@@ -151,6 +141,10 @@ export const Carousel = forwardRef<SlideHandle, CarouselProps>(
         containerRef.current.scrollLeft = scrollOffset[currentPage];
         afterSlide && setTimeout(() => afterSlide(endSlideIndex), 0);
         previousPageRef.current = currentPage;
+        if (initialPage === undefined || currentPage === initialPage) {
+          containerRef.current.classList.remove('scroll-auto');
+          containerRef.current.classList.add('scroll-smooth');
+        }
       }
     }, [currentPage, scrollOffset, beforeSlide, afterSlide]);
 
@@ -186,7 +180,7 @@ export const Carousel = forwardRef<SlideHandle, CarouselProps>(
           )}
           <div className="nuka-slide-container">
             <div
-              className={`nuka-overflow ${currentReachedInitialPage ? 'scroll-smooth' : 'scroll-auto'}`}
+              className="nuka-overflow"
               ref={containerRef}
               onTouchEnd={onTouchEnd}
               onTouchMove={onTouchMove}

--- a/packages/nuka/src/Carousel/Carousel.tsx
+++ b/packages/nuka/src/Carousel/Carousel.tsx
@@ -79,6 +79,16 @@ export const Carousel = forwardRef<SlideHandle, CarouselProps>(
       initialPage,
     });
 
+    // -- remove initial smooth scroll when given initialPage prop
+    const [currentReachedInitialPage, setCurrentReachedInitialPage] =
+      useState(!initialPage);
+
+    useEffect(() => {
+      if (!currentReachedInitialPage && initialPage !== undefined) {
+        setCurrentReachedInitialPage(initialPage === currentPage);
+      }
+    }, [initialPage, currentPage, currentReachedInitialPage]);
+
     // -- handle touch scroll events
     const [touchStart, setTouchStart] = useState<null | number>(null);
     const [touchEnd, setTouchEnd] = useState<null | number>(null);
@@ -176,7 +186,7 @@ export const Carousel = forwardRef<SlideHandle, CarouselProps>(
           )}
           <div className="nuka-slide-container">
             <div
-              className="nuka-overflow"
+              className={`nuka-overflow ${currentReachedInitialPage ? 'scroll-smooth' : 'scroll-auto'}`}
               ref={containerRef}
               onTouchEnd={onTouchEnd}
               onTouchMove={onTouchMove}

--- a/packages/nuka/src/Carousel/Carousel.tsx
+++ b/packages/nuka/src/Carousel/Carousel.tsx
@@ -59,6 +59,7 @@ export const Carousel = forwardRef<SlideHandle, CarouselProps>(
       swiping,
       title,
       wrapMode,
+      initialPage,
     } = options;
 
     const carouselRef = useRef<HTMLDivElement | null>(null);
@@ -75,6 +76,7 @@ export const Carousel = forwardRef<SlideHandle, CarouselProps>(
     const { currentPage, goBack, goForward, goToPage } = usePaging({
       totalPages,
       wrapMode,
+      initialPage
     });
 
     // -- handle touch scroll events

--- a/packages/nuka/src/hooks/use-paging.test.tsx
+++ b/packages/nuka/src/hooks/use-paging.test.tsx
@@ -94,4 +94,25 @@ describe('usePaging', () => {
     });
     expect(result.current.currentPage).toBe(0);
   });
+
+  it('should start at index 0 if not given an initial page index', () => {
+    const { result } = renderHook(() =>
+      usePaging({ totalPages: 5, wrapMode: 'wrap' }),
+    );
+    expect(result.current.currentPage).toBe(0);
+  });
+
+  it('should start at the given initial page index', () => {
+    const { result } = renderHook(() =>
+      usePaging({ totalPages: 5, wrapMode: 'wrap', initialPage: 2 }),
+    );
+    expect(result.current.currentPage).toBe(2);
+  });
+
+  it('should start at index 0 if initial page is out of bounds', () => {
+    const { result } = renderHook(() =>
+      usePaging({ totalPages: 5, wrapMode: 'wrap', initialPage: 200 }),
+    );
+    expect(result.current.currentPage).toBe(0);
+  });
 });

--- a/packages/nuka/src/hooks/use-paging.test.tsx
+++ b/packages/nuka/src/hooks/use-paging.test.tsx
@@ -109,9 +109,16 @@ describe('usePaging', () => {
     expect(result.current.currentPage).toBe(2);
   });
 
-  it('should start at index 0 if initial page is out of bounds', () => {
+  it('should start at in bound indices if initial page is out of bounds', () => {
     const { result } = renderHook(() =>
       usePaging({ totalPages: 5, wrapMode: 'wrap', initialPage: 200 }),
+    );
+    expect(result.current.currentPage).toBe(5);
+  });
+
+  it('should start at 0 indices if initial page is out of bounds', () => {
+    const { result } = renderHook(() =>
+      usePaging({ totalPages: 5, wrapMode: 'wrap', initialPage: -2 }),
     );
     expect(result.current.currentPage).toBe(0);
   });

--- a/packages/nuka/src/hooks/use-paging.tsx
+++ b/packages/nuka/src/hooks/use-paging.tsx
@@ -12,13 +12,19 @@ type UsePagingReturnType = {
 type PagingProps = {
   totalPages: number;
   wrapMode: CarouselProps['wrapMode'];
+  initialPage?: number;
 };
 
 export function usePaging({
   totalPages,
   wrapMode,
+  initialPage,
 }: PagingProps): UsePagingReturnType {
-  const [currentPage, setCurrentPage] = useState(0);
+  const [currentPage, setCurrentPage] = useState(
+    initialPage && initialPage >= 0 && initialPage < totalPages
+      ? initialPage
+      : 0,
+  );
 
   const goToPage = (idx: number) => {
     if (idx < 0 || idx >= totalPages) return;

--- a/packages/nuka/src/hooks/use-paging.tsx
+++ b/packages/nuka/src/hooks/use-paging.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { CarouselProps } from '../types';
 
@@ -20,11 +20,13 @@ export function usePaging({
   wrapMode,
   initialPage,
 }: PagingProps): UsePagingReturnType {
-  const [currentPage, setCurrentPage] = useState(
-    initialPage && initialPage >= 0 && initialPage < totalPages
-      ? initialPage
-      : 0,
-  );
+  const [currentPage, setCurrentPage] = useState(0);
+
+  useEffect(() => {
+    if (initialPage) {
+      setCurrentPage(Math.max(0, Math.min(initialPage, totalPages)));
+    }
+  }, [initialPage, totalPages]);
 
   const goToPage = (idx: number) => {
     if (idx < 0 || idx >= totalPages) return;

--- a/packages/nuka/src/types.ts
+++ b/packages/nuka/src/types.ts
@@ -25,6 +25,7 @@ export type CarouselProps = CarouselCallbacks & {
   swiping?: boolean;
   title?: string;
   wrapMode?: 'nowrap' | 'wrap';
+  initialPage?: number;
 };
 
 export type SlideHandle = {


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Adds a new prop for the carousel to start on any page index. This is related to #1073 and helps with the v7 to v8+ prop migration.

In v7, there was a `slideIndex` prop so users could dictate what slide should be showing at a given time. This was half remedied by the `goToSlide()` method where users could manually update the indicies, but users still couldn't specify an index to start with on load. I've added `initialPage` that's plugged into the default value for the use-paging useState with a fallback to 0. This is specified in the updated prop pages.

<!-- List any dependencies that are required for this change. -->

Fixes #1073 

#### Type of Change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. -->

Tested in browser in Storybook (added a story) and with unit tests.

<!-- Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

### Checklist

<!-- (Feel free to delete this section upon completion) -->

- [ ] My code follows the style guidelines of this project (I have run `pnpm run lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (I have run `pnpm run test:ci-with-server`/`pnpm run test`)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have recorded any user-facing fixes or changes with `pnpm changeset`.
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
